### PR TITLE
Include st2ctl in st2common package

### DIFF
--- a/packages/st2bundle/debian/install
+++ b/packages/st2bundle/debian/install
@@ -9,3 +9,4 @@
 ../st2exporter/conf/syslog.*.conf etc/st2/
 ../st2reactor/conf/logging.*.conf etc/st2/
 ../st2reactor/conf/syslog.*.conf etc/st2/
+../tools/st2ctl usr/bin/

--- a/packages/st2common/debian/install
+++ b/packages/st2common/debian/install
@@ -4,3 +4,4 @@
 ../contrib/examples usr/share/doc/st2/
 #../contrib/tests usr/share/stackstorm/
 ../docs usr/share/doc/st2/
+../tools/st2ctl usr/bin/

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -62,12 +62,12 @@ class ST2Spec
     },
 
     package_has_binaries: {
-      st2common: %w(st2-bootstrap-rmq st2-register-content),
+      st2common: %w(st2-bootstrap-rmq st2ctl st2-register-content),
       st2reactor: %w(st2-rule-tester st2-trigger-refire),
       st2client: %w(st2),
       st2debug: %w(st2-submit-debug-info),
-      st2bundle: %w(st2-bootstrap-rmq st2-register-content st2-rule-tester
-                    st2-trigger-refire st2)
+      st2bundle: %w(st2-bootstrap-rmq st2ctl st2-register-content
+                    st2-rule-tester st2-trigger-refire st2)
     },
 
     package_has_directories: {


### PR DESCRIPTION
The first step of https://github.com/StackStorm/st2-packages/issues/51 is to include `st2ctl` as part of `st2common` package.

Checked/Tested manually especially on Centos7 (because we don't run CI tests on it) - the executable is there.
When it's merged - more TBD in `st2` repo.

---

BTW I really liked this part: https://github.com/StackStorm/st2-packages/blob/master/rpmspec/helpers.spec#L28-L34
