### PR TITLE
Missing rhel fixes bundle

### DIFF
--- a/packages/st2bundle/debian/install
+++ b/packages/st2bundle/debian/install
@@ -4,7 +4,5 @@
 ../contrib/examples usr/share/doc/st2/
 ../st2actions/conf/logging.*.conf etc/st2/
 ../st2actions/conf/syslog.*.conf etc/st2/
-../st2exporter/conf/logging.*.conf etc/st2/
-../st2exporter/conf/syslog.*.conf etc/st2/
 ../st2reactor/conf/logging.*.conf etc/st2/
 ../st2reactor/conf/syslog.*.conf etc/st2/

--- a/packages/st2bundle/debian/rules
+++ b/packages/st2bundle/debian/rules
@@ -26,7 +26,6 @@ override_dh_installinit:
 	dh_installinit --no-start --name=st2actionrunner
 	dh_installinit --no-start --name=st2api
 	dh_installinit --no-start --name=st2auth
-	dh_installinit --no-start --name=st2exporter
 	dh_installinit --no-start --name=st2notifier
 	dh_installinit --no-start --name=st2resultstracker
 	dh_installinit --no-start --name=st2rulesengine

--- a/packages/st2bundle/rpm/st2actionrunner-worker.init
+++ b/packages/st2bundle/rpm/st2actionrunner-worker.init
@@ -80,6 +80,7 @@ write_pidfile() {
   [ -n "$currentpid" ] && echo $currentpid > $pidfile
 }
 
+
 start() {
     echo -n $"Starting $DESC: "
     nohup_start $DAEMON $DAEMON_ARGS
@@ -116,7 +117,7 @@ force_reload() {
 
 rh_status() {
     # run checks to determine if the service is running or use generic status
-    status $DESC
+    status -p $PIDFILE
 }
 
 rh_status_q() {

--- a/packages/st2bundle/rpm/st2actionrunner.init
+++ b/packages/st2bundle/rpm/st2actionrunner.init
@@ -37,22 +37,11 @@ lockfile=/var/lock/subsys/$NAME
 
 
 start() {
-    echo -n $"Starting $NAME: "
     $SPAWNER start
-    retval=$?
-    [ $retval -eq 0 ] && success $"$NAME startup" || failure $"$NAME startup"
-    echo
-    [ $retval -eq 0 ] && touch $lockfile
-    return $retval
 }
 
 stop() {
-    echo -n $"Stopping $NAME: "
     $SPAWNER stop
-    retval=$?
-    echo
-    [ $retval -eq 0 ] && rm -f $lockfile
-    return $retval
 }
 
 restart() {
@@ -69,8 +58,7 @@ force_reload() {
 }
 
 rh_status() {
-    # run checks to determine if the service is running or use generic status
-    status $NAME
+    $SPAWNER status
 }
 
 rh_status_q() {

--- a/packages/st2bundle/rpm/st2bundle.spec
+++ b/packages/st2bundle/rpm/st2bundle.spec
@@ -18,7 +18,7 @@ Conflicts: st2common
 %install
   %default_install
   %pip_install_venv
-  %service_install st2actionrunner %{worker_name} st2api st2auth st2exporter st2notifier
+  %service_install st2actionrunner %{worker_name} st2api st2auth st2notifier
   %service_install st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
   make post_install DESTDIR=%{?buildroot}
   # clean up absolute path in record file, so that /usr/bin/check-buildroot doesn't fail
@@ -46,15 +46,15 @@ Conflicts: st2common
     chown %{svc_user}.%{svc_user} /etc/st2/htpasswd
     chmod 640 /etc/st2/htpasswd
   fi
-  %service_post st2actionrunner %{worker_name} st2api st2auth st2exporter st2notifier
+  %service_post st2actionrunner %{worker_name} st2api st2auth st2notifier
   %service_post st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
 
 %preun
-  %service_preun st2actionrunner %{worker_name} st2api st2auth st2exporter st2notifier
+  %service_preun st2actionrunner %{worker_name} st2api st2auth st2notifier
   %service_preun st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
 
 %postun
-  %service_postun st2actionrunner %{worker_name} st2api st2auth st2exporter st2notifier
+  %service_postun st2actionrunner %{worker_name} st2api st2auth st2notifier
   %service_postun st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
   # rpm has no purge option, so we leave this file
   [ -f /etc/logrotate.d/st2 ] && mv -f /etc/logrotate.d/st2 /etc/logrotate.d/st2.disabled
@@ -77,7 +77,6 @@ Conflicts: st2common
   %{_unitdir}/%{worker_name}.service
   %{_unitdir}/st2api.service
   %{_unitdir}/st2auth.service
-  %{_unitdir}/st2exporter.service
   %{_unitdir}/st2notifier.service
   %{_unitdir}/st2resultstracker.service
   %{_unitdir}/st2rulesengine.service
@@ -88,7 +87,6 @@ Conflicts: st2common
   %{_sysconfdir}/rc.d/init.d/%{worker_name}
   %{_sysconfdir}/rc.d/init.d/st2api
   %{_sysconfdir}/rc.d/init.d/st2auth
-  %{_sysconfdir}/rc.d/init.d/st2exporter
   %{_sysconfdir}/rc.d/init.d/st2notifier
   %{_sysconfdir}/rc.d/init.d/st2resultstracker
   %{_sysconfdir}/rc.d/init.d/st2rulesengine

--- a/packages/st2bundle/rpm/st2bundle.spec
+++ b/packages/st2bundle/rpm/st2bundle.spec
@@ -18,8 +18,8 @@ Conflicts: st2common
 %install
   %default_install
   %pip_install_venv
-  %service_install st2actionrunner %{worker_name} st2api st2auth st2exporter
-  %service_install st2notifier st2resultstracker st2rulesengine st2sensorcontainer
+  %service_install st2actionrunner %{worker_name} st2api st2auth st2exporter st2notifier
+  %service_install st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
   make post_install DESTDIR=%{?buildroot}
   # clean up absolute path in record file, so that /usr/bin/check-buildroot doesn't fail
   find /root/rpmbuild/BUILDROOT/%{package}* -name RECORD -exec sed -i '/\/root\/rpmbuild.*$/d' '{}' ';'
@@ -46,16 +46,16 @@ Conflicts: st2common
     chown %{svc_user}.%{svc_user} /etc/st2/htpasswd
     chmod 640 /etc/st2/htpasswd
   fi
-  %service_post st2actionrunner %{worker_name} st2api st2auth st2exporter
-  %service_post st2notifier st2resultstracker st2rulesengine st2sensorcontainer
+  %service_post st2actionrunner %{worker_name} st2api st2auth st2exporter st2notifier
+  %service_post st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
 
 %preun
-  %service_preun st2actionrunner %{worker_name} st2api st2auth st2exporter
-  %service_preun st2notifier st2resultstracker st2rulesengine st2sensorcontainer
+  %service_preun st2actionrunner %{worker_name} st2api st2auth st2exporter st2notifier
+  %service_preun st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
 
 %postun
-  %service_postun st2actionrunner %{worker_name} st2api st2auth st2exporter
-  %service_postun st2notifier st2resultstracker st2rulesengine st2sensorcontainer
+  %service_postun st2actionrunner %{worker_name} st2api st2auth st2exporter st2notifier
+  %service_postun st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
   # rpm has no purge option, so we leave this file
   [ -f /etc/logrotate.d/st2 ] && mv -f /etc/logrotate.d/st2 /etc/logrotate.d/st2.disabled
   exit 0
@@ -82,6 +82,7 @@ Conflicts: st2common
   %{_unitdir}/st2resultstracker.service
   %{_unitdir}/st2rulesengine.service
   %{_unitdir}/st2sensorcontainer.service
+  %{_unitdir}/st2garbagecollector.service
 %else
   %{_sysconfdir}/rc.d/init.d/st2actionrunner
   %{_sysconfdir}/rc.d/init.d/%{worker_name}
@@ -92,4 +93,5 @@ Conflicts: st2common
   %{_sysconfdir}/rc.d/init.d/st2resultstracker
   %{_sysconfdir}/rc.d/init.d/st2rulesengine
   %{_sysconfdir}/rc.d/init.d/st2sensorcontainer
+  %{_sysconfdir}/rc.d/init.d/st2garbagecollector
 %endif

--- a/packages/st2exporter/debian/install
+++ b/packages/st2exporter/debian/install
@@ -1,2 +1,0 @@
-conf/logging.*.conf etc/st2/
-conf/syslog.*.conf etc/st2/

--- a/packages/st2exporter/debian/rules
+++ b/packages/st2exporter/debian/rules
@@ -22,7 +22,8 @@ override_dh_installdirs:
 
 override_dh_installinit:
 	# So far don't start services
-	dh_installinit --no-start
+	# disabling installation of exporter service
+	# dh_installinit --no-start
 
 override_dh_installdeb:
 	$(MAKE) post_install

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -25,8 +25,7 @@ class ST2Spec
   instance_eval(File.read('rake/build/environment.rb'))
 
   ST2_SERVICES = %w(st2api st2auth st2actionrunner st2notifier
-                    st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
-                    st2exporter)
+                    st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector)
 
   SPECCONF = {
     bin_prefix: '/usr/bin',
@@ -56,7 +55,7 @@ class ST2Spec
       st2actions: %w(st2actionrunner st2notifier st2resultstracker),
       st2reactor: %w(st2rulesengine st2sensorcontainer st2garbagecollector),
       st2bundle: %w(st2api st2auth st2actionrunner st2notifier
-                     st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector st2exporter),
+                     st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector),
       mistral: [
         ['mistral', binary_name: 'mistral-server']
       ]


### PR DESCRIPTION
1. Added missing copy-paste pieces for rhel rpm specs into st2bundle.
2. Wiped out st2exporter service from packages

cc: @lakshmi-kannan , @manasdk, @emedvedev, @Kami 