### PR TITLE
Default connection settings in mistral.conf

### DIFF
--- a/packages/mistral/conf/mistral.conf
+++ b/packages/mistral/conf/mistral.conf
@@ -171,6 +171,7 @@
 # configuration. If not set, we fall back to the rpc_backend option
 # and driver specific configuration. (string value)
 #transport_url = <None>
+transport_url = rabbit://guest:guest@localhost:5672
 
 # The messaging driver to use, defaults to rabbit. Other drivers
 # include qpid and zmq. (string value)
@@ -233,6 +234,7 @@
 # Deprecated group/name - [DATABASE]/sql_connection
 # Deprecated group/name - [sql]/connection
 #connection = <None>
+connection = postgresql://mistral:StackStorm@localhost/mistral
 
 # The SQLAlchemy connection string to use to connect to the slave
 # database. (string value)
@@ -261,6 +263,7 @@
 # Deprecated group/name - [DEFAULT]/sql_max_pool_size
 # Deprecated group/name - [DATABASE]/sql_max_pool_size
 #max_pool_size = <None>
+max_pool_size = 50
 
 # Maximum number of database connection retries during startup. Set to
 # -1 to specify an infinite retry count. (integer value)
@@ -840,3 +843,4 @@
 
 # Enables user authentication in pecan. (boolean value)
 #auth_enable = true
+auth_enable = false


### PR DESCRIPTION
Currently user should generate mistral config by hand, adjusting `rabbitmq` and `postgresql` configuration.

And we do the same via our smoke tests: 
![u17xv8d 1](https://cloud.githubusercontent.com/assets/1533818/12583398/4bb762c6-c44b-11e5-9926-4c9984186c06.png)

Let's place mistral config with default connection, assuming everything is local, removing one step for 80% of users to make it minimally working.

Since mistral config is managed by packaging, once user change default config - it won't be replaced automatically during package upgrade, what is perfectly nice.

> Please commit changes directly to `mistral-default-config` shared branch if you have something to add/adjust for default [`mistral.conf`](https://github.com/StackStorm/st2-packages/blob/master/packages/mistral/conf/mistral.conf).