### PR TITLE
Use Docker 1.9.0 in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,10 +21,6 @@ machine:
     BUILD_DOCKER: 1
     DEPLOY_DOCKER: 1
     DEPLOY_PACKAGES: 0
-  services:
-    - mongodb
-    - postgresql
-    - rabbitmq-server
   pre:
     # Paswordless SSH between parallel build nodes
     - sudo cp /home/ubuntu/.ssh/config /root/.ssh/config
@@ -32,7 +28,11 @@ machine:
     - |
       sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.0-circleci'
       sudo chmod 0755 /usr/bin/docker
-      sudo service docker start
+  services:
+    - docker
+    - mongodb
+    - postgresql
+    - rabbitmq-server
 
 checkout:
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -21,15 +21,18 @@ machine:
     BUILD_DOCKER: 1
     DEPLOY_DOCKER: 1
     DEPLOY_PACKAGES: 0
-  # Don't forget we'll need latest Docker version for some features to work (CircleCI by default installs outdated version)
   services:
-    - docker
     - mongodb
     - postgresql
     - rabbitmq-server
   pre:
     # Paswordless SSH between parallel build nodes
     - sudo cp /home/ubuntu/.ssh/config /root/.ssh/config
+    # Need latest Docker version for some features to work (CircleCI by default works with outdated version)
+    - |
+      sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.0-circleci'
+      sudo chmod 0755 /usr/bin/docker
+      sudo service docker start
 
 checkout:
   post:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -28,9 +28,9 @@ suite-circle:
     file: docker-compose.override.yml
     service: suite
   environment:
-    - RABBITMQHOST=172.17.42.1
-    - POSTGRESHOST=172.17.42.1
-    - MONGODBHOST=172.17.42.1
+    - RABBITMQHOST=172.17.0.2
+    - POSTGRESHOST=172.17.0.2
+    - MONGODBHOST=172.17.0.2
   volumes:
     - /home/ubuntu/.cache/pip:/root/.cache/pip
 


### PR DESCRIPTION
Allows using latest Docker `1.9.0` in CircleCI.
Needed for generating Docker images with `--build-arg` parameter, which appeared in 1.9 version.

See also: https://discuss.circleci.com/t/docker-1-9-0-is-available/366/3