### PR TITLE
Bump mistral to 1.3

### DIFF
--- a/rake/build/environment.rb
+++ b/rake/build/environment.rb
@@ -71,9 +71,9 @@ pipeopts 'mistral' do
   standalone true
   checkout :mistral
   envpass :giturl,  'https://github.com/StackStorm/mistral', from: 'MISTRAL_GITURL'
-  envpass :gitrev,  'st2-1.2.0',                             from: 'MISTRAL_GITREV'
+  envpass :gitrev,  'st2-1.3.0',                             from: 'MISTRAL_GITREV'
   envpass :gitdir,  make_tmpname('mistral-')
-  envpass :mistral_version, '1.2.0'
+  envpass :mistral_version, '1.3.0'
   envpass :mistral_release, 1
 end
 
@@ -81,9 +81,9 @@ pipeopts 'st2mistral' do
   standalone true
   checkout :st2mistral
   envpass :giturl,  'https://github.com/StackStorm/st2mistral', from: 'ST2MISTRAL_GITURL'
-  envpass :gitrev,  'st2-1.2.0',                                from: 'ST2MISTRAL_GITREV'
+  envpass :gitrev,  'st2-1.3.0',                                from: 'ST2MISTRAL_GITREV'
   envpass :gitdir,  make_tmpname('st2mistral-')
-  envpass :mistral_version, '1.2.0'
+  envpass :mistral_version, '1.3.0'
   envpass :mistral_release, 1
 end
 


### PR DESCRIPTION
Bump version, since upstream was updated: 
https://github.com/stackstorm/mistral/tree/st2-1.3.0 - `11 days ago`
https://github.com/stackstorm/st2mistral/tree/st2-1.3.0 - `11 days ago`


Also FYI there is technical debt to move CI related to `mistral` and `st2mistral` to respective repos.
Eg. when there are changes in `mistral` or `st2mistral` - build should be triggered automatically and should only produce `mistral` or `st2mistral` artifacts, without rebuilding entire `st2` packages.
See for more info: https://github.com/StackStorm/st2-packages/issues/82 (it wasn't priority though).

Also FYI @dzimine and @lakshmi-kannan.