### PR TITLE
[Tests] Check if st2 services are listening on respective ports

### DIFF
--- a/rake/spec/default/60-st2_all-services-ok_spec.rb
+++ b/rake/spec/default/60-st2_all-services-ok_spec.rb
@@ -9,16 +9,28 @@ describe 'external services' do
     subject { host(spec[:rabbitmqhost]) }
     it { is_expected.to be_reachable }
   end
+  describe 'rabbitmq' do
+    subject { host(spec[:rabbitmqhost]) }
+    it { should be_reachable.with( :port => 5672, :timeout => 1 ) }
+  end
 
   describe 'mongodb' do
     subject { host(spec[:mongodbhost]) }
     it { is_expected.to be_reachable }
+  end
+  describe 'mongodb' do
+    subject { host(spec[:mongodbhost]) }
+    it { should be_reachable.with( :port => 27017, :timeout => 1 ) }
   end
 
   if spec[:mistral_enabled]
     describe 'postgres' do
       subject { host(spec[:postgreshost]) }
       it { is_expected.to be_reachable }
+    end
+    describe 'postgres' do
+      subject { host(spec[:postgreshost]) }
+      it { should be_reachable.with( :port => 5432, :timeout => 1 ) }
     end
   end
 end

--- a/rake/spec/default/60-st2_all-services-ok_spec.rb
+++ b/rake/spec/default/60-st2_all-services-ok_spec.rb
@@ -63,4 +63,21 @@ describe 'st2 services' do
       it { is_expected.to be_running }
     end
   end
+
+  describe 'st2auth', prompt_on_failure: true do
+    subject { port(9100) }
+    it { should be_listening }
+  end
+
+  describe 'st2api', prompt_on_failure: true do
+    subject { port(9101) }
+    it { should be_listening }
+  end
+
+  if spec[:mistral_enabled]
+    describe 'mistral', prompt_on_failure: true do
+      subject { port(8989) }
+      it { should be_listening }
+    end
+  end
 end

--- a/rake/spec/default/60-st2_all-services-ok_spec.rb
+++ b/rake/spec/default/60-st2_all-services-ok_spec.rb
@@ -8,29 +8,20 @@ describe 'external services' do
   describe 'rabbitmq' do
     subject { host(spec[:rabbitmqhost]) }
     it { is_expected.to be_reachable }
-  end
-  describe 'rabbitmq' do
-    subject { host(spec[:rabbitmqhost]) }
-    it { should be_reachable.with( :port => 5672, :timeout => 1 ) }
+    it { is_expected.to be_reachable.with :port => 5672, :timeout => 1 }
   end
 
   describe 'mongodb' do
     subject { host(spec[:mongodbhost]) }
     it { is_expected.to be_reachable }
-  end
-  describe 'mongodb' do
-    subject { host(spec[:mongodbhost]) }
-    it { should be_reachable.with( :port => 27017, :timeout => 1 ) }
+    it { is_expected.to be_reachable.with :port => 27017, :timeout => 1 }
   end
 
   if spec[:mistral_enabled]
     describe 'postgres' do
       subject { host(spec[:postgreshost]) }
       it { is_expected.to be_reachable }
-    end
-    describe 'postgres' do
-      subject { host(spec[:postgreshost]) }
-      it { should be_reachable.with( :port => 5432, :timeout => 1 ) }
+      it { is_expected.to be_reachable.with :port => 5432, :timeout => 1 }
     end
   end
 end


### PR DESCRIPTION
Add real check if `st2api`, `st2auth`, `mistral` are reachable on `9100`, `9101`, `8989`


Guide:
http://serverspec.org/resource_types.html

-----
First we should include `netstat` binary, required for these checks, which is not available under minimal Docker.

@dennybaa can you add `net-tools` for all test Docker images & publish them, see: https://github.com/StackStorm/st2-dockerfiles/pull/7 ?