### PR TITLE
Use API keys instead of username/password for st2chatops

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -299,6 +299,9 @@ configure_st2chatops() {
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 
+  sudo sed -i -r "/^(export ST2_AUTH_USERNAME.).*/d" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "/^(export ST2_AUTH_PASSWORD.).*/d" /opt/stackstorm/chatops/st2chatops.env
+
   # Setup adapter
   if [ "$HUBOT_ADAPTER"="slack" ] && [ ! -z "$HUBOT_SLACK_TOKEN" ]
   then

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -295,9 +295,9 @@ install_st2chatops() {
 }
 
 configure_st2chatops() {
-  # Set credentials
-  sudo sed -i -r "s/^(export ST2_AUTH_USERNAME.).*/\1$USERNAME/" /opt/stackstorm/chatops/st2chatops.env
-  sudo sed -i -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$PASSWORD/" /opt/stackstorm/chatops/st2chatops.env
+  # set API keys. This should work since CLI is configuered already.
+  ST2_API_KEY=`st2 apikey create -k`
+  sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 
   # Setup adapter
   if [ "$HUBOT_ADAPTER"="slack" ] && [ ! -z "$HUBOT_SLACK_TOKEN" ]

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -389,9 +389,9 @@ install_st2chatops() {
 }
 
 configure_st2chatops() {
-  # Set credentials
-  sudo sed -i -r "s/^(export ST2_AUTH_USERNAME.).*/\1$USERNAME/" /opt/stackstorm/chatops/st2chatops.env
-  sudo sed -i -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$PASSWORD/" /opt/stackstorm/chatops/st2chatops.env
+  # set API keys. This should work since CLI is configuered already.
+  ST2_API_KEY=`st2 apikey create -k`
+  sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 
   # Setup adapter
   if [ "$HUBOT_ADAPTER"="slack" ] && [ ! -z "$HUBOT_SLACK_TOKEN" ]

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -393,6 +393,9 @@ configure_st2chatops() {
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 
+  sudo sed -i -r "/^(export ST2_AUTH_USERNAME.).*/d" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "/^(export ST2_AUTH_PASSWORD.).*/d" /opt/stackstorm/chatops/st2chatops.env
+
   # Setup adapter
   if [ "$HUBOT_ADAPTER"="slack" ] && [ ! -z "$HUBOT_SLACK_TOKEN" ]
   then

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -366,6 +366,9 @@ configure_st2chatops() {
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 
+  sudo sed -i -r "/^(export ST2_AUTH_USERNAME.).*/d" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "/^(export ST2_AUTH_PASSWORD.).*/d" /opt/stackstorm/chatops/st2chatops.env
+
   # Setup adapter
   if [ "$HUBOT_ADAPTER"="slack" ] && [ ! -z "$HUBOT_SLACK_TOKEN" ]
   then

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -362,9 +362,9 @@ install_st2chatops() {
 }
 
 configure_st2chatops() {
-  # Set credentials
-  sudo sed -i -r "s/^(export ST2_AUTH_USERNAME.).*/\1$USERNAME/" /opt/stackstorm/chatops/st2chatops.env
-  sudo sed -i -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$PASSWORD/" /opt/stackstorm/chatops/st2chatops.env
+  # set API keys. This should work since CLI is configuered already.
+  ST2_API_KEY=`st2 apikey create -k`
+  sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 
   # Setup adapter
   if [ "$HUBOT_ADAPTER"="slack" ] && [ ! -z "$HUBOT_SLACK_TOKEN" ]


### PR DESCRIPTION
Based on https://github.com/StackStorm/st2chatops/pull/41

Individual command has been validated locally. Hard to run script without corresponding `st2chatops` packages.