### PR TITLE
Pickup bootstrap scripts from master

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -8,7 +8,6 @@ RHTEST=`cat /etc/redhat-release 2> /dev/null | sed -e "s~\(.*\)release.*~\1~g"`
 VERSION=''
 RELEASE='stable'
 REPO_TYPE=''
-BETA=''
 ST2_PKG_VERSION=''
 USERNAME=''
 PASSWORD=''
@@ -18,15 +17,15 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -V=*|--version=*)
+          -v|--version=*)
           VERSION="${i#*=}"
           shift
           ;;
-          -s=*|--stable)
+          -s|--stable)
           RELEASE=stable
           shift
           ;;
-          -u=*|--unstable)
+          -u|--unstable)
           RELEASE=unstable
           shift
           ;;
@@ -61,10 +60,15 @@ setup_args() {
   fi
 
   if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
-    echo "Let's set StackStorm admin credentials."
-    echo "You can also use \"--user\" and \"--password\" to override default st2 credentials."
     USERNAME=${USERNAME:-st2admin}
     PASSWORD=${PASSWORD:-Ch@ngeMe}
+    echo "You can use \"--user=<CHANGEME>\" and \"--password=<CHANGEME>\" to override following default st2 credentials."
+    SLEEP_TIME=10
+    echo "Username: ${USERNAME}"
+    echo "Password: ${PASSWORD}"
+    echo "Sleeping for ${SLEEP_TIME} seconds if you want to Ctrl + C now..."
+    sleep ${SLEEP_TIME}
+    echo "Resorting to default username and password... You have an option to change password later!"
   fi
 }
 
@@ -78,7 +82,7 @@ get_version_branch() {
 
 if [[ "$VERSION" != '' ]]; then
   get_version_branch $VERSION
-  VERSION="--version ${VERSION}"
+  VERSION="--version=${VERSION}"
 fi
 
 if [[ "$RELEASE" != '' ]]; then
@@ -94,20 +98,34 @@ PASSWORD="--password=${PASSWORD}"
 
 if [[ -n "$RHTEST" ]]; then
   TYPE="rpms"
-  echo "# Detected Distro is ${RHTEST}"
+  echo "*** Detected Distro is ${RHTEST} ***"
   RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
+  echo "*** Detected distro version ${RHMAJVER} ***"
+  if [[ "$RHMAJVER" != '6' && "$RHMAJVER" != '7' ]]; then
+    echo "Unsupported distro version $RHMAJVER! Aborting!"
+    exit 2
+  fi
   ST2BOOTSTRAP="${BASE_PATH}/${BRANCH}/scripts/st2bootstrap-el${RHMAJVER}.sh"
+  BOOTSTRAP_FILE="st2bootstrap-el${RHMAJVER}.sh"
 elif [[ -n "$DEBTEST" ]]; then
   TYPE="debs"
-  echo "# Detected Distro is ${DEBTEST}"
+  echo "*** Detected Distro is ${DEBTEST} ***"
+  SUBTYPE=`lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}'`
+  echo "*** Detected flavor ${SUBTYPE} ***"
+  if [[ "$SUBTYPE" != 'trusty' ]]; then
+    echo "Unsupported ubuntu flavor ${SUBTYPE}. Please use 14.04 (trusty) as base system!"
+    exit 2
+  fi
   ST2BOOTSTRAP="${BASE_PATH}/${BRANCH}/scripts/st2bootstrap-deb.sh"
+  BOOTSTRAP_FILE="st2bootstrap-deb.sh"
 else
   echo "Unknown Operating System"
   exit 2
 fi
 
-CURLTEST=`curl --output /dev/null --silent --head --fail ${ST2BOOTSTRAP}`
+hash curl 2>/dev/null || { echo >&2 "'curl' is not installed. Aborting."; exit 1; }
 
+CURLTEST=`curl --output /dev/null --silent --head --fail ${ST2BOOTSTRAP}`
 if [ $? -ne 0 ]; then
     echo -e "Could not find file ${ST2BOOTSTRAP}"
     exit 2
@@ -117,5 +135,6 @@ else
     chmod +x ${BOOTSTRAP_FILE}
 
     echo "Running deployment script for st2 ${VERSION}..."
+    echo "OS specific script cmd: bash ${BOOTSTRAP_FILE} ${VERSION} ${RELEASE} ${REPO_TYPE} ${USERNAME} ${PASSWORD}"
     bash ${BOOTSTRAP_FILE} ${VERSION} ${RELEASE} ${REPO_TYPE} ${USERNAME} ${PASSWORD}
 fi

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -7,24 +7,28 @@ HUBOT_SLACK_TOKEN=${HUBOT_SLACK_TOKEN:-''}
 VERSION=''
 RELEASE='stable'
 REPO_TYPE=''
-BETA=''
+REPO_PREFIX=''
 ST2_PKG_VERSION=''
 USERNAME=''
 PASSWORD=''
+ST2_PKG='st2'
+ST2MISTRAL_PKG='st2mistral'
+ST2WEB_PKG='st2web'
+ST2CHATOPS_PKG='st2chatops'
 
 setup_args() {
   for i in "$@"
     do
       case $i in
-          -V=*|--version=*)
+          -v|--version=*)
           VERSION="${i#*=}"
           shift
           ;;
-          -s=*|--stable)
+          -s|--stable)
           RELEASE=stable
           shift
           ;;
-          -u=*|--unstable)
+          -u|--unstable)
           RELEASE=unstable
           shift
           ;;
@@ -66,7 +70,7 @@ setup_args() {
   echo "          Installing st2 $RELEASE $VERSION              "
   echo "########################################################"
 
-  if [[ -z "$BETA"  && "$REPO_TYPE"="staging" ]]; then
+  if [ "$REPO_TYPE" == "staging" ]; then
     printf "\n\n"
     echo "################################################################"
     echo "### Installing from staging repos!!! USE AT YOUR OWN RISK!!! ###"
@@ -76,47 +80,66 @@ setup_args() {
   if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
     echo "Let's set StackStorm admin credentials."
     echo "You can also use \"--user\" and \"--password\" for unattended installation."
+    echo "Press \"ENTER\" to continue or \"CTRL+C\" to exit/abort"
     read -e -p "Admin username: " -i "st2admin" USERNAME
     read -e -s -p "Password: " PASSWORD
   fi
+}
 
+
+install_yum_utils() {
+  # We need repoquery tool to get package_name-package_ver-package_rev in RPM based distros
+  # if we don't want to construct this string manually using yum info --show-duplicates and
+  # doing a bunch of sed awk magic. Problem is this is not installed by default on all images.
+  sudo yum install -y yum-utils
 }
 
 
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
-    local ST2_VER=$(yum info st2 | grep Version | awk '{print $3}' | grep ${VERSION} | sort --version-sort | tail -n 1)
+    local ST2_VER=$(repoquery --nvr --show-duplicates st2 | grep ${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo apt-cache policy st2
+      sudo repoquery --nvr --show-duplicates st2
       exit 3
     fi
+    ST2_PKG=${ST2_VER}
 
-    local ST2MISTRAL_VER=$(yum info st2mistral | grep Version | awk '{print $3}' | grep ${VERSION} | sort --version-sort | tail -n 1)
+    local ST2MISTRAL_VER=$(repoquery --nvr --show-duplicates st2mistral | grep ${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2MISTRAL_VER" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo apt-cache policy st2mistral
+      sudo repoquery --nvr --show-duplicates st2mistral
       exit 3
     fi
+    ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(yum info st2web | grep Version | awk '{print $3}' | grep ${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery --nvr --show-duplicates st2web | grep ${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo apt-cache policy st2web
+      sudo repoquery --nvr --show-duplicates st2web
       exit 3
     fi
-    ST2_PKG_VERSION="=${ST2_VER}"
-    ST2MISTRAL_PKG_VERSION="=${ST2MISTRAL_VER}"
-    ST2WEB_PKG_VERSION="=${ST2WEB_VER}"
+    ST2WEB_PKG=${ST2WEB_VER}
+
+    local ST2CHATOPS_VER=$(repoquery --nvr --show-duplicates st2chatops | grep ${VERSION} | sort --version-sort | tail -n 1)
+    if [ -z "$ST2CHATOPS_VER" ]; then
+      echo "Could not find requested version of st2chatops."
+      sudo repoquery --nvr --show-duplicates st2chatops
+      exit 3
+    fi
+    ST2CHATOPS_PKG=${ST2CHATOPS_VER}
+
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
-    echo "st2${ST2_PKG_VERSION}"
-    echo "st2mistral${ST2MISTRAL_PKG_VERSION}"
-    echo "st2web${ST2WEB_PKG_VERSION}"
+    echo "${ST2_PKG}"
+    echo "${ST2MISTRAL_PKG}"
+    echo "${ST2WEB_PKG}"
+    echo "${ST2CHATOPS_PKG}"
     echo "##########################################################"
   fi
 }
+
 
 check_libffi_devel() {
   local message= no_libffi_devel=
@@ -172,9 +195,11 @@ install_st2_dependencies() {
 
 install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.rpm.sh | sudo bash
-  sudo yum -y install st2${ST2_PKG_VERSION}
-  sudo st2ctl reload
+  STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
+  sudo yum -y install ${ST2_PKG}
   sudo st2ctl start
+  sleep 5
+  sudo st2ctl reload --register-all
 }
 
 configure_st2_user() {
@@ -215,6 +240,48 @@ configure_st2_authentication() {
   sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
 
   sudo st2ctl restart-component st2api
+  sudo st2ctl restart-component st2stream
+}
+
+configure_st2_cli_config() {
+  # Configure CLI config (write credentials for the root user and user which ran the script)
+  ROOT_USER="root"
+  CURRENT_USER=$(whoami)
+
+  ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
+  ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
+
+  CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
+  CURRENT_USER_CLI_CONFIG_PATH="${CURRENT_USER_CLI_CONFIG_DIRECTORY}/config"
+
+  if [ ! -d ${ROOT_USER_CLI_CONFIG_DIRECTORY} ]; then
+    sudo mkdir -p ${ROOT_USER_CLI_CONFIG_DIRECTORY}
+  fi
+
+  sudo sh -c "cat <<EOT > ${ROOT_USER_CLI_CONFIG_PATH}
+[credentials]
+username = ${USERNAME}
+password = ${PASSWORD}
+EOT"
+
+  # Write config for root user
+  if [ "${CURRENT_USER}" == "${ROOT_USER}" ]; then
+      return
+  fi
+
+  # Write config for current user (in case current user != root)
+  if [ ! -d ${CURRENT_USER_CLI_CONFIG_DIRECTORY} ]; then
+    sudo mkdir -p ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
+  fi
+
+  sudo sh -c "cat <<EOT > ${CURRENT_USER_CLI_CONFIG_PATH}
+[credentials]
+username = ${USERNAME}
+password = ${PASSWORD}
+EOT"
+
+  # Fix the permissions
+  sudo chown -R ${CURRENT_USER}:${CURRENT_USER} ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
 }
 
 verify_st2() {
@@ -271,7 +338,7 @@ EHD
 
 install_st2mistral() {
   # install mistral
-  sudo yum -y install st2mistral
+  sudo yum -y install ${ST2MISTRAL_PKG}
 
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
@@ -283,7 +350,7 @@ install_st2mistral() {
 }
 
 install_st2web() {
-  # Add key and repo for the lastest stable nginx
+  # Add key and repo for the latest stable nginx
   sudo rpm --import http://nginx.org/keys/nginx_signing.key
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/nginx.repo
 [nginx]
@@ -294,7 +361,7 @@ enabled=1
 EOT"
 
   # Install st2web and nginx
-  sudo yum install -y st2web nginx
+  sudo yum install -y ${ST2WEB_PKG} nginx
 
   # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
   sudo mkdir -p /etc/ssl/st2
@@ -318,13 +385,17 @@ install_st2chatops() {
   sudo yum install -y nodejs
 
   # Install st2chatops
-  sudo yum install -y st2chatops
+  sudo yum install -y ${ST2CHATOPS_PKG}
 }
 
 configure_st2chatops() {
-  # Set credentials
-  sudo sed -i -r "s/^(export ST2_AUTH_USERNAME.).*/\1$USERNAME/" /opt/stackstorm/chatops/st2chatops.env
-  sudo sed -i -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$PASSWORD/" /opt/stackstorm/chatops/st2chatops.env
+  # set API keys. This should work since CLI is configuered already.
+  ST2_API_KEY=`st2 apikey create -k`
+  sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
+
+  sudo sed -i -r "s/^(export ST2_AUTH_URL.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_USERNAME.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
+  sudo sed -i -r "s/^(export ST2_AUTH_PASSWORD.).*/# &/" /opt/stackstorm/chatops/st2chatops.env
 
   # Setup adapter
   if [ "$HUBOT_ADAPTER"="slack" ] && [ ! -z "$HUBOT_SLACK_TOKEN" ]
@@ -380,11 +451,13 @@ trap 'fail' EXIT
 STEP='Parse arguments' && setup_args $@
 STEP='Check libffi-devel availability' && check_libffi_devel
 STEP='Adjust SELinux policies' && adjust_selinux_policies
+STEP='Install repoquery tool' && install_yum_utils
 
 STEP="Install st2 dependencies" && install_st2_dependencies
 STEP="Install st2" && install_st2
 STEP="Configure st2 user" && configure_st2_user
 STEP="Configure st2 auth" && configure_st2_authentication
+STEP="Configure st2 CLI config" && configure_st2_cli_config
 STEP="Verify st2" && verify_st2
 
 STEP="Install mistral dependencies" && install_st2mistral_depdendencies


### PR DESCRIPTION
Upgrade testing workflows require v1.4 specific scripts to actually work. Before this PR, EL7 scripts were broken. We just decided to roll forward the scripts to pick up fixes from master. 