### PR TITLE
Hardcode ST2_WAITFORSTART

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,6 @@ machine:
     ST2_GITURL: https://github.com/StackStorm/st2
     ST2_GITREV: master
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
-    ST2_WAITFORSTART: 10
     BUILD_DOCKER: 0
     DEPLOY_DOCKER: 0
     DEPLOY_PACKAGES: 1

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -36,7 +36,7 @@ class ST2Spec
     rabbitmqhost: pipeopts.rabbitmqhost,
     postgreshost: pipeopts.postgreshost,
     mongodbhost:  pipeopts.mongodbhost,
-    # NB!!! arma do not hardcode the default value here! use circle.yml.
+    # NB!!! We shouldn't change circle.yml for every branch of `st2`! Hardcode value here so it will work for all tests consistently!
     wait_for_start: ENV['ST2_WAITFORSTART'].to_s != '' ? ENV['ST2_WAITFORSTART'].to_i : 7,
     loglines_to_show: 20,
     logdest_pattern: {


### PR DESCRIPTION
After all tests, I must state that WAITFORSTART is not an issue at all for gunicorn (is it `mistral` or `st2auth` or `st2api`).
The root cause was always different (child process died).

@dennybaa see this PR description: https://github.com/StackStorm/st2-packages/pull/102 why we need hardcoding.

> Don't include it in repo-only circle.yml file to propagate it automatically across all needed branches of st2 repo.

Hope that's clear reason and this looks like a good feature. So we'll have consistent tests across all `st2` branches and `st2-packages` repo as well :+1: 