### PR TITLE
Fix ST2_WAITFORSTART when it's empty

### DIFF
--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -36,7 +36,7 @@ class ST2Spec
     rabbitmqhost: pipeopts.rabbitmqhost,
     postgreshost: pipeopts.postgreshost,
     mongodbhost:  pipeopts.mongodbhost,
-    wait_for_start: (ENV['ST2_WAITFORSTART'] || 10).to_i,
+    wait_for_start: ((10 if ENV['ST2_WAITFORSTART'].empty?) or ENV['ST2_WAITFORSTART']).to_i,
     loglines_to_show: 20,
     logdest_pattern: {
       st2actionrunner: 'st2actionrunner.{pid}'


### PR DESCRIPTION
Example: https://circleci.com/gh/StackStorm/st2-packages/268

When `ST2_WAITFORSTART` is empty, eg bash:
```sh
export ST2_WAITFORSTART=
```
which is our case when `ST2_WAITFORSTART` could be optional (https://github.com/StackStorm/st2-packages/blob/master/.circle/buildenv.sh#L53), this is transformed in Ruby part as `nil` -> `0`.

That results in:
![pnx7rq5 1](https://cloud.githubusercontent.com/assets/1533818/12557688/b15b0900-c394-11e5-94da-28a3dba0438f.png)

We want to use default numeric value when `ST2_WAITFORSTART` is empty.