### PR TITLE
Show DISTRO we build and test in CircleCI explicitly

### DIFF
--- a/.circle/docker-compose.sh
+++ b/.circle/docker-compose.sh
@@ -10,11 +10,11 @@
 set -e
 # Source the build environment defintion (details in buildenv.sh)
 . ~/.buildenv
-set -x
 
 # Used for `RABBITMQHOST` `POSTGRESHOST` `MONGODBHOST`, see docker-compose.override.yml
 HOST_IP=$(ifconfig docker0 | grep 'inet addr' | awk -F: '{print $2}' | awk '{print $1}')
 
+set -x
 case "$1" in
   # Perform fake command invocation, technically provides images "pull" phase.
   pull)

--- a/.circle/docker-compose.sh
+++ b/.circle/docker-compose.sh
@@ -18,7 +18,7 @@ HOST_IP=$(ifconfig docker0 | grep 'inet addr' | awk -F: '{print $2}' | awk '{pri
 case "$1" in
   # Perform fake command invocation, technically provides images "pull" phase.
   pull)
-    echo Pulling dependent Docker images for $DISTRO ...
+    echo Pulling dependent Docker images for $2 ...
     docker-compose -f docker-compose.circle.yml run \
         -e ST2_GITURL=${ST2_GITURL} \
         -e ST2_GITREV=${ST2_GITREV} \
@@ -27,10 +27,10 @@ case "$1" in
         -e RABBITMQHOST=${HOST_IP} \
         -e POSTGRESHOST=${HOST_IP} \
         -e MONGODBHOST=${HOST_IP} \
-        $DISTRO /bin/true
+        $2 /bin/true
   ;;
   build)
-    echo Starting Packages Build for $DISTRO ...
+    echo Starting Packages Build for $2 ...
     docker-compose -f docker-compose.circle.yml run \
         -e ST2_GITURL=${ST2_GITURL} \
         -e ST2_GITREV=${ST2_GITREV} \
@@ -39,11 +39,11 @@ case "$1" in
         -e RABBITMQHOST=${HOST_IP} \
         -e POSTGRESHOST=${HOST_IP} \
         -e MONGODBHOST=${HOST_IP} \
-        $DISTRO build
+        $2 build
   ;;
   test)
-    [ "$TESTING" = 0 ] && { echo "Omitting Tests for $DISTRO ..." ; exit 0; }
-    echo Starting Tests for $DISTRO ...
+    [ "$TESTING" = 0 ] && { echo "Omitting Tests for $2 ..." ; exit 0; }
+    echo Starting Tests for $2 ...
     docker-compose -f docker-compose.circle.yml run \
         -e ST2_GITURL=${ST2_GITURL} \
         -e ST2_GITREV=${ST2_GITREV} \
@@ -52,6 +52,6 @@ case "$1" in
         -e RABBITMQHOST=${HOST_IP} \
         -e POSTGRESHOST=${HOST_IP} \
         -e MONGODBHOST=${HOST_IP} \
-        $DISTRO test
+        $2 test
   ;;
 esac

--- a/circle.yml
+++ b/circle.yml
@@ -50,13 +50,13 @@ dependencies:
     - docker-compose version
     - docker version
   override:
-    - .circle/docker-compose.sh pull
+    - .circle/docker-compose.sh pull ${DISTRO}
   post:
-    - .circle/docker-compose.sh build
+    - .circle/docker-compose.sh build ${DISTRO}
 
 test:
   override:
-    - .circle/docker-compose.sh test:
+    - .circle/docker-compose.sh test ${DISTRO}:
         parallel: true
   post:
     - .circle/docker.sh build st2bundle


### PR DESCRIPTION
> Reverting some logic that was created before and is part of https://github.com/StackStorm/st2/blob/master/circle.yml

Show DISTRO we build and test in CircleCI explicitly (we talked about that before If you remember),
**especially** after moving `DISTROS: "wheezy jessie trusty centos7"` inside `circle.yml` config.

It's good to have understanding which commands are unrelated to distro: `sudo pip install wheel docker-compose` and which are really important.

Also as you remember there are *real* docker-compose commands like:
`docker-compose pull wheezy` `docker-compose build wheezy` `docker-compose run wheezy`.

-----
Also I need to iterate through all `$DISTROS` (previous logic, before pushes), so this variable should be an array.