### PR TITLE
Fix -v / --version flag in the bootstrap script

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -17,7 +17,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v=*|--version=*)
+          -v|--version=*)
           VERSION="${i#*=}"
           shift
           ;;

--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -82,7 +82,7 @@ get_version_branch() {
 
 if [[ "$VERSION" != '' ]]; then
   get_version_branch $VERSION
-  VERSION="--version ${VERSION}"
+  VERSION="--version=${VERSION}"
 fi
 
 if [[ "$RELEASE" != '' ]]; then

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -26,7 +26,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v=*|--version=*)
+          -v|--version=*)
           VERSION="${i#*=}"
           shift
           ;;

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -20,7 +20,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v=*|--version=*)
+          -v|--version=*)
           VERSION="${i#*=}"
           shift
           ;;

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -20,7 +20,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v=*|--version=*)
+          -v|--version=*)
           VERSION="${i#*=}"
           shift
           ;;


### PR DESCRIPTION
All the options use -v foo / --value foo notation, but short option for version flag required "-v=foo" notation which is inconsistent with other options.

I assumed that was a copy and paste / type.

In addition to that, this pull request also fixes the whole version concept. It was broken and didn't work because the script passed invalid argument (--version foo instead of --version=foo) to the underlying OS specific script.