### PR TITLE
Perform mistral migration first

### DIFF
--- a/install_debian.md
+++ b/install_debian.md
@@ -60,6 +60,7 @@ EHD
 Start mistral and update schema:
 ```
 sudo service mistral start
+/usr/share/python/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf head
 /usr/share/python/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
 ```
 

--- a/rake/spec/default/60-st2_all-services-ok_spec.rb
+++ b/rake/spec/default/60-st2_all-services-ok_spec.rb
@@ -39,7 +39,8 @@ describe 'start st2 components and services' do
     # start clean postgres (so command fails on the second up invocation %-).
     #
     if spec[:mistral_enabled]
-      puts "===> Invoking mistral-db-manage populate..."
+      puts "===> Invoking mistral-db-manage migration commands..."
+      spec.backend.run_command(spec[:mistral_db_head_command])
       spec.backend.run_command(spec[:mistral_db_populate_command])
     end
     puts

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -45,6 +45,8 @@ class ST2Spec
                               ' --register-fail-on-failure' \
                               ' --register-all' \
                               ' --config-dir /etc/st2',
+    mistral_db_head_command: '/usr/share/python/mistral/bin/mistral-db-manage' \
+                                 ' --config-file /etc/mistral/mistral.conf head',
     mistral_db_populate_command: '/usr/share/python/mistral/bin/mistral-db-manage' \
                                  ' --config-file /etc/mistral/mistral.conf populate',
 


### PR DESCRIPTION
See: https://github.com/openstack/mistral/blob/master/mistral/db/sqlalchemy/migration/alembic_migrations/README.md for more details.
- `head` runs migration (important)
- `populate` registers st2mistral with mistral

This will partially resolve https://github.com/StackStorm/st2-packages/issues/119 Mistral `DBError`,
but init scripts still needs to be fixed (to show correct exit code and to restart child process if hanged).