### PR TITLE
fixed umask to 022, for debian init and upstart services

### DIFF
--- a/packages/mistral/debian/mistral.init
+++ b/packages/mistral/debian/mistral.init
@@ -24,6 +24,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 RUNAS_USER="mistral"
 RUNAS_GROUP="mistral"
+UMASK=022
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -61,8 +62,8 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   lsb_running || return 1
-  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --umask $UMASK --background --make-pidfile --pidfile $PIDFILE \
+    --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 

--- a/packages/mistral/debian/mistral.upstart
+++ b/packages/mistral/debian/mistral.upstart
@@ -9,7 +9,7 @@ setgid mistral
 respawn
 respawn limit 2 5
 
-umask 007
+umask 022
 kill timeout 60
 
 script

--- a/packages/st2bundle/debian/st2bundle.st2actionrunner-worker.init
+++ b/packages/st2bundle/debian/st2bundle.st2actionrunner-worker.init
@@ -22,6 +22,7 @@ DAEMON=/usr/share/python/st2/bin/$NAME
 DAEMON_ARGS="--config-file /etc/st2/st2.conf"
 PIDFILE=/var/run/$NAME-${WORKERID}.pid
 SCRIPTNAME=/etc/init.d/$NAME
+UMASK=022
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -62,8 +63,8 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   lsb_running || return 1
-  start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --umask $UMASK --background --make-pidfile --pidfile $PIDFILE \
+    --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 

--- a/packages/st2bundle/debian/st2bundle.st2actionrunner-worker.upstart
+++ b/packages/st2bundle/debian/st2bundle.st2actionrunner-worker.upstart
@@ -6,7 +6,7 @@ description     "StackStorm actionrunner worker task"
 respawn
 respawn limit 2 5
 
-umask 007
+umask 022
 kill timeout 60
 
 instance $WORKERID

--- a/packages/st2bundle/debian/st2bundle.st2api.init
+++ b/packages/st2bundle/debian/st2bundle.st2api.init
@@ -24,6 +24,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 RUNAS_USER="st2"
 RUNAS_GROUP="st2"
+UMASK=022
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -61,8 +62,8 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   lsb_running || return 1
-  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --umask $UMASK --background --make-pidfile --pidfile $PIDFILE \
+     --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 

--- a/packages/st2bundle/debian/st2bundle.st2api.upstart
+++ b/packages/st2bundle/debian/st2bundle.st2api.upstart
@@ -9,7 +9,7 @@ setgid st2
 respawn
 respawn limit 2 5
 
-umask 007
+umask 022
 kill timeout 60
 
 script

--- a/packages/st2bundle/debian/st2bundle.st2auth.init
+++ b/packages/st2bundle/debian/st2bundle.st2auth.init
@@ -24,6 +24,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 RUNAS_USER="st2"
 RUNAS_GROUP="st2"
+UMASK=022
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -61,8 +62,8 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   lsb_running || return 1
-  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --umask $UMASK --background --make-pidfile --pidfile $PIDFILE \
+     --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 

--- a/packages/st2bundle/debian/st2bundle.st2auth.upstart
+++ b/packages/st2bundle/debian/st2bundle.st2auth.upstart
@@ -9,7 +9,7 @@ setgid st2
 respawn
 respawn limit 2 5
 
-umask 007
+umask 022
 kill timeout 60
 
 script

--- a/packages/st2bundle/debian/st2bundle.st2exporter.init
+++ b/packages/st2bundle/debian/st2bundle.st2exporter.init
@@ -24,6 +24,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 RUNAS_USER="st2"
 RUNAS_GROUP="st2"
+UMASK=022
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -61,8 +62,8 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   lsb_running || return 1
-  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --umask $UMASK --background --make-pidfile --pidfile $PIDFILE \
+     --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 

--- a/packages/st2bundle/debian/st2bundle.st2exporter.upstart
+++ b/packages/st2bundle/debian/st2bundle.st2exporter.upstart
@@ -9,7 +9,7 @@ setgid st2
 respawn
 respawn limit 2 5
 
-umask 007
+umask 022
 kill timeout 60
 
 script

--- a/packages/st2bundle/debian/st2bundle.st2garbagecollector.init
+++ b/packages/st2bundle/debian/st2bundle.st2garbagecollector.init
@@ -24,6 +24,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 RUNAS_USER="st2"
 RUNAS_GROUP="st2"
+UMASK=022
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -61,8 +62,8 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   lsb_running || return 1
-  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --umask $UMASK --background --make-pidfile --pidfile $PIDFILE \
+     --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 

--- a/packages/st2bundle/debian/st2bundle.st2garbagecollector.upstart
+++ b/packages/st2bundle/debian/st2bundle.st2garbagecollector.upstart
@@ -9,7 +9,7 @@ setgid st2
 respawn
 respawn limit 2 5
 
-umask 007
+umask 022
 kill timeout 60
 
 script

--- a/packages/st2bundle/debian/st2bundle.st2notifier.init
+++ b/packages/st2bundle/debian/st2bundle.st2notifier.init
@@ -24,6 +24,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 RUNAS_USER="st2"
 RUNAS_GROUP="st2"
+UMASK=022
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -61,8 +62,8 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   lsb_running || return 1
-  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --umask $UMASK --background --make-pidfile --pidfile $PIDFILE \
+     --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 

--- a/packages/st2bundle/debian/st2bundle.st2notifier.upstart
+++ b/packages/st2bundle/debian/st2bundle.st2notifier.upstart
@@ -9,7 +9,7 @@ setgid st2
 respawn
 respawn limit 2 5
 
-umask 007
+umask 022
 kill timeout 60
 
 script

--- a/packages/st2bundle/debian/st2bundle.st2resultstracker.init
+++ b/packages/st2bundle/debian/st2bundle.st2resultstracker.init
@@ -24,6 +24,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 RUNAS_USER="st2"
 RUNAS_GROUP="st2"
+UMASK=022
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -61,8 +62,8 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   lsb_running || return 1
-  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --umask $UMASK --background --make-pidfile --pidfile $PIDFILE \
+     --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 

--- a/packages/st2bundle/debian/st2bundle.st2resultstracker.upstart
+++ b/packages/st2bundle/debian/st2bundle.st2resultstracker.upstart
@@ -9,7 +9,7 @@ setgid st2
 respawn
 respawn limit 2 5
 
-umask 007
+umask 022
 kill timeout 60
 
 script

--- a/packages/st2bundle/debian/st2bundle.st2rulesengine.init
+++ b/packages/st2bundle/debian/st2bundle.st2rulesengine.init
@@ -24,6 +24,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 RUNAS_USER="st2"
 RUNAS_GROUP="st2"
+UMASK=022
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -61,8 +62,8 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   lsb_running || return 1
-  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --umask $UMASK --background --make-pidfile --pidfile $PIDFILE \
+     --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 

--- a/packages/st2bundle/debian/st2bundle.st2rulesengine.upstart
+++ b/packages/st2bundle/debian/st2bundle.st2rulesengine.upstart
@@ -9,7 +9,7 @@ setgid st2
 respawn
 respawn limit 2 5
 
-umask 007
+umask 022
 kill timeout 60
 
 script

--- a/packages/st2bundle/debian/st2bundle.st2sensorcontainer.init
+++ b/packages/st2bundle/debian/st2bundle.st2sensorcontainer.init
@@ -24,6 +24,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 RUNAS_USER="st2"
 RUNAS_GROUP="st2"
+UMASK=022
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -61,8 +62,8 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   lsb_running || return 1
-  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+  start-stop-daemon --start --quiet --chuid $RUNAS_USER:$RUNAS_GROUP --umask $UMASK --background --make-pidfile --pidfile $PIDFILE \
+     --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 

--- a/packages/st2bundle/debian/st2bundle.st2sensorcontainer.upstart
+++ b/packages/st2bundle/debian/st2bundle.st2sensorcontainer.upstart
@@ -9,7 +9,7 @@ setgid st2
 respawn
 respawn limit 2 5
 
-umask 007
+umask 022
 kill timeout 60
 
 script


### PR DESCRIPTION
fixed default umask for debain/ubuntu systems.

PS: systemd, redhat sysv init scripts will use 022 by default if not explicitly set.