### PR TITLE
don't use version branch for *dev versions [ci skip]

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -65,7 +65,9 @@ setup_args() {
 setup_args $@
 
 get_version_branch() {
-  BRANCH="v$(echo ${VERSION} | awk 'BEGIN {FS="."}; {print $1 "." $2}')"
+  if [[ "$RELEASE" == 'stable' ]]; then
+      BRANCH="v$(echo ${VERSION} | awk 'BEGIN {FS="."}; {print $1 "." $2}')"
+  fi
 }
 
 if [[ "$VERSION" != '' ]]; then


### PR DESCRIPTION
Currently we try to pull the bootstrap script from the corresponding version branch even on dev.  This makes us use the master branch for dev releases.