### PR TITLE
Use st2-register-content with --register-fail-on-failure

### DIFF
--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -43,6 +43,7 @@ class ST2Spec
       st2actionrunner: 'st2actionrunner.{pid}'
     },
     register_content_command: '/usr/bin/st2-register-content' \
+                              ' --register-fail-on-failure' \
                               ' --register-all' \
                               ' --config-dir /etc/st2',
     mistral_db_populate_command: '/usr/share/python/mistral/bin/mistral-db-manage' \


### PR DESCRIPTION
Even if `st2-register-content` fails to register something and there were Python errors - it silently exits with `0` success code.

https://github.com/StackStorm/st2/pull/2291 implements new flag `--register-fail-on-failure`: 
> If this flag is provided, registrar will fail and exit with non-zero if a registration of any resource fails (validation error, etc.)

Let's use that flag to avoid skipping errors silently if something went wrong during `st2-register-content` execution in CI.

P.S There is still small bug: https://github.com/StackStorm/st2/issues/2314, but anyway we need this flag.