### PR TITLE
Adding psycopg2

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -9,6 +9,7 @@ PBR_GITURL := git+https://github.com/openstack-dev/pbr@d19459daa8616dd18fde016c2
 # We use special additional requirements in our mistral bundle!
 define INJECT_DEPS
 gunicorn
+psycopg2
 git+https://github.com/StackStorm/st2mistral.git@$(GITREV)#egg=st2mistral
 git+https://github.com/StackStorm/python-mistralclient.git@$(GITREV)#egg=python-mistralclient
 $(PBR_GITURL)

--- a/packages/st2mistral/debian/rules
+++ b/packages/st2mistral/debian/rules
@@ -33,5 +33,5 @@ override_dh_installdeb:
 	dh_installdeb
 
 override_dh_virtualenv:
-	dh_virtualenv --extra-pip-arg '--find-links=$(WHEELDIR)' --preinstall psycopg2 \
+	dh_virtualenv --extra-pip-arg '--find-links=$(WHEELDIR)' \
 								--extra-pip-arg '--no-index' --install-suffix mistral --no-test

--- a/rake/build/environment.rb
+++ b/rake/build/environment.rb
@@ -79,8 +79,8 @@ end
 pipeopts 'st2mistral' do
   checkout true
   envpass :giturl,  'https://github.com/StackStorm/mistral', from: 'ST2MISTRAL_GITURL'
-  envpass :gitrev,  'st2-1.3.2',                             from: 'ST2MISTRAL_GITREV'
+  envpass :gitrev,  'master',                                from: 'ST2MISTRAL_GITREV'
   envpass :gitdir,  make_tmpname('mistral-')
-  envpass :mistral_version, '1.3.2'
-  envpass :mistral_release, 1
+  envpass :mistral_version, '1.4dev'
+  envpass :mistral_release, 3
 end

--- a/rake/build/environment.rb
+++ b/rake/build/environment.rb
@@ -79,7 +79,7 @@ end
 pipeopts 'st2mistral' do
   checkout true
   envpass :giturl,  'https://github.com/StackStorm/mistral', from: 'ST2MISTRAL_GITURL'
-  envpass :gitrev,  'st2-1.3.2',                                from: 'ST2MISTRAL_GITREV'
+  envpass :gitrev,  'st2-1.3.2',                             from: 'ST2MISTRAL_GITREV'
   envpass :gitdir,  make_tmpname('mistral-')
   envpass :mistral_version, '1.3.2'
   envpass :mistral_release, 1

--- a/rake/build/environment.rb
+++ b/rake/build/environment.rb
@@ -79,8 +79,8 @@ end
 pipeopts 'st2mistral' do
   checkout true
   envpass :giturl,  'https://github.com/StackStorm/mistral', from: 'ST2MISTRAL_GITURL'
-  envpass :gitrev,  'master',                                from: 'ST2MISTRAL_GITREV'
+  envpass :gitrev,  'st2-1.3.2',                                from: 'ST2MISTRAL_GITREV'
   envpass :gitdir,  make_tmpname('mistral-')
-  envpass :mistral_version, '1.4dev'
-  envpass :mistral_release, 3
+  envpass :mistral_version, '1.3.2'
+  envpass :mistral_release, 1
 end


### PR DESCRIPTION
psycopg2 is required to use postgres with mistral.  It doesn't get added to the requirements.txt in the mistral master branch since it isn't required upstream.