### PR TITLE
Password prompt in bootstrap scripts

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -10,6 +10,8 @@ RELEASE='stable'
 REPO_TYPE='staging'
 BETA=''
 ST2_PKG_VERSION=''
+USERNAME=''
+PASSWORD=''
 BRANCH='master'
 
 setup_args() {
@@ -21,19 +23,27 @@ setup_args() {
           shift
           ;;
           -s=*|--stable)
-        RELEASE=stable
+          RELEASE=stable
           shift
           ;;
           -u=*|--unstable)
-        RELEASE=unstable
+          RELEASE=unstable
           shift
           ;;
           --staging)
-        REPO_TYPE='staging'
-        shift
-        ;;
+          REPO_TYPE='staging'
+          shift
+          ;;
+          --user=*)
+          USERNAME="${i#*=}"
+          shift
+          ;;
+          --password=*)
+          PASSWORD="${i#*=}"
+          shift
+          ;;
           *)
-                  # unknown option
+          # unknown option
           ;;
       esac
     done
@@ -49,6 +59,14 @@ setup_args() {
      RELEASE='unstable'
     fi
   fi
+
+  if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
+    echo "Let's set StackStorm admin credentials."
+    echo "You can also use \"--user\" and \"--password\" for unattended installation."
+    read -e -p "Admin username: " -i "st2admin" USERNAME
+    read -e -s -p "Password: " PASSWORD
+  fi
+
 }
 
 setup_args $@
@@ -71,6 +89,9 @@ fi
 if [[ "$REPO_TYPE" == 'staging' ]]; then
   REPO_TYPE="--staging"
 fi
+
+USERNAME="--user=${USERNAME}"
+PASSWORD="--password=${PASSWORD}"
 
 if [[ -n "$RHTEST" ]]; then
   TYPE="rpms"
@@ -97,5 +118,5 @@ else
     chmod +x ${BOOTSTRAP_FILE}
 
     echo "Running deployment script for St2 ${VERSION}..."
-    bash ${BOOTSTRAP_FILE} ${VERSION} ${RELEASE} ${REPO_TYPE}
+    bash ${BOOTSTRAP_FILE} ${VERSION} ${RELEASE} ${REPO_TYPE} ${USERNAME} ${PASSWORD}
 fi

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -2,9 +2,6 @@
 
 set -eu
 
-USERNAME='st2admin'
-PASSWORD='Ch@ngeMe'
-
 HUBOT_ADAPTER='slack'
 HUBOT_SLACK_TOKEN=${HUBOT_SLACK_TOKEN:-''}
 VERSION=''
@@ -14,6 +11,8 @@ BETA=''
 ST2_PKG_VERSION=''
 ST2MISTRAL_PKG_VERSION=''
 ST2WEB_PKG_VERSION=''
+USERNAME=''
+PASSWORD=''
 
 fail() {
   echo "############### ERROR ###############"

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -31,19 +31,27 @@ setup_args() {
           shift
           ;;
           -s=*|--stable)
-        RELEASE=stable
+          RELEASE=stable
           shift
           ;;
           -u=*|--unstable)
-        RELEASE=unstable
+          RELEASE=unstable
           shift
           ;;
           --staging)
-        REPO_TYPE='staging'
-        shift
-        ;;
+          REPO_TYPE='staging'
+          shift
+          ;;
+          --user=*)
+          USERNAME="${i#*=}"
+          shift
+          ;;
+          --password=*)
+          PASSWORD="${i#*=}"
+          shift
+          ;;
           *)
-                  # unknown option
+          # unknown option
           ;;
       esac
     done
@@ -69,6 +77,13 @@ setup_args() {
     echo "################################################################"
     echo "### Installing from staging repos!!! USE AT YOUR OWN RISK!!! ###"
     echo "################################################################"
+  fi
+
+  if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
+    echo "Let's set StackStorm admin credentials."
+    echo "You can also use \"--user\" and \"--password\" for unattended installation."
+    read -e -p "Admin username: " -i "st2admin" USERNAME
+    read -e -s -p "Password: " PASSWORD
   fi
 }
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -22,19 +22,27 @@ setup_args() {
           shift
           ;;
           -s=*|--stable)
-        RELEASE=stable
+          RELEASE=stable
           shift
           ;;
           -u=*|--unstable)
-        RELEASE=unstable
+          RELEASE=unstable
           shift
           ;;
           --staging)
-        REPO_TYPE='staging'
-        shift
-        ;;
+          REPO_TYPE='staging'
+          shift
+          ;;
+          --user=*)
+          USERNAME="${i#*=}"
+          shift
+          ;;
+          --password=*)
+          PASSWORD="${i#*=}"
+          shift
+          ;;
           *)
-                  # unknown option
+          # unknown option
           ;;
       esac
     done
@@ -61,6 +69,14 @@ setup_args() {
     echo "### Installing from staging repos!!! USE AT YOUR OWN RISK!!! ###"
     echo "################################################################"
   fi
+
+  if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
+    echo "Let's set StackStorm admin credentials."
+    echo "You can also use \"--user\" and \"--password\" for unattended installation."
+    read -e -p "Admin username: " -i "st2admin" USERNAME
+    read -e -s -p "Password: " PASSWORD
+  fi
+
 }
 
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -2,9 +2,6 @@
 
 set -eu
 
-USERNAME='st2admin'
-PASSWORD='Ch@ngeMe'
-
 HUBOT_ADAPTER='slack'
 HUBOT_SLACK_TOKEN=${HUBOT_SLACK_TOKEN:-''}
 VERSION=''
@@ -12,6 +9,8 @@ RELEASE='stable'
 REPO_TYPE='staging'
 BETA=''
 ST2_PKG_VERSION=''
+USERNAME=''
+PASSWORD=''
 
 setup_args() {
   for i in "$@"

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -2,9 +2,6 @@
 
 set -eu
 
-USERNAME='st2admin'
-PASSWORD='Ch@ngeMe'
-
 HUBOT_ADAPTER='slack'
 HUBOT_SLACK_TOKEN=${HUBOT_SLACK_TOKEN:-''}
 VERSION=''
@@ -12,6 +9,8 @@ RELEASE='stable'
 REPO_TYPE='staging'
 BETA=''
 ST2_PKG_VERSION=''
+USERNAME=''
+PASSWORD=''
 
 setup_args() {
   for i in "$@"

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -22,19 +22,27 @@ setup_args() {
           shift
           ;;
           -s=*|--stable)
-        RELEASE=stable
+          RELEASE=stable
           shift
           ;;
           -u=*|--unstable)
-        RELEASE=unstable
+          RELEASE=unstable
           shift
           ;;
           --staging)
-        REPO_TYPE='staging'
-        shift
-        ;;
+          REPO_TYPE='staging'
+          shift
+          ;;
+          --user=*)
+          USERNAME="${i#*=}"
+          shift
+          ;;
+          --password=*)
+          PASSWORD="${i#*=}"
+          shift
+          ;;
           *)
-                  # unknown option
+          # unknown option
           ;;
       esac
     done
@@ -60,6 +68,13 @@ setup_args() {
     echo "################################################################"
     echo "### Installing from staging repos!!! USE AT YOUR OWN RISK!!! ###"
     echo "################################################################"
+  fi
+
+  if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
+    echo "Let's set StackStorm admin credentials."
+    echo "You can also use \"--user\" and \"--password\" for unattended installation."
+    read -e -p "Admin username: " -i "st2admin" USERNAME
+    read -e -s -p "Password: " PASSWORD
   fi
 }
 


### PR DESCRIPTION
I hate having a default username/password pair in our bootstrap script because that’s what a lot of people is going to end up using without paying much attention. It’s a security flaw, even if we’re not responsible for it.

So, in this latest RDD (Rage-Driven Development) effort I’m proposing having a username/password prompt along with options for unattended install. Everyone ok with this?

Also, I’m not sure if we’re using these scripts for CI, and if we do, the CI step should be updated with flags.