### PR TITLE
Integrate with st2 staging

### DIFF
--- a/.circle/hook_st2.py
+++ b/.circle/hook_st2.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+import argparse
+import glob
+import os
+import sys
+import json
+import re
+import requests
+from itertools import islice
+
+ST2_HOOK_URL = os.environ.get('ST2_HOOK_URL') or sys.exit('ST2_HOOK_URL env variable is required!')
+ST2_API_KEY = os.environ.get('ST2_API_KEY') or sys.exit('ST2_API_KEY env variable is required!')
+DISTROS = (os.environ.get('DISTROS') or sys.exit('DISTROS env variable is required!')).split(' ')
+CIRCLE_NODE_TOTAL = int(os.environ.get('CIRCLE_NODE_TOTAL')) or sys.exit('CIRCLE_NODE_TOTAL env variable is required!')
+requests.packages.urllib3.disable_warnings()
+
+
+def env(var):
+    """
+    Shortcut to get ENV variable value
+    :param var: Input environment variable name
+    :type var: ``str``
+    :return:
+    :rtype: ``str``
+    """
+    return os.environ.get(var, '')
+
+
+class Payload(object):
+    """
+    Representation of data to be send to ST2 via Web Hook
+    """
+    data = {
+        'success': True,
+        'reason': [],
+        'circle': {
+            'CIRCLE_PROJECT_USERNAME': env('CIRCLE_PROJECT_USERNAME'),
+            'CIRCLE_PROJECT_REPONAME': env('CIRCLE_PROJECT_REPONAME'),
+            'CIRCLE_BRANCH': env('CIRCLE_BRANCH'),
+            'CIRCLE_SHA1': env('CIRCLE_SHA1'),
+            'CIRCLE_COMPARE_URL': env('CIRCLE_COMPARE_URL'),
+            'CIRCLE_BUILD_NUM': env('CIRCLE_BUILD_NUM'),
+            'CIRCLE_PREVIOUS_BUILD_NUM': env('CIRCLE_PREVIOUS_BUILD_NUM'),
+            'CI_PULL_REQUESTS': env('CI_PULL_REQUESTS'),
+            'CI_PULL_REQUEST': env('CI_PULL_REQUEST'),
+            'CIRCLE_USERNAME': env('CIRCLE_USERNAME'),
+            'CIRCLE_PR_USERNAME': env('CIRCLE_PR_USERNAME'),
+            'CIRCLE_PR_REPONAME': env('CIRCLE_PR_REPONAME'),
+            'CIRCLE_PR_NUMBER': env('CIRCLE_PR_NUMBER'),
+            'CIRCLE_NODE_TOTAL': env('CIRCLE_NODE_TOTAL'),
+        },
+        'build': {
+            'ST2_GITURL': env('ST2_GITURL'),
+            'ST2_GITREV': env('ST2_GITREV'),
+            'DEPLOY_PACKAGES': env('DEPLOY_PACKAGES'),
+            'DISTROS': env('DISTROS'),
+            'NOTESTS': env('NOTESTS'),
+        },
+        'packages': [],
+    }
+
+
+class DebParse(object):
+    """
+    Parse metadata from .deb file name like: version number, revision number, architecture.
+    """
+    PATTERN = re.compile('^(?P<name>[^/\n_]*)_(?P<version>[^_-]*)-(?P<revision>[^_-]*)_(?P<architecture>[^_]*)\.deb$')
+
+    def __init__(self, package_file):
+        self.package = os.path.basename(package_file)
+
+        match = self.PATTERN.match(self.package)
+        if not match:
+            raise ValueError("'{0}' naming doesn't looks like package".format(self.package))
+
+        self.name = match.group('name')
+        self.version = match.group('version')
+        self.revision = match.group('revision')
+        self.architecture = match.group('architecture')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Send Web Hook with build results to StackStorm")
+    parser.add_argument('dir', help='directory tree with created packages')
+    args = parser.parse_args()
+
+    if int(env('DEPLOY_PACKAGES')):
+        for distro in islice(DISTROS, CIRCLE_NODE_TOTAL):
+            try:
+                filename = glob.glob(os.path.join(args.dir, distro, 'st2api*.deb'))[0]
+                deb = DebParse(filename)
+                Payload.data['packages'].append({
+                    'distro': distro,
+                    'version': deb.version,
+                    'revision': deb.revision
+                })
+            except IndexError:
+                Payload.data['success'] = False
+                Payload.data['reason'].append("CircleCI build produced no packages for '{0}'".format(distro))
+
+    headers = {
+        'Content-Type': 'application/json',
+        'St2-Api-Key': ST2_API_KEY
+    }
+    response = requests.post(ST2_HOOK_URL, headers=headers, json=Payload.data, verify=False)
+    if response.status_code != 202:
+        raise Exception("Failed to hook ST2: {0}\n\n{1}".format(response.status_code, response.text))
+
+    print 'OK: {0}\n\n{1}'.format(response.status_code, response.text)

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@
 # DOCKER_USER
 # DOCKER_EMAIL
 # DOCKER_PASSWORD
+# ST2_HOOK_URL
+# ST2_API_KEY
 general:
   artifacts:
     - ~/packages
@@ -41,6 +43,7 @@ dependencies:
     - ~/.cache/pip
   pre:
     - sudo .circle/configure-services.sh
+    - pip install requests
     - sudo .circle/fix-cache-permissions.sh
     - sudo pip install wheel docker-compose
     - docker-compose version
@@ -76,5 +79,5 @@ deployment:
           .circle/bintray.sh deploy ${DISTROS[$i]}_staging ~/packages/${DISTROS[$i]} &
         done
         wait
-      - echo Web Hook triggering st2 Staging box with build context payload will be here
+      - .circle/hook_st2.py ~/packages
       - .circle/docker.sh deploy st2actionrunner st2api st2auth st2exporter st2notifier st2resultstracker st2rulesengine st2sensorcontainer

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,6 @@
 # DOCKER_USER
 # DOCKER_EMAIL
 # DOCKER_PASSWORD
-# ST2_HOOK_URL
-# ST2_API_KEY
 general:
   artifacts:
     - ~/packages
@@ -43,7 +41,6 @@ dependencies:
     - ~/.cache/pip
   pre:
     - sudo .circle/configure-services.sh
-    - pip install requests
     - sudo .circle/fix-cache-permissions.sh
     - sudo pip install wheel docker-compose
     - docker-compose version
@@ -79,5 +76,5 @@ deployment:
           .circle/bintray.sh deploy ${DISTROS[$i]}_staging ~/packages/${DISTROS[$i]} &
         done
         wait
-      - .circle/hook_st2.py ~/packages
       - .circle/docker.sh deploy st2actionrunner st2api st2auth st2exporter st2notifier st2resultstracker st2rulesengine st2sensorcontainer
+      - .circle/save_payload.py ~/packages


### PR DESCRIPTION
Web Hook with build metadata to notify `st2 staging box` when packages are ready/uploaded into Bintray staging repos.

Required ENV variables in CircleCI WEB UI:
* `ST2_HOOK_URL`
* `ST2_API_KEY`

Example payload received by `st2` (tested on my own AWS with fresh st2 version installed):
```json
{
   "packages":[
      {
         "version":"1.3dev",
         "revision":"7",
         "distro":"wheezy"
      },
      {
         "version":"1.3dev",
         "revision":"8",
         "distro":"jessie"
      },
      {
         "version":"1.3dev",
         "revision":"8",
         "distro":"trusty"
      }
   ],
   "circle":{
      "CIRCLE_BUILD_NUM":"367",
      "CI_PULL_REQUESTS":"",
      "CIRCLE_SHA1":"fdcdbc395ffc1a58e2563747d2259e701460cf58",
      "CIRCLE_USERNAME":"armab",
      "CIRCLE_PR_REPONAME":"",
      "CIRCLE_PROJECT_USERNAME":"armab",
      "CIRCLE_PR_USERNAME":"",
      "CIRCLE_COMPARE_URL":"https://github.com/armab/st2-packages/compare/6e7ef9fbef2e...fdcdbc395ffc",
      "CI_PULL_REQUEST":"",
      "CIRCLE_PROJECT_REPONAME":"st2-packages",
      "CIRCLE_BRANCH":"master",
      "CIRCLE_NODE_TOTAL":"3",
      "CIRCLE_PR_NUMBER":"",
      "CIRCLE_PREVIOUS_BUILD_NUM":"353"
   },
   "success":true,
   "reason":[],
   "build":{
      "DEPLOY_PACKAGES":"1",
      "ST2_GITURL":"https://github.com/StackStorm/st2",
      "NOTESTS":"centos7",
      "ST2_GITREV":"master",
      "DISTROS":"wheezy jessie trusty centos7"
   }
}
```

See https://circleci.com/docs/environment-variables for variables explanation.