### PR TITLE
comment out lines instead of delete and also comment out auth-url

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -299,8 +299,9 @@ configure_st2chatops() {
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 
-  sudo sed -i -r "/^(export ST2_AUTH_USERNAME.).*/d" /opt/stackstorm/chatops/st2chatops.env
-  sudo sed -i -r "/^(export ST2_AUTH_PASSWORD.).*/d" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_URL.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_USERNAME.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_PASSWORD.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
 
   # Setup adapter
   if [ "$HUBOT_ADAPTER"="slack" ] && [ ! -z "$HUBOT_SLACK_TOKEN" ]

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -393,8 +393,9 @@ configure_st2chatops() {
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 
-  sudo sed -i -r "/^(export ST2_AUTH_USERNAME.).*/d" /opt/stackstorm/chatops/st2chatops.env
-  sudo sed -i -r "/^(export ST2_AUTH_PASSWORD.).*/d" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_URL.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_USERNAME.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_PASSWORD.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
 
   # Setup adapter
   if [ "$HUBOT_ADAPTER"="slack" ] && [ ! -z "$HUBOT_SLACK_TOKEN" ]

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -366,8 +366,9 @@ configure_st2chatops() {
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 
-  sudo sed -i -r "/^(export ST2_AUTH_USERNAME.).*/d" /opt/stackstorm/chatops/st2chatops.env
-  sudo sed -i -r "/^(export ST2_AUTH_PASSWORD.).*/d" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_URL.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_USERNAME.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_PASSWORD.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
 
   # Setup adapter
   if [ "$HUBOT_ADAPTER"="slack" ] && [ ! -z "$HUBOT_SLACK_TOKEN" ]


### PR DESCRIPTION
* Leaving the `ST2_AUTH_URL` in causes `hubot-stackstorm` to be unhappy. So it is now commented out.
* Also better to comment out lines than delete them so user can easily switch.

Something like,
```
# StackStorm auth endpoint.
export ST2_AUTH_URL="${ST2_API:-https://${ST2_HOSTNAME}/api}"
```

Becomes,
```
# StackStorm auth endpoint.
# export ST2_AUTH_URL="${ST2_API:-https://${ST2_HOSTNAME}/api}"
```