### PR TITLE
Remove Bintray deployments [ci skip]

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,6 @@
 # Setup in CircleCI account the following ENV variables:
 # IS_PRODUCTION (default: 0)
 # IS_ENTERPRISE (default: 0)
-# BINTRAY_ORGANIZATION (default: stackstorm)
-# BINTRAY_ACCOUNT
-# BINTRAY_API_KEY
 # PACKAGECLOUD_ORGANIZATION (default: stackstorm)
 # PACKAGECLOUD_TOKEN
 # DOCKER_USER
@@ -76,10 +73,6 @@ deployment:
       - feature/circleci
     owner: StackStorm
     commands:
-      # Deploy to Bintray all artifacts for respective distros in parallel
-      - |
-        DISTROS=($DISTROS)
-        parallel -v -j0 --line-buffer .circle/bintray.sh deploy {}_staging ~/packages/{} ::: ${DISTROS[@]::$CIRCLE_NODE_TOTAL}
       # Deploy to PackageCloud all artifacts for respective distros in parallel
       - |
         DISTROS=($DISTROS)


### PR DESCRIPTION
Remove Bintray deployments in favor of PackageCloud

Part of: 
https://github.com/StackStorm/st2/pull/2540
https://github.com/StackStorm/st2/pull/2539