### PR TITLE
Change revision Discovery to PackageCloud

### DIFF
--- a/.circle/buildenv.sh
+++ b/.circle/buildenv.sh
@@ -45,7 +45,10 @@ write_env() {
 ST2_GITURL=${ST2_GITURL:-$(st2_giturl)}
 ST2_GITREV=${ST2_GITREV:-$CIRCLE_BRANCH}
 ST2PKG_VERSION=$(fetch_version)
-ST2PKG_RELEASE=$(.circle/bintray.sh next-revision ${DISTRO}_staging ${ST2PKG_VERSION} st2)
+# for Bintray
+#ST2PKG_RELEASE=$(.circle/bintray.sh next-revision ${DISTRO}_staging ${ST2PKG_VERSION} st2)
+# for PackageCloud
+ST2PKG_RELEASE=$(.circle/packagecloud.sh next-revision ${DISTRO} ${ST2PKG_VERSION} st2)
 
 re="\\b$DISTRO\\b"
 [[ "$NOTESTS" =~ $re ]] && TESTING=0


### PR DESCRIPTION
Part of https://github.com/StackStorm/st2-packages/issues/130

Start revision discovery and revision increment based on PackageCloud repositories, instead of Bintray repositories.

This could lead to errors because of current rough `curl | pq` implementation in [`packagecloud.sh`](https://github.com/StackStorm/st2-packages/blob/51061cc6456c3926e747b14cf1ecebb22842f4dd/.circle/packagecloud.sh#L211-L224), so let's do it now to know if it's stable enough.