### PR TITLE
Make circle scripts reusable for st2web

### DIFF
--- a/.bintray_package
+++ b/.bintray_package
@@ -1,0 +1,13 @@
+{
+  "name": "${PKG_NAME}",
+  "desc": "Packages for StackStorm event-driven automation platform",
+  "vcs_url": "https://github.com/stackstorm/st2.git",
+  "licenses": ["Apache-2.0"],
+  "labels": ["st2", "StackStorm", "DevOps", "automation", "auto-remediation", "chatops"],
+  "website_url": "https://stackstorm.com",
+  "issue_tracker_url": "https://github.com/stackstorm/st2/issues",
+  "github_repo": "stackstorm/st2",
+  "github_release_notes_file": "CHANGELOG.rst",
+  "public_download_numbers": false,
+  "public_stats": true
+}

--- a/.circle/buildenv.sh
+++ b/.circle/buildenv.sh
@@ -44,7 +44,7 @@ write_env() {
 ST2_GITURL=${ST2_GITURL:-$(st2_giturl)}
 ST2_GITREV=${ST2_GITREV:-$CIRCLE_BRANCH}
 ST2PKG_VERSION=$(fetch_version)
-ST2PKG_RELEASE=$(.circle/bintray.sh next-revision ${DISTRO}_staging ${ST2PKG_VERSION})
+ST2PKG_RELEASE=$(.circle/bintray.sh next-revision ${DISTRO}_staging ${ST2PKG_VERSION} st2api)
 
 re="\\b$DISTRO\\b"
 [[ "$NOTESTS" =~ $re ]] && TESTING=0


### PR DESCRIPTION
Since st2web would be on a different revision cycle, we need a way to pick revision per package.