### PR TITLE
Tail more log lines by default on the service start failure

### DIFF
--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -38,7 +38,7 @@ class ST2Spec
     mongodbhost:  pipeopts.mongodbhost,
     # NB!!! We shouldn't change circle.yml for every branch of `st2`! Hardcode value here so it will work for all tests consistently!
     wait_for_start: ENV['ST2_WAITFORSTART'].to_s != '' ? ENV['ST2_WAITFORSTART'].to_i : 12,
-    loglines_to_show: 20,
+    loglines_to_show: 100,
     logdest_pattern: {
       st2actionrunner: 'st2actionrunner.{pid}'
     },


### PR DESCRIPTION
The title says it all.

Ideally we would also run services with `--debug` flag on start up, but that's a bit hard to do right now.