### PR TITLE
Register rules during bootstrap

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -146,7 +146,7 @@ install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.deb.sh | sudo bash
   STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
   sudo apt-get install -y st2${ST2_PKG_VERSION}
-  sudo st2ctl reload
+  sudo st2ctl reload --register-all
   sudo st2ctl start
 }
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -196,7 +196,7 @@ install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.rpm.sh | sudo bash
   STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
   sudo yum -y install ${ST2_PKG}
-  sudo st2ctl reload
+  sudo st2ctl reload --register-all
   sudo st2ctl start
 }
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -177,7 +177,7 @@ install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.rpm.sh | sudo bash
   STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
   sudo yum -y install ${ST2_PKG}
-  sudo st2ctl reload
+  sudo st2ctl reload --register-all
   sudo st2ctl start
 }
 


### PR DESCRIPTION
Failure to do so results in broken chatops installations. Without `chatops.notify` rule present, no results are sent back to the bot.