### PR TITLE
Don't require tty for sudo

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -153,12 +153,12 @@ configure_st2_user () {
   sudo chmod 0700 /home/stanley/.ssh
   sudo chown -R stanley:stanley /home/stanley
 
-  # Disable requiretty for all users
-  sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
-
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
   sudo chmod 0440 /etc/sudoers.d/st2
+
+  # Disable requiretty for all users
+  sed -i "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
 
   ##### NOTE STILL NEED ADJUST CONFIGURATION FOR ST2 USER SECTION #####
 }

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -158,7 +158,7 @@ configure_st2_user () {
   sudo chmod 0440 /etc/sudoers.d/st2
 
   # Disable requiretty for all users
-  sed -i -r "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
+  sed -i -r "s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers
 
   ##### NOTE STILL NEED ADJUST CONFIGURATION FOR ST2 USER SECTION #####
 }

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -158,7 +158,7 @@ configure_st2_user () {
   sudo chmod 0440 /etc/sudoers.d/st2
 
   # Disable requiretty for all users
-  sed -i "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
+  sed -i -r "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
 
   ##### NOTE STILL NEED ADJUST CONFIGURATION FOR ST2 USER SECTION #####
 }

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -153,6 +153,9 @@ configure_st2_user () {
   sudo chmod 0700 /home/stanley/.ssh
   sudo chown -R stanley:stanley /home/stanley
 
+  # Disable requiretty for all users
+  sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
+
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
   sudo chmod 0440 /etc/sudoers.d/st2

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -195,7 +195,7 @@ configure_st2_user() {
   sudo chmod 0440 /etc/sudoers.d/st2
 
   # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-  sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
+  sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers
 }
 
 configure_st2_authentication() {

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -195,7 +195,7 @@ configure_st2_user() {
   sudo chmod 0440 /etc/sudoers.d/st2
 
   # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-  sudo sed -i "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
+  sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
 }
 
 configure_st2_authentication() {

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -190,6 +190,9 @@ configure_st2_user() {
   sudo chmod 0600 /home/stanley/.ssh/authorized_keys
   sudo chown -R stanley:stanley /home/stanley
 
+  # Disable requiretty for all users
+  sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
+
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
   sudo chmod 0440 /etc/sudoers.d/st2

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -190,15 +190,12 @@ configure_st2_user() {
   sudo chmod 0600 /home/stanley/.ssh/authorized_keys
   sudo chown -R stanley:stanley /home/stanley
 
-  # Disable requiretty for all users
-  sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
-
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
   sudo chmod 0440 /etc/sudoers.d/st2
 
   # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-  sudo sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
+  sudo sed -i "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
 }
 
 configure_st2_authentication() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -170,15 +170,12 @@ configure_st2_user() {
   sudo chmod 0600 /home/stanley/.ssh/authorized_keys
   sudo chown -R stanley:stanley /home/stanley
 
-  # Disable requiretty for all users
-  sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
-
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
   sudo chmod 0440 /etc/sudoers.d/st2
 
   # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-  sudo sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
+  sudo sed -i "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
 }
 
 configure_st2_authentication() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -175,7 +175,7 @@ configure_st2_user() {
   sudo chmod 0440 /etc/sudoers.d/st2
 
   # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-  sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
+  sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers
 }
 
 configure_st2_authentication() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -175,7 +175,7 @@ configure_st2_user() {
   sudo chmod 0440 /etc/sudoers.d/st2
 
   # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-  sudo sed -i "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
+  sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
 }
 
 configure_st2_authentication() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -170,6 +170,9 @@ configure_st2_user() {
   sudo chmod 0600 /home/stanley/.ssh/authorized_keys
   sudo chown -R stanley:stanley /home/stanley
 
+  # Disable requiretty for all users
+  sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
+
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
   sudo chmod 0440 /etc/sudoers.d/st2


### PR DESCRIPTION
This disables requiretty for all the users. I believe it's only enabled by default on RHEL, but it doesn't hurt to do the same on Ubuntu (if it's not enabled it's a no-op).

In theory, we could only do that for `st2` user but this could potentially cause issues if user doesn't run stuff under `st2` user, etc. and `requiretty` doesn't offer many security benefits anyway.

Note: It turned out the script already disabled it, but regex modifier was to strict (it didn't allow multiple spaces) so it wouldn't always get disabled.

This resolves part of #264.