### PR TITLE
Test Deployments in `feature/circleci` branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -71,7 +71,9 @@ test:
 
 deployment:
   publish:
-    branch: master
+    branch:
+      - master
+      - feature/circleci
     owner: StackStorm
     commands:
       # Deploy to Bintray all artifacts for respective distros in parallel


### PR DESCRIPTION
With existing config, CircleCI `deployment` stage was executed only after merging the PR.
This feature allows us to test `deployment` stage **before** merging, if we push to `feature/circleci` branch.
For example it could be useful to test if [Bintray/PackageCloud/save_payload scripts works as expected](https://github.com/StackStorm/st2-packages/blob/610a3064a05f7a03531a576aabd9b592c877eaaf/circle.yml#L72-L86).

#### Example
1.) Create upstream branch `feature/circleci`
2.) Push changes to `feature/circleci`
3.) Open PR, check the CircleCI logs, test `deployment`
4.) Merge changes and delete `feature/circleci` branch (just don't forget to do that to avoid collisions with other's work)

Thanks @enykeev for nice idea in [`st2web`](https://github.com/StackStorm/st2web/blob/7daa2a7c2e9df0a6e2145f35867429aa65511251/circle.yml#L68)

------

@lakshmi-kannan @dennybaa ^^ Instructions.