### PR TITLE
Hardcode default ST2_WAITFORSTART to 10sec in internal files

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,6 @@ machine:
     ST2_GITURL: https://github.com/StackStorm/st2
     ST2_GITREV: master
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
-    ST2_WAITFORSTART: 10
     BUILD_DOCKER: 0
     DEPLOY_DOCKER: 0
     DEPLOY_PACKAGES: 1

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -36,7 +36,7 @@ class ST2Spec
     rabbitmqhost: pipeopts.rabbitmqhost,
     postgreshost: pipeopts.postgreshost,
     mongodbhost:  pipeopts.mongodbhost,
-    wait_for_start: (ENV['ST2_WAITFORSTART'] || 7).to_i,
+    wait_for_start: (ENV['ST2_WAITFORSTART'] || 10).to_i,
     loglines_to_show: 20,
     logdest_pattern: {
       st2actionrunner: 'st2actionrunner.{pid}'


### PR DESCRIPTION
Don't include it in repo-only `circle.yml` file to propagate it automatically across all needed branches of `st2` repo.