### PR TITLE
Remove references to docs

### DIFF
--- a/packages/st2bundle/debian/install
+++ b/packages/st2bundle/debian/install
@@ -2,7 +2,6 @@
 ../contrib/packs opt/stackstorm/packs/
 ../contrib/linux opt/stackstorm/packs/
 ../contrib/examples usr/share/doc/st2/
-../docs usr/share/doc/st2/
 ../st2actions/conf/logging.*.conf etc/st2/
 ../st2actions/conf/syslog.*.conf etc/st2/
 ../st2exporter/conf/logging.*.conf etc/st2/

--- a/packages/st2bundle/rpm/st2bundle.spec
+++ b/packages/st2bundle/rpm/st2bundle.spec
@@ -60,7 +60,6 @@ Conflicts: st2common
 %files
   %defattr(-,root,root,-)
   %{_bindir}/*
-  %doc %{_datadir}/doc/st2/docs
   %config(noreplace) %{_sysconfdir}/logrotate.d/st2
   %config(noreplace) %{_sysconfdir}/st2/*
   %{_datadir}/python/%{venv_name}

--- a/packages/st2common/debian/install
+++ b/packages/st2common/debian/install
@@ -3,4 +3,3 @@
 ../contrib/linux opt/stackstorm/packs/
 ../contrib/examples usr/share/doc/st2/
 #../contrib/tests usr/share/stackstorm/
-../docs usr/share/doc/st2/

--- a/packages/st2common/rpm/st2common.spec
+++ b/packages/st2common/rpm/st2common.spec
@@ -45,7 +45,6 @@ Summary: St2Common - StackStorm shared files
 %files
   %defattr(-,root,root,-)
   %{_bindir}/*
-  %doc %{_datadir}/doc/st2/docs
   %config(noreplace) %{_sysconfdir}/st2/st2.conf
   %config(noreplace) %{_sysconfdir}/logrotate.d/st2
   %{_datadir}/python/%{name}


### PR DESCRIPTION
* Docs now live in https://github.com/StackStorm/st2docs
* Not sure why packaging docs in st2common was done in the first place. Given change of repo keep this functionality would be challenging anyway and unless deemed necessary will keep it out.
