### PR TITLE
drop rpm brp python compile

### DIFF
--- a/rpmspec/helpers.spec
+++ b/rpmspec/helpers.spec
@@ -40,22 +40,14 @@
 # Define use_systemd to know if we on a systemd system
 %global use_systemd %{!?_unitdir:0}%{?_unitdir:1}
 
-# Redefine and set some macroses to do proper bytecompile
-# (/usr/lib/rpm/brp-python-bytecompile)
+# Redefine and to drop python brp bytecompile
 #
-# We ship python into /usr/local, since we need updated on OSes < rhel7
-%if "%([ -x /usr/local/bin/python ] && echo -n 1)" == "1"
-  %define __python /usr/local/bin/python
-  %define __os_install_post() \
-      /usr/lib/rpm/redhat/brp-compress \
-      %{!?__debug_package:/usr/lib/rpm/redhat/brp-strip %{__strip}} \
-      /usr/lib/rpm/redhat/brp-strip-static-archive %{__strip} \
-      /usr/lib/rpm/redhat/brp-strip-comment-note %{__strip} %{__objdump} \
-      /usr/lib/rpm/brp-python-bytecompile %{__python} \
-      /usr/lib/rpm/redhat/brp-python-hardlink \
-      %{!?__jar_repack:/usr/lib/rpm/redhat/brp-java-repack-jars} \
-  %{nil}
-%endif
+%define __os_install_post() \
+    /usr/lib/rpm/redhat/brp-compress \
+    %{!?__debug_package:/usr/lib/rpm/redhat/brp-strip %{__strip}} \
+    /usr/lib/rpm/redhat/brp-strip-static-archive %{__strip} \
+    /usr/lib/rpm/redhat/brp-strip-comment-note %{__strip} %{__objdump} \
+%{nil}
 
 # Set variable indicating that we use our python
 %if "%(echo -n $ST2_PYTHON)" == "1"

--- a/rpmspec/package_venv.spec
+++ b/rpmspec/package_venv.spec
@@ -15,23 +15,6 @@
 %define venv_python %{venv_bin}/python
 %define venv_pip %{venv_python} %{venv_bin}/pip install --find-links=%{wheel_dir}
 
-# Install a link to a common binary 
-%define inst_venv_divertions \
-  for file in %{div_links}; do \
-    [ -L /usr/$file ] || ln -s /usr/share/python/%{package}/$file /usr/$file \
-  done \
-%{nil}
-
-# Change/remove a link to common binary, if the package containing common binary is
-# removed a link is changed to point to another package binary.
-%define uninst_venv_divertions \
-  for file in %{div_links}; do \
-    [ -L /usr/$file ] && rm /usr/$file \
-    div=$(find /usr/share/python/st2*/bin -name `basename $file` -executable -print -quit 2>/dev/null) \
-    [ -z "$div" ] || ln -s $div /usr/$file \
-  done \
-%{nil}
-
 # 1. RECORD files are used by wheels for checksum. They contain path names which
 # match the buildroot and must be removed or the package will fail to build.
 # 2. Change the virtualenv path to the target installation direcotry.


### PR DESCRIPTION
Should resolve some speed issues for rpm builds. At least it seems that centos7 takes approximately the same time as trusty :) 