### PR TITLE
Make sure we link st2-submit-debug-info binary into /usr/bin

### DIFF
--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -86,5 +86,4 @@ wheelhouse: .stamp-wheelhouse
 inject-deps: .stamp-inject-deps
 .stamp-inject-deps:
 	echo "st2client==$(ST2PKG_NORMALIZED_VERSION)" >> requirements.txt
-	echo "st2debug" >> requirements.txt
 	touch $@

--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -86,4 +86,5 @@ wheelhouse: .stamp-wheelhouse
 inject-deps: .stamp-inject-deps
 .stamp-inject-deps:
 	echo "st2client==$(ST2PKG_NORMALIZED_VERSION)" >> requirements.txt
+	echo "st2debug" >> requirements.txt
 	touch $@

--- a/packages/st2/debian/st2.links
+++ b/packages/st2/debian/st2.links
@@ -4,5 +4,6 @@ opt/stackstorm/st2/bin/st2-rule-tester usr/bin/st2-rule-tester
 opt/stackstorm/st2/bin/st2-register-content usr/bin/st2-register-content
 opt/stackstorm/st2/bin/st2-apply-rbac-definitions usr/bin/st2-apply-rbac-definitions
 opt/stackstorm/st2/bin/st2-bootstrap-rmq usr/bin/st2-bootstrap-rmq
-opt/stackstorm/st2/bin/st2ctl usr/bin/st2ctl
+opt/stackstorm/st2/bin/st2-submit-debug-info usr/bin/st2-submit-debug-info
 opt/stackstorm/st2/bin/st2-generate-symmetric-crypto-key usr/bin/st2-generate-symmetric-crypto-key
+opt/stackstorm/st2/bin/st2ctl usr/bin/st2ctl

--- a/packages/st2/debian/st2.links
+++ b/packages/st2/debian/st2.links
@@ -1,3 +1,4 @@
+# Note: This file is used for both - debian and rpm packages
 opt/stackstorm/st2/bin/st2 usr/bin/st2
 opt/stackstorm/st2/bin/st2-trigger-refire usr/bin/st2-trigger-refire
 opt/stackstorm/st2/bin/st2-rule-tester usr/bin/st2-rule-tester

--- a/packages/st2/in-requirements.txt
+++ b/packages/st2/in-requirements.txt
@@ -5,4 +5,5 @@ st2stream
 st2auth
 st2reactor
 st2exporter
+st2debug
 git+https://github.com/StackStorm/st2-auth-backend-pam.git@master#egg=st2-auth-backend-pam

--- a/rake/build/environment.rb
+++ b/rake/build/environment.rb
@@ -9,7 +9,8 @@ require 'resolv'
 ST2_COMPONENTS = %w(
   st2api st2stream st2actions st2common
   st2auth st2client st2exporter
-  st2reactor)
+  st2reactor
+  st2debug)
 
 # Default list of packages to build
 BUILDLIST = 'st2 st2mistral'

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -71,7 +71,7 @@ class ST2Spec
       st2debug: %w(st2-submit-debug-info),
       st2: %w(st2-bootstrap-rmq st2-register-content st2-rule-tester
               st2-apply-rbac-definitions st2-trigger-refire st2 st2ctl
-              st2-generate-symmetric-crypto-key),
+              st2-generate-symmetric-crypto-key st2-submit-debug-info),
       mistral: %w(mistral)
     },
 


### PR DESCRIPTION
The title says it all.

IIRC, this .links file is also used by rpms so if that's indeed the case we should move it outside debian/ directory to reduce the confusion (e.g. into common/ or similar).