### PR TITLE
RFR - Bootstrap script fixes

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -44,13 +44,14 @@ configure_ssh_and_sudo () {
 	#sudo cp ${KEY_LOCATION}/stanley_rsa.pub /home/stanley/.ssh/stanley_rsa.pub
 
 	# Authorize key-base acces
-	sudo cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys
+	sudo cat /home/stanley/.ssh/stanley_rsa.pub | sudo tee -a /home/stanley/.ssh/authorized_keys
 	sudo chmod 0600 /home/stanley/.ssh/authorized_keys
 	sudo chmod 0700 /home/stanley/.ssh
 	sudo chown -R stanley:stanley /home/stanley
 
 	# Enable passwordless sudo
-	sudo echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2
+	sudo echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" | sudo tee -a /etc/sudoers.d/st2
+    sudo chmod 0440 /etc/sudoers.d/st2
 
 	##### NOTE STILL NEED ADJUST CONFIGURATION FOR ST2 USER SECTION #####
 }

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -35,13 +35,13 @@ configure_st2_user () {
   #sudo cp ${KEY_LOCATION}/stanley_rsa.pub /home/stanley/.ssh/stanley_rsa.pub
 
   # Authorize key-base acces
-  sudo cat /home/stanley/.ssh/stanley_rsa.pub | sudo tee -a /home/stanley/.ssh/authorized_keys
+  sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
   sudo chmod 0600 /home/stanley/.ssh/authorized_keys
   sudo chmod 0700 /home/stanley/.ssh
   sudo chown -R stanley:stanley /home/stanley
 
   # Enable passwordless sudo
-  sudo echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" | sudo tee -a /etc/sudoers.d/st2
+  sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
   sudo chmod 0440 /etc/sudoers.d/st2
 
   ##### NOTE STILL NEED ADJUST CONFIGURATION FOR ST2 USER SECTION #####

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -1,61 +1,63 @@
 #!/bin/bash
 
+set -e
+
 fail() {
-    echo "############### ERROR ###############"
-    echo "# Failed on $1 #"
-    echo "#####################################"
-    exit 2
+  echo "############### ERROR ###############"
+  echo "# Failed on $1 #"
+  echo "#####################################"
+  exit 2
 }
 
 install_st2_dependencies() {
-    sudo apt-get update
-    sudo apt-get install -y curl mongodb-server rabbitmq-server
+  sudo apt-get update
+  sudo apt-get install -y curl mongodb-server rabbitmq-server
 }
 
 install_st2() {
-    # Following script adds a repo file, registers gpg key and runs apt-get update
-    curl -s https://packagecloud.io/install/repositories/StackStorm/staging-stable/script.deb.sh | sudo bash
-    sudo apt-get install -y st2
-    sudo st2ctl reload
-    sudo st2ctl start
+  # Following script adds a repo file, registers gpg key and runs apt-get update
+  curl -s https://packagecloud.io/install/repositories/StackStorm/staging-stable/script.deb.sh | sudo bash
+  sudo apt-get install -y st2
+  sudo st2ctl reload
+  sudo st2ctl start
 }
 
 configure_st2_user () {
 
-    # Create an SSH system user
-    sudo useradd stanley
-    sudo mkdir -p /home/stanley/.ssh
+  # Create an SSH system user
+  sudo useradd stanley
+  sudo mkdir -p /home/stanley/.ssh
 
-    # Generate ssh keys on StackStorm box and copy over public key into remote box.
-    sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
-    #sudo cp ${KEY_LOCATION}/stanley_rsa.pub /home/stanley/.ssh/stanley_rsa.pub
+  # Generate ssh keys on StackStorm box and copy over public key into remote box.
+  sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
+  #sudo cp ${KEY_LOCATION}/stanley_rsa.pub /home/stanley/.ssh/stanley_rsa.pub
 
-    # Authorize key-base acces
-    sudo cat /home/stanley/.ssh/stanley_rsa.pub | sudo tee -a /home/stanley/.ssh/authorized_keys
-    sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-    sudo chmod 0700 /home/stanley/.ssh
-    sudo chown -R stanley:stanley /home/stanley
+  # Authorize key-base acces
+  sudo cat /home/stanley/.ssh/stanley_rsa.pub | sudo tee -a /home/stanley/.ssh/authorized_keys
+  sudo chmod 0600 /home/stanley/.ssh/authorized_keys
+  sudo chmod 0700 /home/stanley/.ssh
+  sudo chown -R stanley:stanley /home/stanley
 
-    # Enable passwordless sudo
-    sudo echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" | sudo tee -a /etc/sudoers.d/st2
-    sudo chmod 0440 /etc/sudoers.d/st2
+  # Enable passwordless sudo
+  sudo echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" | sudo tee -a /etc/sudoers.d/st2
+  sudo chmod 0440 /etc/sudoers.d/st2
 
-    ##### NOTE STILL NEED ADJUST CONFIGURATION FOR ST2 USER SECTION #####
+  ##### NOTE STILL NEED ADJUST CONFIGURATION FOR ST2 USER SECTION #####
 }
 
 configure_st2_authentication() {
-    # Install htpasswd and tool for editing ini files
-    sudo apt-get install -y apache2-utils crudini
+  # Install htpasswd and tool for editing ini files
+  sudo apt-get install -y apache2-utils crudini
 
-    # Create a user record in a password file.
-    sudo echo "Ch@ngeMe" | sudo htpasswd -i /etc/st2/htpasswd test
+  # Create a user record in a password file.
+  sudo echo "Ch@ngeMe" | sudo htpasswd -i /etc/st2/htpasswd test
 
-    # Configure [auth] section in st2.conf
-    sudo crudini --set /etc/st2/st2.conf auth enable 'True'
-    sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
-    sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
+  # Configure [auth] section in st2.conf
+  sudo crudini --set /etc/st2/st2.conf auth enable 'True'
+  sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
+  sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
 
-    sudo st2ctl restart-component st2api
+  sudo st2ctl restart-component st2api
 }
 
 install_st2mistral_depdendencies() {
@@ -78,22 +80,22 @@ install_st2mistral() {
 }
 
 install_st2web() {
-    # Install st2web and nginx
-    sudo apt-get install -y st2web nginx
+  # Install st2web and nginx
+  sudo apt-get install -y st2web nginx
 
-    # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
-    sudo mkdir -p /etc/ssl/st2
-    sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
-    -days XXX -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information \
-    Technology/CN=$(hostname)"
+  # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
+  sudo mkdir -p /etc/ssl/st2
+  sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
+  -days XXX -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information \
+  Technology/CN=$(hostname)"
 
-    # Remove default site, if present
-    sudo rm /etc/nginx/sites-enabled/default
-    # Copy and enable StackStorm's supplied config file
-    sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/sites-available/
-    sudo ln -s /etc/nginx/sites-available/st2.conf /etc/nginx/sites-enabled/st2.conf
+  # Remove default site, if present
+  sudo rm /etc/nginx/sites-enabled/default
+  # Copy and enable StackStorm's supplied config file
+  sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/sites-available/
+  sudo ln -s /etc/nginx/sites-available/st2.conf /etc/nginx/sites-enabled/st2.conf
 
-    sudo service nginx restart
+  sudo service nginx restart
 }
 
 verify_st2() {
@@ -121,30 +123,30 @@ verify_st2() {
 }
 
 ok_message() {
-    ST2_IP=`ifconfig | grep 'inet addr' | awk '{print $2 }' | awk 'BEGIN {FS=":"}; {print $2}' | head -n 1`
+  ST2_IP=`ifconfig | grep 'inet addr' | awk '{print $2 }' | awk 'BEGIN {FS=":"}; {print $2}' | head -n 1`
 
-    echo ""
-    echo ""
-    echo "███████╗████████╗██████╗      ██████╗ ██╗  ██╗";
-    echo "██╔════╝╚══██╔══╝╚════██╗    ██╔═══██╗██║ ██╔╝";
-    echo "███████╗   ██║    █████╔╝    ██║   ██║█████╔╝ ";
-    echo "╚════██║   ██║   ██╔═══╝     ██║   ██║██╔═██╗ ";
-    echo "███████║   ██║   ███████╗    ╚██████╔╝██║  ██╗";
-    echo "╚══════╝   ╚═╝   ╚══════╝     ╚═════╝ ╚═╝  ╚═╝";
-    echo ""
-    echo "  st2 is installed and ready to use."
-    echo ""
-    echo "Head to https://${ST2_IP} to access the WebUI"
-    echo ""
-    echo "Don't forget to dive into our documentation! Here are some resources"
-    echo "for you:"
-    echo ""
-    echo "* Documentation  - https://docs.stackstorm.com"
-    echo "* Knowledge Base - https://stackstorm.reamaze.com"
-    echo ""
-    echo "Thanks for installing StackStorm! Come visit us in our Slack Channel"
-    echo "and tell us how it's going. We'd love to hear from you!"
-    echo "http://stackstorm.com/community-signup"
+  echo ""
+  echo ""
+  echo "███████╗████████╗██████╗      ██████╗ ██╗  ██╗";
+  echo "██╔════╝╚══██╔══╝╚════██╗    ██╔═══██╗██║ ██╔╝";
+  echo "███████╗   ██║    █████╔╝    ██║   ██║█████╔╝ ";
+  echo "╚════██║   ██║   ██╔═══╝     ██║   ██║██╔═██╗ ";
+  echo "███████║   ██║   ███████╗    ╚██████╔╝██║  ██╗";
+  echo "╚══════╝   ╚═╝   ╚══════╝     ╚═════╝ ╚═╝  ╚═╝";
+  echo ""
+  echo "  st2 is installed and ready to use."
+  echo ""
+  echo "Head to https://${ST2_IP} to access the WebUI"
+  echo ""
+  echo "Don't forget to dive into our documentation! Here are some resources"
+  echo "for you:"
+  echo ""
+  echo "* Documentation  - https://docs.stackstorm.com"
+  echo "* Knowledge Base - https://stackstorm.reamaze.com"
+  echo ""
+  echo "Thanks for installing StackStorm! Come visit us in our Slack Channel"
+  echo "and tell us how it's going. We'd love to hear from you!"
+  echo "http://stackstorm.com/community-signup"
 }
 
 ## Let's do this!

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -1,91 +1,123 @@
 #!/bin/bash
 
 fail() {
-	echo "############### ERROR ###############"
-	echo "# Failed on $1 #"
-	echo "#####################################"
-	exit 2
+    echo "############### ERROR ###############"
+    echo "# Failed on $1 #"
+    echo "#####################################"
+    exit 2
 }
 
-install_dependencies() {
-	sudo apt-get update
-	sudo apt-get install -y curl mongodb-server rabbitmq-server postgresql
+install_st2_dependencies() {
+    sudo apt-get update
+    sudo apt-get install -y curl mongodb-server rabbitmq-server
 }
 
-setup_repositories() {
+install_st2() {
     # Following script adds a repo file, registers gpg key and runs apt-get update
     curl -s https://packagecloud.io/install/repositories/StackStorm/staging-stable/script.deb.sh | sudo bash
+    sudo apt-get install -y st2
+    sudo st2ctl reload
+    sudo st2ctl start
 }
 
-install_stackstorm_components() {
-	sudo apt-get install -y st2 st2mistral
+configure_st2_user () {
+
+    # Create an SSH system user
+    sudo useradd stanley
+    sudo mkdir -p /home/stanley/.ssh
+
+    # Generate ssh keys on StackStorm box and copy over public key into remote box.
+    sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
+    #sudo cp ${KEY_LOCATION}/stanley_rsa.pub /home/stanley/.ssh/stanley_rsa.pub
+
+    # Authorize key-base acces
+    sudo cat /home/stanley/.ssh/stanley_rsa.pub | sudo tee -a /home/stanley/.ssh/authorized_keys
+    sudo chmod 0600 /home/stanley/.ssh/authorized_keys
+    sudo chmod 0700 /home/stanley/.ssh
+    sudo chown -R stanley:stanley /home/stanley
+
+    # Enable passwordless sudo
+    sudo echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" | sudo tee -a /etc/sudoers.d/st2
+    sudo chmod 0440 /etc/sudoers.d/st2
+
+    ##### NOTE STILL NEED ADJUST CONFIGURATION FOR ST2 USER SECTION #####
 }
 
-setup_mistral_database() {
-	cat << EHD | sudo -u postgres psql
+configure_st2_authentication() {
+    # Install htpasswd and tool for editing ini files
+    sudo apt-get install -y apache2-utils crudini
+
+    # Create a user record in a password file.
+    sudo echo "Ch@ngeMe" | sudo htpasswd -i /etc/st2/htpasswd test
+
+    # Configure [auth] section in st2.conf
+    sudo crudini --set /etc/st2/st2.conf auth enable 'True'
+    sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
+    sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
+
+    sudo st2ctl restart-component st2api
+}
+
+install_st2mistral_depdendencies() {
+  sudo apt-get install -y postgresql
+
+  cat << EHD | sudo -u postgres psql
 CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD 'StackStorm';
 CREATE DATABASE mistral OWNER mistral;
 EHD
-
-	# Setup Mistral DB tables, etc.
-	/opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
-	# Register mistral actions
-	/opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
 }
 
-configure_ssh_and_sudo () {
+install_st2mistral() {
+  # install mistral
+  sudo apt-get install -y st2mistral
 
-	# Create an SSH system user
-	sudo useradd stanley
-	sudo mkdir -p /home/stanley/.ssh
-
-	# Generate ssh keys on StackStorm box and copy over public key into remote box.
-	sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
-	#sudo cp ${KEY_LOCATION}/stanley_rsa.pub /home/stanley/.ssh/stanley_rsa.pub
-
-	# Authorize key-base acces
-	sudo cat /home/stanley/.ssh/stanley_rsa.pub | sudo tee -a /home/stanley/.ssh/authorized_keys
-	sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-	sudo chmod 0700 /home/stanley/.ssh
-	sudo chown -R stanley:stanley /home/stanley
-
-	# Enable passwordless sudo
-	sudo echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" | sudo tee -a /etc/sudoers.d/st2
-    sudo chmod 0440 /etc/sudoers.d/st2
-
-	##### NOTE STILL NEED ADJUST CONFIGURATION FOR ST2 USER SECTION #####
+  # Setup Mistral DB tables, etc.
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
+  # Register mistral actions
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
 }
 
-use_st2ctl() {
-	sudo st2ctl $1
+install_st2web() {
+    # Install st2web and nginx
+    sudo apt-get install -y st2web nginx
+
+    # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
+    sudo mkdir -p /etc/ssl/st2
+    sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
+    -days XXX -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information \
+    Technology/CN=$(hostname)"
+
+    # Remove default site, if present
+    sudo rm /etc/nginx/sites-enabled/default
+    # Copy and enable StackStorm's supplied config file
+    sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/sites-available/
+    sudo ln -s /etc/nginx/sites-available/st2.conf /etc/nginx/sites-enabled/st2.conf
+
+    sudo service nginx restart
 }
 
-configure_authentication() {
-	sed -i '/^\[auth\]$/,/^\[/ s/^enable = False/enable = True/' /etc/st2/st2.conf
-	# Install htpasswd utility if you don't have it
-	sudo apt-get install -y apache2-utils
-	# Create a user record in a password file.
-	sudo echo "Ch@ngeMe" | sudo htpasswd -i /etc/st2/htpasswd test
+verify_st2() {
+  st2 --version
+  st2 -h
 
-}
+  st2 auth test -p Ch@ngeMe
+  # A shortcut to authenticate and export the token
+  export ST2_AUTH_TOKEN=$(st2 auth test -p Ch@ngeMe -t)
 
-install_webui_and_setup_ssl_termination() {
-	# Install st2web and nginx
-	sudo apt-get install -y st2web nginx
+  # List the actions from a 'core' pack
+  st2 action list --pack=core
 
-	# Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
-	sudo mkdir -p /etc/ssl/st2
-	sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
-	-days XXX -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information \
-	Technology/CN=$(hostname)"
+  # Run a local shell command
+  st2 run core.local -- date -R
 
-	# Remove default site, if present
-	sudo rm /etc/nginx/sites-enabled/default
-	# Copy and enable StackStorm's supplied config file
-	sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/sites-available/
-	sudo ln -s /etc/nginx/sites-available/st2.conf /etc/nginx/sites-enabled/st2.conf
+  # See the execution results
+  st2 execution list
 
-	sudo service nginx restart
+  # Fire a remote comand via SSH (Requires passwordless SSH)
+  st2 run core.remote hosts='127.0.0.1' -- uname -a
+
+  # Install a pack
+  st2 run packs.install packs=st2
 }
 
 ok_message() {
@@ -115,32 +147,17 @@ ok_message() {
     echo "http://stackstorm.com/community-signup"
 }
 
-verify() {
-
-	st2 auth test -p Ch@ngeMe || fail "st2 auth test"
-	# A shortcut to authenticate and export the token
-	export ST2_AUTH_TOKEN=$(st2 auth test -p Ch@ngeMe -t)
-
-	st2 --version || fail "st2 --version"
-	st2 -h || fail "st2 -h"
-	st2 action list --pack=core || fail "st2 action list"
-	st2 run core.local -- date -R || fail "st2 run core.local -- date -R"
-	st2 execution list || fail "st2 execution list"
-	st2 run core.remote hosts='127.0.0.1' -- uname -a || fail "st2 run core.remote hosts='127.0.0.1' -- uname -a"
-	st2 run packs.install packs=st2 || fail "st2 run packs.install packs=st2"
-    ok_message
-
-}
-
 ## Let's do this!
 
-install_dependencies || fail "install_dependencies"
-setup_repositories || fail "setup_repositories"
-install_stackstorm_components || fail "install_stackstorm_components"
-setup_mistral_database || fail "setup_mistral_database"
-configure_ssh_and_sudo || fail "configure_ss_and_sudo"
-configure_authentication || fail "configure_authentication"
-install_webui_and_setup_ssl_termination || fail "install_webui_and_setup_ssl_termination"
-use_st2ctl start || fail "use_st2ctl start"
-use_st2ctl reload || fail "use_st2ctl reload"
-verify
+install_st2_dependencies || fail "install_st2_dependencies"
+install_st2 || fail "install_st2"
+configure_st2_user || fail "configure_st2_user"
+configure_st2_authentication || fail "configure_st2_authentication"
+verify_st2 || fail "verify_st2"
+
+install_st2mistral_depdendencies || fail "install_st2mistral_depdendencies"
+install_st2mistral || fail "install_st2mistral"
+
+install_st2web || fail "install_st2web"
+
+ok_message

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -23,9 +23,11 @@ install_st2() {
 }
 
 configure_st2_user () {
+  # Create an SSH system user (default `stanley` user may be already created)
+  if (! id stanley 2>/dev/null); then
+    sudo useradd stanley
+  fi
 
-  # Create an SSH system user
-  sudo useradd stanley
   sudo mkdir -p /home/stanley/.ssh
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
@@ -123,8 +125,6 @@ verify_st2() {
 }
 
 ok_message() {
-  ST2_IP=`ifconfig | grep 'inet addr' | awk '{print $2 }' | awk 'BEGIN {FS=":"}; {print $2}' | head -n 1`
-
   echo ""
   echo ""
   echo "███████╗████████╗██████╗      ██████╗ ██╗  ██╗";
@@ -136,7 +136,7 @@ ok_message() {
   echo ""
   echo "  st2 is installed and ready to use."
   echo ""
-  echo "Head to https://${ST2_IP} to access the WebUI"
+  echo "Head to https://YOUR_HOST_IP/ to access the WebUI"
   echo ""
   echo "Don't forget to dive into our documentation! Here are some resources"
   echo "for you:"

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-set -e
+set -eu
 
 fail() {
   echo "############### ERROR ###############"
-  echo "# Failed on $1 #"
+  echo "# Failed on step - $STEP #"
   echo "#####################################"
   exit 2
 }
@@ -151,15 +151,17 @@ ok_message() {
 
 ## Let's do this!
 
-install_st2_dependencies || fail "install_st2_dependencies"
-install_st2 || fail "install_st2"
-configure_st2_user || fail "configure_st2_user"
-configure_st2_authentication || fail "configure_st2_authentication"
-verify_st2 || fail "verify_st2"
+trap 'fail' EXIT
+STEP="Install st2 dependencies" && install_st2_dependencies
+STEP="Install st2" && install_st2
+STEP="Configure st2 user" && configure_st2_user
+STEP="Configure st2 auth" && configure_st2_authentication
+STEP="Verify st2" && verify_st2
 
-install_st2mistral_depdendencies || fail "install_st2mistral_depdendencies"
-install_st2mistral || fail "install_st2mistral"
+STEP="Install mistral dependencies" && install_st2mistral_depdendencies
+STEP="Install mistral" && install_st2mistral
 
-install_st2web || fail "install_st2web"
+STEP="Install st2web" && install_st2web
+trap - EXIT
 
 ok_message

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -9,7 +9,7 @@ fail() {
 
 install_dependencies() {
 	sudo apt-get update
-	sudo apt-get install -y mongodb-server rabbitmq-server postgresql
+	sudo apt-get install -y curl mongodb-server rabbitmq-server postgresql
 }
 
 setup_repositories() {

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -30,6 +30,8 @@ install_st2_dependencies() {
   sudo yum -y install curl mongodb-server rabbitmq-server
   sudo service mongod start
   sudo service rabbitmq-server start
+  sudo chkconfig mongod on
+  sudo chkconfig rabbitmq-server on
 }
 
 install_st2() {
@@ -116,6 +118,7 @@ install_st2mistral_depdendencies() {
 
   # Start PostgreSQL service
   sudo service postgresql-9.4 start
+  sudo chkconfig postgresql-9.4 on
 
   cat << EHD | sudo -u postgres psql
 CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD 'StackStorm';
@@ -153,6 +156,7 @@ install_st2web() {
   sudo sed -i 's/default_server//g' /etc/nginx/conf.d/default.conf
 
   sudo service nginx start
+  sudo chkconfig nginx on
 }
 
 ok_message() {

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eu
 
 # Note that default SELINUX policies for RHEL7 differ with CentOS7. CentOS7 is more permissive by default
 # Note that depending on distro assembly/settings you may need more rules to change
@@ -20,7 +20,7 @@ adjust_selinux_policies() {
 
 fail() {
   echo "############### ERROR ###############"
-  echo "# Failed on $1 #"
+  echo "# Failed on $STEP #"
   echo "#####################################"
   exit 2
 }
@@ -180,18 +180,19 @@ ok_message() {
   echo "http://stackstorm.com/community-signup"
 }
 
+trap 'fail' EXIT
+STEP='adjust_selinux_policies' && adjust_selinux_policies
 
-adjust_selinux_policies || fail "adjust_selinux_policies"
+STEP="Install st2 dependencies" && install_st2_dependencies
+STEP="Install st2" && install_st2
+STEP="Configure st2 user" && configure_st2_user
+STEP="Configure st2 auth" && configure_st2_authentication
+STEP="Verify st2" && verify_st2
 
-install_st2_dependencies || fail "install_st2_dependencies"
-install_st2 || fail "install_st2"
-configure_st2_user || fail "configure_st2_user"
-configure_st2_authentication || fail "configure_st2_authentication"
-verify_st2 || fail "verify_st2"
+STEP="Install mistral dependencies" && install_st2mistral_depdendencies
+STEP="Install mistral" && install_st2mistral
 
-install_st2mistral_depdendencies || fail "install_st2mistral_depdendencies"
-install_st2mistral || fail "install_st2mistral"
-
-install_st2web || fail "install_st2web"
+STEP="Install st2web" && install_st2web
+trap - EXIT
 
 ok_message

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -156,28 +156,28 @@ install_st2web() {
 }
 
 ok_message() {
-    echo ""
-    echo ""
-    echo "███████╗████████╗██████╗      ██████╗ ██╗  ██╗";
-    echo "██╔════╝╚══██╔══╝╚════██╗    ██╔═══██╗██║ ██╔╝";
-    echo "███████╗   ██║    █████╔╝    ██║   ██║█████╔╝ ";
-    echo "╚════██║   ██║   ██╔═══╝     ██║   ██║██╔═██╗ ";
-    echo "███████║   ██║   ███████╗    ╚██████╔╝██║  ██╗";
-    echo "╚══════╝   ╚═╝   ╚══════╝     ╚═════╝ ╚═╝  ╚═╝";
-    echo ""
-    echo "  st2 is installed and ready to use."
-    echo ""
-    echo "Head to https://YOUR_HOST_IP/ to access the WebUI"
-    echo ""
-    echo "Don't forget to dive into our documentation! Here are some resources"
-    echo "for you:"
-    echo ""
-    echo "* Documentation  - https://docs.stackstorm.com"
-    echo "* Knowledge Base - https://stackstorm.reamaze.com"
-    echo ""
-    echo "Thanks for installing StackStorm! Come visit us in our Slack Channel"
-    echo "and tell us how it's going. We'd love to hear from you!"
-    echo "http://stackstorm.com/community-signup"
+  echo ""
+  echo ""
+  echo "███████╗████████╗██████╗      ██████╗ ██╗  ██╗";
+  echo "██╔════╝╚══██╔══╝╚════██╗    ██╔═══██╗██║ ██╔╝";
+  echo "███████╗   ██║    █████╔╝    ██║   ██║█████╔╝ ";
+  echo "╚════██║   ██║   ██╔═══╝     ██║   ██║██╔═██╗ ";
+  echo "███████║   ██║   ███████╗    ╚██████╔╝██║  ██╗";
+  echo "╚══════╝   ╚═╝   ╚══════╝     ╚═════╝ ╚═╝  ╚═╝";
+  echo ""
+  echo "  st2 is installed and ready to use."
+  echo ""
+  echo "Head to https://YOUR_HOST_IP/ to access the WebUI"
+  echo ""
+  echo "Don't forget to dive into our documentation! Here are some resources"
+  echo "for you:"
+  echo ""
+  echo "* Documentation  - https://docs.stackstorm.com"
+  echo "* Knowledge Base - https://stackstorm.reamaze.com"
+  echo ""
+  echo "Thanks for installing StackStorm! Come visit us in our Slack Channel"
+  echo "and tell us how it's going. We'd love to hear from you!"
+  echo "http://stackstorm.com/community-signup"
 }
 
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+
+set -e
+
+# Note that default SELINUX policies for RHEL7 differ with CentOS7. CentOS7 is more permissive by default
+# Note that depending on distro assembly/settings you may need more rules to change
+# Apply these changes OR disable selinux in /etc/selinux/config (manually)
+adjust_selinux_policies() {
+  if getenforce | grep -q 'Enforcing'; then
+    # SELINUX management tools, not available for some minimal installations
+    sudo yum install -y policycoreutils-python
+
+    # Allow rabbitmq to use '25672' port, otherwise it will fail to start
+    sudo semanage port --list | grep -q 25672 || sudo semanage port -a -t amqp_port_t -p tcp 25672
+
+    # Allow network access for nginx
+    sudo setsebool -P httpd_can_network_connect 1
+  fi
+}
+
+fail() {
+  echo "############### ERROR ###############"
+  echo "# Failed on $1 #"
+  echo "#####################################"
+  exit 2
+}
+
+install_st2_dependencies() {
+  sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+  sudo yum -y install curl mongodb-server rabbitmq-server
+  sudo service mongod start
+  sudo service rabbitmq-server start
+}
+
+install_st2() {
+  curl -s https://packagecloud.io/install/repositories/StackStorm/staging-stable/script.rpm.sh | sudo bash
+  sudo yum -y install st2
+  sudo st2ctl reload
+  sudo st2ctl start
+}
+
+configure_st2_user() {
+  # Create an SSH system user (default `stanley` user may be already created)
+  if (! id stanley 2>/dev/null); then
+    sudo useradd stanley
+  fi
+
+  sudo mkdir -p /home/stanley/.ssh
+  sudo chmod 0700 /home/stanley/.ssh
+
+  # On StackStorm host, generate ssh keys
+  sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
+
+  # Authorize key-base acces
+  sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
+  sudo chmod 0600 /home/stanley/.ssh/authorized_keys
+  sudo chown -R stanley:stanley /home/stanley
+
+  # Enable passwordless sudo
+  sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
+  sudo chmod 0440 /etc/sudoers.d/st2
+
+  # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
+  sudo sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
+}
+
+configure_st2_authentication() {
+  # Install htpasswd and tool for editing ini files
+  sudo yum -y install httpd-tools crudini
+
+  # Create a user record in a password file.
+  sudo htpasswd -bs /etc/st2/htpasswd test Ch@ngeMe
+
+  # Configure [auth] section in st2.conf
+  sudo crudini --set /etc/st2/st2.conf auth enable 'True'
+  sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
+  sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
+
+  sudo st2ctl restart-component st2api
+}
+
+verify_st2() {
+  st2 --version
+  st2 -h
+
+  st2 auth test -p Ch@ngeMe
+  # A shortcut to authenticate and export the token
+  export ST2_AUTH_TOKEN=$(st2 auth test -p Ch@ngeMe -t)
+
+  # List the actions from a 'core' pack
+  st2 action list --pack=core
+
+  # Run a local shell command
+  st2 run core.local -- date -R
+
+  # See the execution results
+  st2 execution list
+
+  # Fire a remote comand via SSH (Requires passwordless SSH)
+  st2 run core.remote hosts='127.0.0.1' -- uname -a
+
+  # Install a pack
+  st2 run packs.install packs=st2
+}
+
+install_st2mistral_depdendencies() {
+  sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpm
+  sudo yum -y install postgresql94-server postgresql94-contrib postgresql94-devel
+
+  # Setup postgresql at a first time
+  sudo service postgresql-9.4 initdb
+
+  # Make localhost connections to use an MD5-encrypted password for authentication
+  sudo sed -i "s/\(host.*all.*all.*127.0.0.1\/32.*\)ident/\1md5/" /var/lib/pgsql/9.4/data/pg_hba.conf
+  sudo sed -i "s/\(host.*all.*all.*::1\/128.*\)ident/\1md5/" /var/lib/pgsql/9.4/data/pg_hba.conf
+
+  # Start PostgreSQL service
+  sudo service postgresql-9.4 start
+
+  cat << EHD | sudo -u postgres psql
+CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD 'StackStorm';
+CREATE DATABASE mistral OWNER mistral;
+EHD
+}
+
+install_st2mistral() {
+  # install mistral
+  sudo yum -y install st2mistral
+
+  # Setup Mistral DB tables, etc.
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
+  # Register mistral actions
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+
+  # start mistral
+  sudo service mistral start
+}
+
+install_st2web() {
+  # Install st2web and nginx
+  sudo yum install -y st2web nginx
+
+  # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
+  sudo mkdir -p /etc/ssl/st2
+
+  sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
+  -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information Technology/CN=$(hostname)"
+
+  # Copy and enable StackStorm's supplied config file
+  sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/
+
+  # Disable default_server configuration in existing /etc/nginx/conf.d/default.conf
+  sudo sed -i 's/default_server//g' /etc/nginx/conf.d/default.conf
+
+  sudo service nginx start
+}
+
+ok_message() {
+    echo ""
+    echo ""
+    echo "███████╗████████╗██████╗      ██████╗ ██╗  ██╗";
+    echo "██╔════╝╚══██╔══╝╚════██╗    ██╔═══██╗██║ ██╔╝";
+    echo "███████╗   ██║    █████╔╝    ██║   ██║█████╔╝ ";
+    echo "╚════██║   ██║   ██╔═══╝     ██║   ██║██╔═██╗ ";
+    echo "███████║   ██║   ███████╗    ╚██████╔╝██║  ██╗";
+    echo "╚══════╝   ╚═╝   ╚══════╝     ╚═════╝ ╚═╝  ╚═╝";
+    echo ""
+    echo "  st2 is installed and ready to use."
+    echo ""
+    echo "Head to https://YOUR_HOST_IP/ to access the WebUI"
+    echo ""
+    echo "Don't forget to dive into our documentation! Here are some resources"
+    echo "for you:"
+    echo ""
+    echo "* Documentation  - https://docs.stackstorm.com"
+    echo "* Knowledge Base - https://stackstorm.reamaze.com"
+    echo ""
+    echo "Thanks for installing StackStorm! Come visit us in our Slack Channel"
+    echo "and tell us how it's going. We'd love to hear from you!"
+    echo "http://stackstorm.com/community-signup"
+}
+
+
+adjust_selinux_policies || fail "adjust_selinux_policies"
+
+install_st2_dependencies || fail "install_st2_dependencies"
+install_st2 || fail "install_st2"
+configure_st2_user || fail "configure_st2_user"
+configure_st2_authentication || fail "configure_st2_authentication"
+verify_st2 || fail "verify_st2"
+
+install_st2mistral_depdendencies || fail "install_st2mistral_depdendencies"
+install_st2mistral || fail "install_st2mistral"
+
+install_st2web || fail "install_st2web"
+
+ok_message

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -29,6 +29,7 @@ install_st2_dependencies() {
   sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   sudo yum -y install curl mongodb-server rabbitmq-server
   sudo systemctl start mongod rabbitmq-server
+  sudo systemctl enable mongod rabbitmq-server
 }
 
 install_st2() {
@@ -114,6 +115,7 @@ install_st2mistral_depdendencies() {
 
   # Start PostgreSQL service
   sudo systemctl start postgresql
+  sudo systemctl enable postgresql
 
   cat << EHD | sudo -u postgres psql
 CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD 'StackStorm';
@@ -151,6 +153,7 @@ install_st2web() {
   sudo sed -i 's/default_server//g' /etc/nginx/nginx.conf
 
   sudo systemctl restart nginx
+  sudo systemctl enable nginx
 }
 
 ok_message() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -154,28 +154,28 @@ install_st2web() {
 }
 
 ok_message() {
-    echo ""
-    echo ""
-    echo "███████╗████████╗██████╗      ██████╗ ██╗  ██╗";
-    echo "██╔════╝╚══██╔══╝╚════██╗    ██╔═══██╗██║ ██╔╝";
-    echo "███████╗   ██║    █████╔╝    ██║   ██║█████╔╝ ";
-    echo "╚════██║   ██║   ██╔═══╝     ██║   ██║██╔═██╗ ";
-    echo "███████║   ██║   ███████╗    ╚██████╔╝██║  ██╗";
-    echo "╚══════╝   ╚═╝   ╚══════╝     ╚═════╝ ╚═╝  ╚═╝";
-    echo ""
-    echo "  st2 is installed and ready to use."
-    echo ""
-    echo "Head to https://YOUR_HOST_IP/ to access the WebUI"
-    echo ""
-    echo "Don't forget to dive into our documentation! Here are some resources"
-    echo "for you:"
-    echo ""
-    echo "* Documentation  - https://docs.stackstorm.com"
-    echo "* Knowledge Base - https://stackstorm.reamaze.com"
-    echo ""
-    echo "Thanks for installing StackStorm! Come visit us in our Slack Channel"
-    echo "and tell us how it's going. We'd love to hear from you!"
-    echo "http://stackstorm.com/community-signup"
+  echo ""
+  echo ""
+  echo "███████╗████████╗██████╗      ██████╗ ██╗  ██╗";
+  echo "██╔════╝╚══██╔══╝╚════██╗    ██╔═══██╗██║ ██╔╝";
+  echo "███████╗   ██║    █████╔╝    ██║   ██║█████╔╝ ";
+  echo "╚════██║   ██║   ██╔═══╝     ██║   ██║██╔═██╗ ";
+  echo "███████║   ██║   ███████╗    ╚██████╔╝██║  ██╗";
+  echo "╚══════╝   ╚═╝   ╚══════╝     ╚═════╝ ╚═╝  ╚═╝";
+  echo ""
+  echo "  st2 is installed and ready to use."
+  echo ""
+  echo "Head to https://YOUR_HOST_IP/ to access the WebUI"
+  echo ""
+  echo "Don't forget to dive into our documentation! Here are some resources"
+  echo "for you:"
+  echo ""
+  echo "* Documentation  - https://docs.stackstorm.com"
+  echo "* Knowledge Base - https://stackstorm.reamaze.com"
+  echo ""
+  echo "Thanks for installing StackStorm! Come visit us in our Slack Channel"
+  echo "and tell us how it's going. We'd love to hear from you!"
+  echo "http://stackstorm.com/community-signup"
 }
 
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -26,7 +26,10 @@ fail() {
 }
 
 install_st2_dependencies() {
-  sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+  is_epel_installed=$(rpm -qa | grep epel-release || true)
+  if [[ -z "$is_epel_installed" ]]; then
+    sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+  fi
   sudo yum -y install curl mongodb-server rabbitmq-server
   sudo systemctl start mongod rabbitmq-server
   sudo systemctl enable mongod rabbitmq-server

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eu
 
 # Note that default SELINUX policies for RHEL7 differ with CentOS7. CentOS7 is more permissive by default
 # Note that depending on distro assembly/settings you may need more rules to change
@@ -20,7 +20,7 @@ adjust_selinux_policies() {
 
 fail() {
   echo "############### ERROR ###############"
-  echo "# Failed on $1 #"
+  echo "# Failed on $STEP #"
   echo "#####################################"
   exit 2
 }
@@ -178,18 +178,19 @@ ok_message() {
   echo "http://stackstorm.com/community-signup"
 }
 
+trap 'fail' EXIT
+STEP='adjust_selinux_policies' && adjust_selinux_policies
 
-adjust_selinux_policies || fail "adjust_selinux_policies"
+STEP="Install st2 dependencies" && install_st2_dependencies
+STEP="Install st2" && install_st2
+STEP="Configure st2 user" && configure_st2_user
+STEP="Configure st2 auth" && configure_st2_authentication
+STEP="Verify st2" && verify_st2
 
-install_st2_dependencies || fail "install_st2_dependencies"
-install_st2 || fail "install_st2"
-configure_st2_user || fail "configure_st2_user"
-configure_st2_authentication || fail "configure_st2_authentication"
-verify_st2 || fail "verify_st2"
+STEP="Install mistral dependencies" && install_st2mistral_depdendencies
+STEP="Install mistral" && install_st2mistral
 
-install_st2mistral_depdendencies || fail "install_st2mistral_depdendencies"
-install_st2mistral || fail "install_st2mistral"
-
-install_st2web || fail "install_st2web"
+STEP="Install st2web" && install_st2web
+trap - EXIT
 
 ok_message


### PR DESCRIPTION
## How to test?

* git clone https://github.com/lakshmi-kannan/st2-test-ground
* HOSTNAME=pkg-test-${flavor} vagrant up ${flavor}
* Notice comment before each flavor in Vagrantfile to see if you need to do any pre-requisites for that specific box. Run those commands.
* wget https://{location_to_bootstrap_script)
* chmod +x st2bootstrap-${flavor}.sh
* ./st2bootstrap-${flavor}.sh 
* Monkey test

## TODO

* [X] Install curl -  https://github.com/StackStorm/st2-packages/issues/183
* [X] Fix ubuntu script to run as non sudo - https://github.com/StackStorm/st2-packages/issues/184
* [x] Fix ubuntu script to be similar as EL7 -   https://github.com/StackStorm/st2-packages/issues/186
* [x] Install crudini in ubuntu - https://github.com/StackStorm/st2-packages/issues/187
* [X] EL6 bootstrap script 
    1. [x] WebUI can't be accessed outside virtualbox on centos66. Figure out if firewall is blocking.
* [x] Test EL script on an actual RHEL box
     1. [x] RHEL 7 -  (RHEL-7.2_HVM_GA-20151112-x86_64-1-Hourly2-GP2 (ami-2051294a))
     2. [ ] RHEL 6  - Packages don't work on RHEL6 because of missing libffi-devel. cc: @dennybaa 
* [x] Salvage docs for EL7 from https://gist.github.com/armab/2ab4d2ccc592db422439. https://github.com/StackStorm/st2docs/pull/75/files
* [x] Salvage docs for EL6 from https://gist.github.com/lakshmi-kannan/b885a6265e1a694ae0fd.
https://github.com/StackStorm/st2docs/pull/75/files
* [x] Chatops testing on EL6/EL7
   1. [x] No docker available for EL6 unless 3.10 kernel is installed by user. 
   2. [x] Tested docker story on EL7 and validated it works. 
* [x] Reboot box testing 
   1. [X] U14
   2. [x]  RHEL6 - st2 services don't come up. Manual st2ctl start needed.
   3. [x] RHEL7 - st2 services don't come up. Manual st2ctl start needed.