### PR TITLE
include default pack

### DIFF
--- a/packages/st2/debian/install
+++ b/packages/st2/debian/install
@@ -2,6 +2,7 @@
 ../contrib/packs opt/stackstorm/packs/
 ../contrib/linux opt/stackstorm/packs/
 ../contrib/chatops opt/stackstorm/packs/
+../contrib/default opt/stackstorm/packs/
 ../contrib/examples usr/share/doc/st2/
 ../st2actions/conf/logging.*.conf etc/st2/
 ../st2actions/conf/syslog.*.conf etc/st2/


### PR DESCRIPTION
### deb
```
vagrant@st2vagrant:~$ dpkg -c st2_1.5dev-110_amd64.deb | grep packs/default
drwxr-xr-x root/root         0 2016-06-21 19:46 ./opt/stackstorm/packs/default/
drwxr-xr-x root/root         0 2016-06-21 19:46 ./opt/stackstorm/packs/default/actions/
-rw-r--r-- root/root       304 2016-06-21 19:46 ./opt/stackstorm/packs/default/actions/README.md
-rw-r--r-- root/root      1996 2016-06-21 19:46 ./opt/stackstorm/packs/default/icon.png
-rw-r--r-- root/root       195 2016-06-21 19:46 ./opt/stackstorm/packs/default/pack.yaml
drwxr-xr-x root/root         0 2016-06-21 19:46 ./opt/stackstorm/packs/default/rules/
-rw-r--r-- root/root       125 2016-06-21 19:46 ./opt/stackstorm/packs/default/rules/README.md
drwxr-xr-x root/root         0 2016-06-21 19:46 ./opt/stackstorm/packs/default/sensors/
-rw-r--r-- root/root       166 2016-06-21 19:46 ./opt/stackstorm/packs/default/sensors/README.md
```

### rpm
```
vagrant@st2vagrant:~$ rpm -qlp st2-1.5dev-110.x86_64.rpm | grep packs/default
/opt/stackstorm/packs/default
/opt/stackstorm/packs/default/actions
/opt/stackstorm/packs/default/actions/README.md
/opt/stackstorm/packs/default/icon.png
/opt/stackstorm/packs/default/pack.yaml
/opt/stackstorm/packs/default/rules
/opt/stackstorm/packs/default/rules/README.md
/opt/stackstorm/packs/default/sensors
/opt/stackstorm/packs/default/sensors/README.md
```