### PR TITLE
Fix bug when `mistral` upstart invoked `api` and `server` init scripts, instead of upstart

### DIFF
--- a/packages/st2mistral/debian/mistral-api.upstart
+++ b/packages/st2mistral/debian/mistral-api.upstart
@@ -16,6 +16,7 @@ kill timeout 60
 
 script
   NAME=mistral
+  COMPONENTS="api,engine,executor"
   API_ARGS="--log-file /var/log/mistral/mistral-api.log -b 127.0.0.1:8989 -w 2 mistral.api.wsgi --graceful-timeout 10"
 
   # Read configuration variable file if it is present

--- a/packages/st2mistral/debian/mistral-server.upstart
+++ b/packages/st2mistral/debian/mistral-server.upstart
@@ -16,12 +16,14 @@ kill timeout 60
 
 script
   NAME=mistral
+  COMPONENTS="api,engine,executor"
   SERVER_ARGS="--config-file /etc/mistral/mistral.conf --log-file /var/log/mistral/mistral-server.log"
 
   # Read configuration variable file if it is present
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
   # Exit if server components are disabled, otherwise inject them into args.
+  . /opt/stackstorm/mistral/share/sysvinit/helpers
   enabled_list -q server || exit 0
 
   exec /opt/stackstorm/mistral/bin/mistral-server --server $(enabled_list server) ${SERVER_ARGS}

--- a/packages/st2mistral/debian/mistral.upstart
+++ b/packages/st2mistral/debian/mistral.upstart
@@ -6,18 +6,18 @@ stop on starting rc RUNLEVEL=[016]
 
 pre-start script
   retval=0
-  /etc/init.d/mistral-api start
+  /sbin/initctl start mistral-api
   rs=$?; [ $rs -gt $retval ] && retval=$rs
-  /etc/init.d/mistral-server start
+  /sbin/initctl start mistral-server
   rs=$?; [ $rs -gt $retval ] && retval=$rs
   exit $retval
 end script
 
 post-stop script
   retval=0
-  /etc/init.d/mistral-api stop
+  /sbin/initctl stop mistral-api
   rs=$?; [ $rs -gt $retval ] && retval=$rs
-  /etc/init.d/mistral-server stop
+  /sbin/initctl stop mistral-server
   rs=$?; [ $rs -gt $retval ] && retval=$rs
   exit $retval
 end script


### PR DESCRIPTION
Solves the root cause of https://github.com/StackStorm/st2-packages/issues/254 when command like: 
```
service mistral start
```
under `ubuntu trusty` invoked `init` scripts (creates `pid`), instead of using native `upstart` (doesn't create `pid`).
