### PR TITLE
Enable el6 distro builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ general:
 machine:
   # Overwrite these ENV variables in parametrized (manual/API) builds
   environment:
-    DISTROS: "wheezy jessie trusty el7"
+    DISTROS: "wheezy jessie trusty el6 el7"
     NOTESTS: "el7"
     ST2_GITURL: https://github.com/StackStorm/st2
     ST2_GITREV: master


### PR DESCRIPTION
Since https://github.com/StackStorm/st2-packages/pull/65 is complete, we can start building `el6` packages and deploying them to https://bintray.com/stackstorm/el6_staging.

Don't merge it yet. Needs +1 CircleCI container, see:
https://stackstorm.slack.com/archives/stackstorm/p1452691983023863