### PR TITLE
Fix st2chatops service restart in st2bootstrap-el7.sh script

### DIFF
--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -330,7 +330,7 @@ configure_st2chatops() {
     sudo sed -i -r "s/^(export HUBOT_ADAPTER.).*/\1$HUBOT_ADAPTER/" /opt/stackstorm/chatops/st2chatops.env
     sudo sed -i -r "s/^(export HUBOT_SLACK_TOKEN.).*/\1$HUBOT_SLACK_TOKEN/" /opt/stackstorm/chatops/st2chatops.env
 
-    sudo systemctl st2chatops restart
+    sudo systemctl restart st2chatops
     sudo systemctl enable st2chatops
   else
     echo "####################### WARNING ########################"


### PR DESCRIPTION
The syntax for the service restart of the st2chaptops service following
the configuration incorrectly utilized the st2chatops service name as
the first argument of the systemctl command.