### PR TITLE
Follow st2 branching (master)

### DIFF
--- a/.circle/buildenv.sh
+++ b/.circle/buildenv.sh
@@ -4,7 +4,44 @@ set -e
 distros=($DISTROS)
 DISTRO=${distros[$CIRCLE_NODE_INDEX]}
 
-fetch_version() {
+# Install dependencies
+if ! command -v jq > /dev/null 2>&1; then
+  sudo apt-get -yq install jq
+fi
+
+# Discover st2 giturl, eg. the repo we work with
+# In case of forked PR - it will use user's `st2` giturl
+get_st2_giturl() {
+  # Handle pull requests properly
+  if [ -z "$CIRCLE_PR_REPONAME" ]; then
+    echo "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+  else
+    echo "https://github.com/${CIRCLE_PR_USERNAME}/${CIRCLE_PR_REPONAME}"
+  fi
+}
+
+# Discover the st2 target branch we work with
+get_st2_gitrev() {
+  if [ -z "$CI_PULL_REQUEST" ]; then
+    TARGET_BRANCH=${CIRCLE_BRANCH}
+  else # pull request
+    TARGET_PR_ORG=$(echo ${CI_PULL_REQUEST} | awk -F/ '{print $4}')
+    TARGET_PR_REPO=$(echo ${CI_PULL_REQUEST} | awk -F/ '{print $5}')
+    TARGET_PR_NUMBER=$(echo ${CI_PULL_REQUEST} | awk -F/ '{print $7}')
+
+    # branch name user opened PR against
+    TARGET_BRANCH=$(curl -Ss -q https://api.github.com/repos/${TARGET_PR_ORG}/${TARGET_PR_REPO}/pulls/${TARGET_PR_NUMBER} | jq -r ".base.ref")
+  fi
+
+  if echo "${TARGET_BRANCH}" | grep -q '^v[0-9]\+\.[0-9]\+$'; then
+    echo "${TARGET_BRANCH}"
+  else
+    echo "master"
+  fi
+}
+
+# Discover st2 version based on st2common `__init__` file
+get_st2_version() {
   if [ -f ../st2common/st2common/__init__.py ]; then
     # Get st2 version based on hardcoded string in st2common
     # build takes place in `st2` repo
@@ -13,16 +50,6 @@ fetch_version() {
     # build takes place in `st2-packages` repo
     curl -sSL -o /tmp/st2_version.py ${ST2_GITURL}/raw/${ST2_GITREV}/st2common/st2common/__init__.py
     python -c 'execfile("/tmp/st2_version.py"); print __version__'
-  fi
-}
-
-# Needs explantion???
-st2_giturl() {
-  # Handle pull requests properly
-  if [ -z "$CIRCLE_PR_REPONAME" ]; then
-    echo "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-  else
-    echo "https://github.com/${CIRCLE_PR_USERNAME}/${CIRCLE_PR_REPONAME}"
   fi
 }
 
@@ -42,9 +69,9 @@ write_env() {
 # ST2PKG_RELEASE - Release number aka revision number for `st2` package, will be reused in Docker metadata (ex: 4)
 # ST2_WAITFORSTART - Delay between st2 start and service checks
 
-ST2_GITURL=${ST2_GITURL:-$(st2_giturl)}
-ST2_GITREV=${ST2_GITREV:-$CIRCLE_BRANCH}
-ST2PKG_VERSION=$(fetch_version)
+ST2_GITURL=${ST2_GITURL:-$(get_st2_giturl)}
+ST2_GITREV=${ST2_GITREV:-$(get_st2_gitrev)}
+ST2PKG_VERSION=$(get_st2_version)
 # for Bintray
 #ST2PKG_RELEASE=$(.circle/bintray.sh next-revision ${DISTRO}_staging ${ST2PKG_VERSION} st2)
 # for PackageCloud

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,6 @@ machine:
     DISTROS: "wheezy jessie trusty el6 el7"
     NOTESTS: "el7"
     ST2_GITURL: https://github.com/StackStorm/st2
-    ST2_GITREV: master
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     BUILD_DOCKER: 0
     DEPLOY_DOCKER: 0


### PR DESCRIPTION
Autodetect specific `st2` branch depending on `st2-packages` branch.

#### What this change brings
* pushing to `master` of `st2-packages` repo will generate packages based on `master` of `st2`
* pushing to `v1.3` of `st2-packages` repo will generate packages based on `v1.3` of `st2`
* opening PR against `master` branch of `st2-packages` repo will use `st2` `master`
* opening PR against `v1.3` branch of `st2-packages` repo will use `st2` `v1.3`
* opening PR against any other branch of `st2-packages` repo will use `st2` `master`

This autodetect works for both Pull Requests and inside `vX.Y` and `master` branches of `st2-packages` repo.

Branch autodetection for PR is based on target branch: 
> **armab**  wants to merge 1 commit into (--->)  `master` from `feature/branching`
