### PR TITLE
Better defaults for non-CI docker-compose run

### DIFF
--- a/.circle/docker-compose.sh
+++ b/.circle/docker-compose.sh
@@ -19,7 +19,7 @@ case "$1" in
   ;;
   build)
     echo Starting Packages Build for $2 ...
-    docker-compose -f compose.yml -f docker-compose.circle.yml run $2
+    docker-compose -f compose.yml -f docker-compose.circle.yml run -e ST2_GITURL=${ST2_GITURL} -e ST2_GITREV=${ST2_GITREV} -e ST2PKG_VERSION=${ST2PKG_VERSION} -e ST2PKG_RELEASE=${ST2PKG_RELEASE} $2
   ;;
   test)
     echo Starting Tests for $2 ...

--- a/.circle/docker-compose.sh
+++ b/.circle/docker-compose.sh
@@ -15,14 +15,14 @@ set -x
 case "$1" in
   pull)
     echo Pulling dependent Docker images for $2 ...
-    docker-compose -f compose.yml -f docker-compose.circle.yml run $2 /bin/true
+    docker-compose -f docker-compose.circle.yml run $2 /bin/true
   ;;
   build)
     echo Starting Packages Build for $2 ...
-    docker-compose -f compose.yml -f docker-compose.circle.yml run -e ST2_GITURL=${ST2_GITURL} -e ST2_GITREV=${ST2_GITREV} -e ST2PKG_VERSION=${ST2PKG_VERSION} -e ST2PKG_RELEASE=${ST2PKG_RELEASE} $2
+    docker-compose -f docker-compose.circle.yml run -e ST2_GITURL=${ST2_GITURL} -e ST2_GITREV=${ST2_GITREV} -e ST2PKG_VERSION=${ST2PKG_VERSION} -e ST2PKG_RELEASE=${ST2PKG_RELEASE} $2
   ;;
   test)
     echo Starting Tests for $2 ...
-    docker-compose -f compose.yml -f docker-compose.circle.yml run $2 bash -c 'cp /root/Gemfile* ./ && bundle exec rspec'
+    docker-compose -f docker-compose.circle.yml run $2 bash -c 'cp /root/Gemfile* ./ && bundle exec rspec'
   ;;
 esac

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ It's very simple to invoke the whole build-test pipeline. First just make sure t
 
 ```shell
 # First clean out previous build containers (it's optional)
-docker-compose -f compose.yml -f docker-compose.yml kill
-docker-compose -f compose.yml -f docker-compose.yml rm -f
+docker-compose kill
+docker-compose rm -f
 
 # We want to build packages for debian wheezy
-docker-compose -f compose.yml -f docker-compose.yml run wheezy
+docker-compose run wheezy
 ```
 
 Execution takes about *6 to 10 minutes* to build around 10 packages it depends on computing power of your CPU. When build and tests are finished, you can find all of StackStorm packages in your host local directory `/tmp/st2-packages`:

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -1,7 +1,7 @@
 wheezy:
   image: quay.io/stackstorm/packagingrunner
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite-circle
   environment:
     - BUILDNODE=wheezybuild
@@ -13,7 +13,7 @@ wheezy:
 jessie:
   image: quay.io/stackstorm/packagingrunner
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite-circle
   environment:
     - BUILDNODE=jessiebuild
@@ -25,7 +25,7 @@ jessie:
 trusty:
   image: quay.io/stackstorm/packagingrunner
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite-circle
   environment:
     - BUILDNODE=trustybuild
@@ -37,7 +37,7 @@ trusty:
 centos7:
   image: quay.io/stackstorm/packagingrunner
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite-circle
   environment:
     - BUILDNODE=centos7build
@@ -49,7 +49,7 @@ centos7:
 centos6:
   image: quay.io/stackstorm/packagingrunner
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite-circle
   environment:
     - ST2_PYTHON=1
@@ -64,31 +64,31 @@ centos6:
 wheezybuild:
   image: quay.io/stackstorm/packagingenv:wheezy
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-circle
 
 jessiebuild:
   image: quay.io/stackstorm/packagingenv:jessie
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-circle
 
 trustybuild:
   image: quay.io/stackstorm/packagingenv:trusty
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-circle
 
 centos6build:
   image: quay.io/stackstorm/packagingenv:centos6
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-circle
 
 centos7build:
   image: quay.io/stackstorm/packagingenv:centos7
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-circle
 
 ## Package testing nodes
@@ -96,31 +96,31 @@ centos7build:
 wheezytest:
   image: quay.io/dennybaa/droneunit:wheezy-sshd
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-circle
 
 jessietest:
   image: quay.io/dennybaa/droneunit:jessie-sshd
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-circle
 
 trustytest:
   image: quay.io/dennybaa/droneunit:trusty-upstart
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-circle
 
 centos6test:
   image: quay.io/dennybaa/droneunit:centos6-sshd
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-circle
 
 centos7test:
   image: quay.io/dennybaa/droneunit:centos7-systemd
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-circle
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -20,7 +20,7 @@ suite:
 suite-compose:
   image: fake
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite
 
 suite-circle:
@@ -29,7 +29,7 @@ suite-circle:
     bash -c "cp /root/Gemfile* ./ &&
               bundle exec rake"
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite
   environment:
     - RABBITMQHOST=172.17.42.1

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -9,10 +9,6 @@ suite:
               bundle exec rspec"
   environment:
     - DEBUG_LEVEL=0
-    - ST2_GITURL=${ST2_GITURL}
-    - ST2_GITREV=${ST2_GITREV}
-    - ST2PKG_VERSION=${ST2PKG_VERSION}
-    - ST2PKG_RELEASE=${ST2PKG_RELEASE}
   volumes:
     - .:/root/st2-packages
     - /tmp/st2-packages:/root/build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 wheezy:
   image: quay.io/stackstorm/packagingrunner
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite-compose
   environment:
     - BUILDNODE=wheezybuild
@@ -16,7 +16,7 @@ wheezy:
 jessie:
   image: quay.io/stackstorm/packagingrunner
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite-compose
   environment:
     - BUILDNODE=jessiebuild
@@ -31,7 +31,7 @@ jessie:
 trusty:
   image: quay.io/stackstorm/packagingrunner
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite-compose
   environment:
     - BUILDNODE=trustybuild
@@ -46,7 +46,7 @@ trusty:
 centos7:
   image: quay.io/stackstorm/packagingrunner
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite-compose
   environment:
     - BUILDNODE=centos7build
@@ -61,7 +61,7 @@ centos7:
 centos6:
   image: quay.io/stackstorm/packagingrunner
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: suite-compose
   environment:
     - ST2_PYTHON=1
@@ -79,31 +79,31 @@ centos6:
 wheezybuild:
   image: quay.io/stackstorm/packagingenv:wheezy
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-compose
 
 jessiebuild:
   image: quay.io/stackstorm/packagingenv:jessie
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-compose
 
 trustybuild:
   image: quay.io/stackstorm/packagingenv:trusty
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-compose
 
 centos6build:
   image: quay.io/stackstorm/packagingenv:centos6
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-compose
 
 centos7build:
   image: quay.io/stackstorm/packagingenv:centos7
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-compose
 
 ## Package testing nodes
@@ -111,31 +111,31 @@ centos7build:
 wheezytest:
   image: quay.io/dennybaa/droneunit:wheezy-sshd
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-compose
 
 jessietest:
   image: quay.io/dennybaa/droneunit:jessie-sshd
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-compose
 
 trustytest:
   image: quay.io/dennybaa/droneunit:trusty-upstart
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-compose
 
 centos6test:
   image: quay.io/dennybaa/droneunit:centos6-sshd
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-compose
 
 centos7test:
   image: quay.io/dennybaa/droneunit:centos7-systemd
   extends:
-    file: compose.yml
+    file: docker-compose.override.yml
     service: volumes-compose
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup


### PR DESCRIPTION
* [x] Pass env variables from CI to `docker-compose` via CLI (avoid warnings for users)
* [x] Better defaults for non-CI run

From user side just run `docker-compose run`, instead of hard to write and remember:
`docker-compose -f compose.yml -f docker-compose.yml run`.

See https://docs.docker.com/compose/reference/docker-compose/