### PR TITLE
st2actionrunner upstart script fails to stop all running instances

### DIFF
--- a/packages/st2/debian/st2.st2actionrunner.upstart
+++ b/packages/st2/debian/st2.st2actionrunner.upstart
@@ -25,6 +25,7 @@ end script
 post-stop script
   NAME=st2actionrunner
   # same number as in runner.sh!
+  WORKERS=$(/usr/bin/nproc 2>/dev/null)
   WORKERS=${WORKERS:-10}
 
   # Read configuration variable file if it is present


### PR DESCRIPTION
I mistakenly created an issue under the st2 repo because I didn't realise the package scripts were managed under another repo.

Details of the issue can bee seen here: https://github.com/StackStorm/st2/issues/2778

The fix is to calculate the number of processors in the same way as the pre-start script.
