### PR TITLE
Fix PackageCloud revision increment bug [ci skip]

### DIFF
--- a/.circle/packagecloud.sh
+++ b/.circle/packagecloud.sh
@@ -217,7 +217,7 @@ function get_revision() {
   versions_url=$(get_versions_url)
   if [[ ${versions_url} == /* ]]; then
     curl -Ss -q https://${PACKAGECLOUD_TOKEN}:@packagecloud.io${versions_url} |
-      jq -r "[.[] | select(.version == \"${PKG_VERSION}\") | .release] | max"
+      jq -r "[.[] | select(.version == \"${PKG_VERSION}\") | .release | tonumber] | max"
   fi
 }
 


### PR DESCRIPTION
> Get `max` from the array of numbers, rather then array of strings.

The bug resulted in wrong revision discovery, catched when `st2mistral` reached number `10`.

```sh
Using https://packagecloud.io with token:******a7e9
Looking for repository at stackstorm/staging-stable... success!
Pushing /home/ubuntu/packages/wheezy/st2mistral_1.3.2-10_amd64.deb... error:

	filename: has already been taken
```

We use [`jq`](https://stedolan.github.io/jq/manual/) tool in bash to process JSON output from PackageCloud API and discover latest revision number for package to increment.
