### PR TITLE
Hardcode respective version of st2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ machine:
     DISTROS: "wheezy jessie trusty el6 el7"
     NOTESTS: "el7"
     ST2_GITURL: https://github.com/StackStorm/st2
-    ST2_GITREV: $CIRCLE_BRANCH
+    ST2_GITREV: v1.3
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     BUILD_DOCKER: 0
     DEPLOY_DOCKER: 0
@@ -35,7 +35,6 @@ machine:
 
 checkout:
   post:
-    - echo $CIRCLE_BRANCH
     - .circle/buildenv.sh
 
 dependencies:


### PR DESCRIPTION
Problem here is that `$CIRCLE_BRANCH` refers to the branch name we're currently building, not the one it's going to be merged to. And we can't really predict merge branch because CircleCI runs tests for commits, not for PRs.

The need to manually edit a version in every branch we create doesn't seem to me like too big of a hassle considering we do it pretty much everywhere else, but maybe @armab would be able to find a better solution during his experiments.