### PR TITLE
fix components build regression

### DIFF
--- a/rake/build/environment.rb
+++ b/rake/build/environment.rb
@@ -14,7 +14,7 @@ pipeopts do
 
   env     :buildnode
   env     :testnode
-  envpass :testmode, 'bundle' # components || bundle
+  envpass :testmode, 'components' # components || bundle
   envpass :basedir,  '/root'
   envpass :debug_level, 1
   envpass :artifact_dir, '/root/build'    # make it temp??
@@ -64,7 +64,7 @@ end
 ## Choose packages to test
 pipeopts.packages.dup.tap do |list|
   if pipeopts.testmode == 'components'
-    list.delete!(:st2bundle)
+    list.delete(:st2bundle)
   elsif list.include?(:st2bundle)
     list.select! {|p| not p.to_s.start_with?('st2')}
     list << :st2bundle

--- a/rake/build/wheelhouse.rake
+++ b/rake/build/wheelhouse.rake
@@ -28,8 +28,7 @@ namespace :build do
         with env do
           within buildroot do
             make :wheelhouse,  label: "wheelhouse: #{package_name}"
-            # Do not try to run it manually! left here as a reminder!
-            # make :bdist_wheel, label: "bdistwheel: #{package_name}"
+            make :bdist_wheel, label: "bdistwheel: #{package_name}"
           end
         end
       end

--- a/rake/build/wheelhouse.rake
+++ b/rake/build/wheelhouse.rake
@@ -28,7 +28,8 @@ namespace :build do
         with env do
           within buildroot do
             make :wheelhouse,  label: "wheelhouse: #{package_name}"
-            make :bdist_wheel, label: "bdistwheel: #{package_name}"
+            # Do not try to run it manually! left here as a reminder!
+            # make :bdist_wheel, label: "bdistwheel: #{package_name}"
           end
         end
       end


### PR DESCRIPTION
We must not pre-built `st2*` wheel, before installation.

If we do so, wheeled component is being by pip `pip install --find-links=/tmp/wheelhouse`, where scripts shebangs occur to be `#!python`.

This breaks `dh_virtualenv` operation... So our processing order is:
1. First build package for st2 component.
2. After package is built, create bdist wheel.
