### PR TITLE
Fix shorthand arg format to work [ci skip]

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -125,6 +125,7 @@ fi
 
 hash curl 2>/dev/null || { echo >&2 "'curl' is not installed. Aborting."; exit 1; }
 
+CURLTEST=`curl --output /dev/null --silent --head --fail ${ST2BOOTSTRAP}`
 if [ $? -ne 0 ]; then
     echo -e "Could not find file ${ST2BOOTSTRAP}"
     exit 2

--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -17,15 +17,15 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -V=*|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;
-          -s=*|--stable)
+          -s|--stable)
           RELEASE=stable
           shift
           ;;
-          -u=*|--unstable)
+          -u|--unstable)
           RELEASE=unstable
           shift
           ;;
@@ -60,15 +60,15 @@ setup_args() {
   fi
 
   if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
-    echo "You can use \"--user\" and \"--password\" to override default st2 credentials."
+    USERNAME=${USERNAME:-st2admin}
+    PASSWORD=${PASSWORD:-Ch@ngeMe}
+    echo "You can use \"--user=<CHANGEME>\" and \"--password=<CHANGEME>\" to override following default st2 credentials."
     SLEEP_TIME=10
+    echo "Username: ${USERNAME}"
+    echo "Password: ${PASSWORD}"
     echo "Sleeping for ${SLEEP_TIME} seconds if you want to Ctrl + C now..."
     sleep ${SLEEP_TIME}
     echo "Resorting to default username and password... You have an option to change password later!"
-    USERNAME=${USERNAME:-st2admin}
-    PASSWORD=${PASSWORD:-Ch@ngeMe}
-    echo "Username: ${USERNAME}"
-    echo "Password: ${PASSWORD}"
   fi
 }
 
@@ -123,7 +123,7 @@ else
   exit 2
 fi
 
-CURLTEST=`curl --output /dev/null --silent --head --fail ${ST2BOOTSTRAP}`
+hash curl 2>/dev/null || { echo >&2 "'curl' is not installed. Aborting."; exit 1; }
 
 if [ $? -ne 0 ]; then
     echo -e "Could not find file ${ST2BOOTSTRAP}"

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -26,15 +26,15 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -V=*|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;
-          -s=*|--stable)
+          -s|--stable)
           RELEASE=stable
           shift
           ;;
-          -u=*|--unstable)
+          -u|--unstable)
           RELEASE=unstable
           shift
           ;;

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -20,15 +20,15 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -V=*|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;
-          -s=*|--stable)
+          -s|--stable)
           RELEASE=stable
           shift
           ;;
-          -u=*|--unstable)
+          -u|--unstable)
           RELEASE=unstable
           shift
           ;;

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -20,15 +20,15 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -V=*|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;
-          -s=*|--stable)
+          -s|--stable)
           RELEASE=stable
           shift
           ;;
-          -u=*|--unstable)
+          -u|--unstable)
           RELEASE=unstable
           shift
           ;;


### PR DESCRIPTION
Fixes: https://github.com/StackStorm/st2-packages/issues/297

## Tests

```
vagrant@st2test:~$ ./install.sh -v=1.3.2 --user=foo --password=foo
*** Detected Distro is Ubuntu ***
*** Detected flavor trusty ***
Downloading deployment script from: https://raw.githubusercontent.com/StackStorm/st2-packages/v1.3/scripts/st2bootstrap-deb.sh...
Running deployment script for st2 --version 1.3.2...
OS specific script cmd: bash st2bootstrap-deb.sh --version 1.3.2 --stable  --user=foo --password=foo


vagrant@st2test:~$ ./install.sh -u --staging --user=foo --password=foo
*** Detected Distro is Ubuntu ***
*** Detected flavor trusty ***
Downloading deployment script from: https://raw.githubusercontent.com/StackStorm/st2-packages/master/scripts/st2bootstrap-deb.sh...
Running deployment script for st2 ...
OS specific script cmd: bash st2bootstrap-deb.sh  --unstable --staging --user=foo --password=foo


vagrant@st2test:~$ ./install.sh -s --user=foo --password=foo
*** Detected Distro is Ubuntu ***
*** Detected flavor trusty ***
Downloading deployment script from: https://raw.githubusercontent.com/StackStorm/st2-packages/master/scripts/st2bootstrap-deb.sh...
Running deployment script for st2 ...
OS specific script cmd: bash st2bootstrap-deb.sh  --stable  --user=foo --password=foo


vagrant@st2test:~$ ./install.sh -s
You can use "--user=<CHANGEME>" and "--password=<CHANGEME>" to override following default st2 credentials.
Username: st2admin
Password: Ch@ngeMe
Sleeping for 10 seconds if you want to Ctrl + C now...
^C
vagrant@st2test:~$
```