### PR TITLE
[RFC] Update bootstrap scripts to write a CLI config with the default credentials

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -217,14 +217,13 @@ password = ${PASSWORD}
 EOT"
 
   # Write config for root user
-  if [ "${CURRENT_USER}" == "${ROOT_USER}"]; then
+  if [ "${CURRENT_USER}" == "${ROOT_USER}" ]; then
       return
   fi
 
   # Write config for current user (in case current user != root)
   if [ ! -d ${CURRENT_USER_CLI_CONFIG_DIRECTORY} ]; then
     sudo mkdir -p ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
-    sudo chown -R ${CURRENT_USER}:${CURRENT_USER}
   fi
 
   sudo sh -c "cat <<EOT > ${CURRENT_USER_CLI_CONFIG_PATH}

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -197,30 +197,14 @@ configure_st2_authentication() {
 
 configure_st2_cli_config() {
   # Configure CLI config (write credentials for the root user and user which ran the script)
-  CURRENT_USER=$(whoami)
   ROOT_USER="root"
-
-  CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
-  CURRENT_USER_CLI_CONFIG_PATH="${CURRENT_USER_CLI_CONFIG_DIRECTORY}/config"
+  CURRENT_USER=$(whoami)
 
   ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
   ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
 
-  # Write config for current user
-  if [ ! -d ${CURRENT_USER_CLI_CONFIG_DIRECTORY} ]; then
-    sudo mkdir -p ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
-  fi
-
-  sudo sh -c "cat <<EOT > ${CURRENT_USER_CLI_CONFIG_PATH}
-[credentials]
-username = ${USERNAME}
-password = ${PASSWORD}
-EOT"
-
-  # Write config for root user (in case current user != root)
-  if [ "${CURRENT_USER}" == "${ROOT_USER}"]; then
-      return
-  fi
+  CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
+  CURRENT_USER_CLI_CONFIG_PATH="${CURRENT_USER_CLI_CONFIG_DIRECTORY}/config"
 
   if [ ! -d ${ROOT_USER_CLI_CONFIG_DIRECTORY} ]; then
     sudo mkdir -p ${ROOT_USER_CLI_CONFIG_DIRECTORY}
@@ -231,6 +215,26 @@ EOT"
 username = ${USERNAME}
 password = ${PASSWORD}
 EOT"
+
+  # Write config for root user
+  if [ "${CURRENT_USER}" == "${ROOT_USER}"]; then
+      return
+  fi
+
+  # Write config for current user (in case current user != root)
+  if [ ! -d ${CURRENT_USER_CLI_CONFIG_DIRECTORY} ]; then
+    sudo mkdir -p ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
+    sudo chown -R ${CURRENT_USER}:${CURRENT_USER}
+  fi
+
+  sudo sh -c "cat <<EOT > ${CURRENT_USER_CLI_CONFIG_PATH}
+[credentials]
+username = ${USERNAME}
+password = ${PASSWORD}
+EOT"
+
+  # Fix the permissions
+  sudo chown -R ${CURRENT_USER}:${CURRENT_USER} ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
 }
 
 install_st2mistral_depdendencies() {

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -147,8 +147,9 @@ install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.deb.sh | sudo bash
   STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
   sudo apt-get install -y st2${ST2_PKG_VERSION}
-  sudo st2ctl reload --register-all
   sudo st2ctl start
+  sleep 5
+  sudo st2ctl reload --register-all
 }
 
 configure_st2_user () {

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -86,6 +86,7 @@ setup_args() {
   if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
     echo "Let's set StackStorm admin credentials."
     echo "You can also use \"--user\" and \"--password\" for unattended installation."
+    echo "Press \"ENTER\" to continue or \"CTRL+C\" to exit/abort"
     read -e -p "Admin username: " -i "st2admin" USERNAME
     read -e -s -p "Password: " PASSWORD
   fi

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -194,6 +194,43 @@ configure_st2_authentication() {
   sudo st2ctl restart-component st2stream
 }
 
+configure_st2_cli_config() {
+  # Configure CLI config (write credentials for the root user and user which ran the script)
+  CURRENT_USER=$(whoami)
+  ROOT_USER="root"
+
+  CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
+  CURRENT_USER_CLI_CONFIG_PATH="${CURRENT_USER_CLI_CONFIG_DIRECTORY}/config"
+  ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
+  ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
+
+  # Write config for current user
+  if [ ! -d ${CURRENT_USER_CLI_CONFIG_DIRECTORY} ]; then
+    sudo mkdir -f ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
+  fi
+
+  sudo sh -c "cat <<EOT > ${CURRENT_USER_CLI_CONFIG_PATH}
+[credentials]
+username = ${USERNAME}
+password = ${PASSWORD}
+EOT"
+
+  # Write config for root user (in case current user != root)
+  if [ "${CURRENT_USER}" == "${ROOT_USER}"]; then
+      return
+  fi
+
+  if [ ! -d ${ROOT_USER_CLI_CONFIG_DIRECTORY} ]; then
+    sudo mkdir -f ${ROOT_USER_CLI_CONFIG_DIRECTORY}
+  fi
+
+  sudo sh -c "cat <<EOT > ${ROOT_USER_CLI_CONFIG_PATH}
+[credentials]
+username = ${USERNAME}
+password = ${PASSWORD}
+EOT"
+}
+
 install_st2mistral_depdendencies() {
   sudo apt-get install -y postgresql
 
@@ -338,6 +375,7 @@ STEP="Install st2 dependencies" && install_st2_dependencies
 STEP="Install st2" && install_st2
 STEP="Configure st2 user" && configure_st2_user
 STEP="Configure st2 auth" && configure_st2_authentication
+STEP="Configure st2 CLI config" && configure_st2_cli_config
 STEP="Verify st2" && verify_st2
 
 STEP="Install mistral dependencies" && install_st2mistral_depdendencies

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -201,12 +201,13 @@ configure_st2_cli_config() {
 
   CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
   CURRENT_USER_CLI_CONFIG_PATH="${CURRENT_USER_CLI_CONFIG_DIRECTORY}/config"
+
   ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
   ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
 
   # Write config for current user
   if [ ! -d ${CURRENT_USER_CLI_CONFIG_DIRECTORY} ]; then
-    sudo mkdir -f ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
+    sudo mkdir -p ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
   fi
 
   sudo sh -c "cat <<EOT > ${CURRENT_USER_CLI_CONFIG_PATH}
@@ -221,7 +222,7 @@ EOT"
   fi
 
   if [ ! -d ${ROOT_USER_CLI_CONFIG_DIRECTORY} ]; then
-    sudo mkdir -f ${ROOT_USER_CLI_CONFIG_DIRECTORY}
+    sudo mkdir -p ${ROOT_USER_CLI_CONFIG_DIRECTORY}
   fi
 
   sudo sh -c "cat <<EOT > ${ROOT_USER_CLI_CONFIG_PATH}

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -197,8 +197,9 @@ install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.rpm.sh | sudo bash
   STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
   sudo yum -y install ${ST2_PKG}
-  sudo st2ctl reload --register-all
   sudo st2ctl start
+  sleep 5
+  sudo st2ctl reload --register-all
 }
 
 configure_st2_user() {

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -80,6 +80,7 @@ setup_args() {
   if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
     echo "Let's set StackStorm admin credentials."
     echo "You can also use \"--user\" and \"--password\" for unattended installation."
+    echo "Press \"ENTER\" to continue or \"CTRL+C\" to exit/abort"
     read -e -p "Admin username: " -i "st2admin" USERNAME
     read -e -s -p "Password: " PASSWORD
   fi

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -242,6 +242,47 @@ configure_st2_authentication() {
   sudo st2ctl restart-component st2stream
 }
 
+configure_st2_cli_config() {
+  # Configure CLI config (write credentials for the root user and user which ran the script)
+  ROOT_USER="root"
+  CURRENT_USER=$(whoami)
+
+  ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
+  ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
+
+  CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
+  CURRENT_USER_CLI_CONFIG_PATH="${CURRENT_USER_CLI_CONFIG_DIRECTORY}/config"
+
+  if [ ! -d ${ROOT_USER_CLI_CONFIG_DIRECTORY} ]; then
+    sudo mkdir -p ${ROOT_USER_CLI_CONFIG_DIRECTORY}
+  fi
+
+  sudo sh -c "cat <<EOT > ${ROOT_USER_CLI_CONFIG_PATH}
+[credentials]
+username = ${USERNAME}
+password = ${PASSWORD}
+EOT"
+
+  # Write config for root user
+  if [ "${CURRENT_USER}" == "${ROOT_USER}" ]; then
+      return
+  fi
+
+  # Write config for current user (in case current user != root)
+  if [ ! -d ${CURRENT_USER_CLI_CONFIG_DIRECTORY} ]; then
+    sudo mkdir -p ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
+  fi
+
+  sudo sh -c "cat <<EOT > ${CURRENT_USER_CLI_CONFIG_PATH}
+[credentials]
+username = ${USERNAME}
+password = ${PASSWORD}
+EOT"
+
+  # Fix the permissions
+  sudo chown -R ${CURRENT_USER}:${CURRENT_USER} ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
+}
+
 verify_st2() {
   st2 --version
   st2 -h
@@ -411,6 +452,7 @@ STEP="Install st2 dependencies" && install_st2_dependencies
 STEP="Install st2" && install_st2
 STEP="Configure st2 user" && configure_st2_user
 STEP="Configure st2 auth" && configure_st2_authentication
+STEP="Configure st2 CLI config" && configure_st2_cli_config
 STEP="Verify st2" && verify_st2
 
 STEP="Install mistral dependencies" && install_st2mistral_depdendencies

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -178,8 +178,9 @@ install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.rpm.sh | sudo bash
   STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
   sudo yum -y install ${ST2_PKG}
-  sudo st2ctl reload --register-all
   sudo st2ctl start
+  sleep 5
+  sudo st2ctl reload --register-all
 }
 
 configure_st2_user() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -247,6 +247,47 @@ verify_st2() {
   st2 run packs.install packs=st2
 }
 
+configure_st2_cli_config() {
+  # Configure CLI config (write credentials for the root user and user which ran the script)
+  ROOT_USER="root"
+  CURRENT_USER=$(whoami)
+
+  ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
+  ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
+
+  CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
+  CURRENT_USER_CLI_CONFIG_PATH="${CURRENT_USER_CLI_CONFIG_DIRECTORY}/config"
+
+  if [ ! -d ${ROOT_USER_CLI_CONFIG_DIRECTORY} ]; then
+    sudo mkdir -p ${ROOT_USER_CLI_CONFIG_DIRECTORY}
+  fi
+
+  sudo sh -c "cat <<EOT > ${ROOT_USER_CLI_CONFIG_PATH}
+[credentials]
+username = ${USERNAME}
+password = ${PASSWORD}
+EOT"
+
+  # Write config for root user
+  if [ "${CURRENT_USER}" == "${ROOT_USER}" ]; then
+      return
+  fi
+
+  # Write config for current user (in case current user != root)
+  if [ ! -d ${CURRENT_USER_CLI_CONFIG_DIRECTORY} ]; then
+    sudo mkdir -p ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
+  fi
+
+  sudo sh -c "cat <<EOT > ${CURRENT_USER_CLI_CONFIG_PATH}
+[credentials]
+username = ${USERNAME}
+password = ${PASSWORD}
+EOT"
+
+  # Fix the permissions
+  sudo chown -R ${CURRENT_USER}:${CURRENT_USER} ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
+}
+
 install_st2mistral_depdendencies() {
   sudo yum -y install postgresql-server postgresql-contrib postgresql-devel
 
@@ -384,6 +425,7 @@ STEP="Install st2 dependencies" && install_st2_dependencies
 STEP="Install st2" && install_st2
 STEP="Configure st2 user" && configure_st2_user
 STEP="Configure st2 auth" && configure_st2_authentication
+STEP="Configure st2 CLI config" && configure_st2_cli_config
 STEP="Verify st2" && verify_st2
 
 STEP="Install mistral dependencies" && install_st2mistral_depdendencies

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -80,6 +80,7 @@ setup_args() {
   if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
     echo "Let's set StackStorm admin credentials."
     echo "You can also use \"--user\" and \"--password\" for unattended installation."
+    echo "Press \"ENTER\" to continue or \"CTRL+C\" to exit/abort"
     read -e -p "Admin username: " -i "st2admin" USERNAME
     read -e -s -p "Password: " PASSWORD
   fi


### PR DESCRIPTION
This pull request updates bootstrap script to write a CLI config for root user and user who ran the script with the default credentials.

I think this is fine to do in case of the bootstrap script since bootstrap script is there for quick testing and evaluation and not for production deployment. In the testing / evaluation scenario, speed and UX (aka getting up and running ASAP) matters even more so it makes sense to write default credentials in the config and save user one or two command (st2 auth, exporting token).

Note: I'm also fine if we write config just for the root user and not for both.