### PR TITLE
CircleCI Cosmetic Adjustments

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -43,11 +43,9 @@ dependencies:
     - docker-compose version
     - docker version
   override:
-    - .circle/docker-compose.sh pull ${DISTRO}:
-        parallel: true
+    - .circle/docker-compose.sh pull ${DISTRO}
   post:
-    - .circle/docker-compose.sh build ${DISTRO}:
-        parallel: true
+    - .circle/docker-compose.sh build ${DISTRO}
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,9 @@ machine:
   # Don't forget we'll need latest Docker version for some features to work (CircleCI by default installs outdated version)
   services:
     - docker
+    - mongodb
+    - postgresql
+    - rabbitmq-server
   pre:
     # Paswordless SSH between parallel build nodes
     - sudo cp /home/ubuntu/.ssh/config /root/.ssh/config

--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,10 @@ suite:
               bundle exec rspec"
   environment:
     - DEBUG_LEVEL=0
-    - ST2_GITURL=https://github.com/dennybaa/st2
+    - ST2_GITURL=${ST2_GITURL}
+    - ST2_GITREV=${ST2_GITREV}
+    - ST2PKG_VERSION=${ST2PKG_VERSION}
+    - ST2PKG_RELEASE=${ST2PKG_RELEASE}
   volumes:
     - .:/root/st2-packages
     - /tmp/st2-packages:/root/build

--- a/compose.yml
+++ b/compose.yml
@@ -24,7 +24,7 @@ suite-circle:
   image: fake
   command: >-
     bash -c "cp /root/Gemfile* ./ &&
-              bundle exec rake -j9"
+              bundle exec rake"
   extends:
     file: compose.yml
     service: suite


### PR DESCRIPTION
Cosmetic changes

* [x] Remove `parallel: true` for non-test section
* [x] Show CircleCI services that we use explicitly (mongo, rabbit, postgres)
* [x] Tests with rake `j4`/`j9` parallel flag
* [x] Pass ENV variables from CI to Dockerized environment