### PR TITLE
Remove `prompt_on_failure` for new Rspec tests, change format

### DIFF
--- a/rake/spec/default/60-st2_all-services-ok_spec.rb
+++ b/rake/spec/default/60-st2_all-services-ok_spec.rb
@@ -64,23 +64,16 @@ describe 'st2 services' do
   spec[:service_list].each do |name|
     describe service(name), prompt_on_failure: true do
       it { is_expected.to be_running }
-    end
-  end
-
-  describe 'st2auth' do
-    subject { port(9100) }
-    it { is_expected.to be_listening }
-  end
-
-  describe 'st2api' do
-    subject { port(9101) }
-    it { is_expected.to be_listening }
-  end
-
-  if spec[:mistral_enabled]
-    describe 'mistral' do
-      subject { port(8989) }
-      it { is_expected.to be_listening }
+      if service(name) == 'st2auth'
+        subject { port(9100) }
+        it { is_expected.to be_listening }
+      elsif service(name) == 'st2api'
+        subject { port(9101) }
+        it { is_expected.to be_listening }
+      elsif service(name) == 'mistral'
+        subject { port(8989) }
+        it { is_expected.to be_listening }
+      end
     end
   end
 end

--- a/rake/spec/default/60-st2_all-services-ok_spec.rb
+++ b/rake/spec/default/60-st2_all-services-ok_spec.rb
@@ -67,20 +67,20 @@ describe 'st2 services' do
     end
   end
 
-  describe 'st2auth', prompt_on_failure: true do
+  describe 'st2auth' do
     subject { port(9100) }
-    it { should be_listening }
+    it { is_expected.to be_listening }
   end
 
-  describe 'st2api', prompt_on_failure: true do
+  describe 'st2api' do
     subject { port(9101) }
-    it { should be_listening }
+    it { is_expected.to be_listening }
   end
 
   if spec[:mistral_enabled]
-    describe 'mistral', prompt_on_failure: true do
+    describe 'mistral' do
       subject { port(8989) }
-      it { should be_listening }
+      it { is_expected.to be_listening }
     end
   end
 end


### PR DESCRIPTION
As requested by @dennybaa https://github.com/StackStorm/st2-packages/pull/107/files#r50952487