### PR TITLE
Connect to DB on localhost by default

### DIFF
--- a/packages/st2mistral/conf/mistral.conf
+++ b/packages/st2mistral/conf/mistral.conf
@@ -234,7 +234,7 @@ transport_url = rabbit://guest:guest@127.0.0.1:5672
 # Deprecated group/name - [DATABASE]/sql_connection
 # Deprecated group/name - [sql]/connection
 #connection = <None>
-connection = postgresql://mistral:StackStorm@127.0.0.1/mistral
+connection = postgresql://mistral:StackStorm@localhost/mistral
 
 # The SQLAlchemy connection string to use to connect to the slave
 # database. (string value)


### PR DESCRIPTION
By default, PostgreSQL binds on localhost and on some distros it might not always be 127.0.0.1.

In discussion with @armab we decided to make an exception from 'always use 127.0.0.1' rule for this particular case.