### PR TITLE
Mistral client wrapper

### DIFF
--- a/packages/st2mistral/bin/mistral
+++ b/packages/st2mistral/bin/mistral
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Wrapper script, used to override default mistral client environment variables
+# https://github.com/StackStorm/python-mistralclient#running-mistral-client
+
+OS_MISTRAL_URL=${OS_MISTRAL_URL:-http://127.0.0.1:8989/v2}
+export OS_MISTRAL_URL
+
+exec /opt/stackstorm/mistral/bin/mistral "$@"

--- a/packages/st2mistral/debian/install
+++ b/packages/st2mistral/debian/install
@@ -1,1 +1,2 @@
 conf/mistral.conf /etc/mistral
+bin/mistral /usr/bin

--- a/packages/st2mistral/debian/st2mistral.links
+++ b/packages/st2mistral/debian/st2mistral.links
@@ -1,1 +1,0 @@
-opt/stackstorm/mistral/bin/mistral usr/bin/mistral

--- a/packages/st2mistral/rpm/st2mistral.spec
+++ b/packages/st2mistral/rpm/st2mistral.spec
@@ -52,7 +52,7 @@ Summary: Mistral workflow service
   %service_postun mistral mistral-api mistral-server
 
 %files
-  %{_bindir}/*
+  %{_bindir}/mistral
   /opt/stackstorm/mistral
   %config(noreplace) %{_sysconfdir}/mistral/*
   %attr(755, %{svc_user}, %{svc_user}) %{_localstatedir}/log/mistral


### PR DESCRIPTION
Overrides `OS_MISTRAL_URL` to use `127.0.0.1` instead of `localhost` for mistral client via wrapper script, approach descried: https://www.debian.org/doc/debian-policy/ch-opersys.html#s9.9

Related to issue #157

cc @lakshmi-kannan