### PR TITLE
Don't forget chatops pack

### DIFF
--- a/packages/st2/debian/install
+++ b/packages/st2/debian/install
@@ -1,6 +1,7 @@
 ../contrib/core opt/stackstorm/packs/
 ../contrib/packs opt/stackstorm/packs/
 ../contrib/linux opt/stackstorm/packs/
+../contrib/chatops opt/stackstorm/packs/
 ../contrib/examples usr/share/doc/st2/
 ../st2actions/conf/logging.*.conf etc/st2/
 ../st2actions/conf/syslog.*.conf etc/st2/

--- a/packages/st2/rpm/st2.spec
+++ b/packages/st2/rpm/st2.spec
@@ -69,6 +69,7 @@ Conflicts: st2common
   /opt/stackstorm/packs/core
   /opt/stackstorm/packs/linux
   /opt/stackstorm/packs/packs
+  /opt/stackstorm/packs/chatops
   %{_datadir}/doc/st2
   %attr(755, %{svc_user}, %{svc_user}) %{_localstatedir}/log/st2
   %attr(755, %{svc_user}, %{svc_user}) /opt/stackstorm/exports


### PR DESCRIPTION
For now, without st2chatops package adding chatops by user is really ugly. 
I am ok to revert this when we do st2chatops, ideally, the chatops pack would be in that package.