### PR TITLE
RFR: Fix RHEL6 instructions 

### DIFF
--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -185,7 +185,7 @@ ok_message() {
 }
 
 trap 'fail' EXIT
-STEP='adjust_selinux_policies' && adjust_selinux_policies
+STEP='Adjust SELinux policies' && adjust_selinux_policies
 
 STEP="Install st2 dependencies" && install_st2_dependencies
 STEP="Install st2" && install_st2


### PR DESCRIPTION
## What?

* RHEL 6 doesn't ship with libffi-devel. This means st2 installation fails. The workaround is to find a version of libffi-devel from Internet that matches the version of libffi installed on the box. I don't know how to automate this part. So I made a fix in docs to address this. See https://github.com/StackStorm/st2docs/pull/76. With that I also try to install libffi-devel and if that fails, abort the script there. yum search libffi-devel breaks on AWS RHEL AMIs. So there is no option other than to install and if it fails on No package, then abort. 
Tested script on RHEL 6 and CentOS. Works. See https://gist.github.com/lakshmi-kannan/64079cea5c5092b3d00e for RHEL6. Tested on RHEL-6.7_HVM_GA-20150714-x86_64-1-Hourly2-GP2 (ami-0d28fe66)

* After fixing the libffi-devel on RHEL6, I noticed that the postgres rpm for RHEL6 is different than CentOS6. I fixed that as well. Noted the change in docs - https://github.com/StackStorm/st2docs/pull/76/files#diff-81217534b75eeb0ec51517074b44e54eR78

