### PR TITLE
Update installer scripts to install latest version of MongoDB (3.2) by default

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -11,7 +11,9 @@ REPO_TYPE=''
 ST2_PKG_VERSION=''
 USERNAME=''
 PASSWORD=''
-BRANCH='master'
+
+# Note: This variable needs to default to a branch of the latest stable release
+BRANCH='v1.5'
 
 setup_args() {
   for i in "$@"
@@ -73,6 +75,15 @@ setup_args() {
 }
 
 setup_args $@
+
+# Note: If either --unstable or --staging flag is provided we default branch to master
+if [[ "$RELEASE" == 'unstable' ]]; then
+  BRANCH="master"
+fi
+
+if [[ "$REPO_TYPE" == 'staging' ]]; then
+  BRANCH="master"
+fi
 
 get_version_branch() {
   if [[ "$RELEASE" == 'stable' ]]; then

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -94,11 +94,15 @@ setup_args() {
 
 install_st2_dependencies() {
   sudo apt-get update
-  sudo apt-get install -y curl rabbitmq-server
+
+  # Note: gnupg-curl is needed to be able to use https transport when fetching keys
+  sudo apt-get install -y gnupg-curl
+  sudo apt-get install -y curl
+  sudo apt-get install -y rabbitmq-server
 }
 
 install_mongodb() {
-    # Add key and repo for the latest stable MongoDB (3.x)
+    # Add key and repo for the latest stable MongoDB (3.2)
   sudo apt-key adv --fetch-keys https://www.mongodb.org/static/pgp/server-3.2.asc
   sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/mongodb-org-3.2.list
 deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -94,7 +94,18 @@ setup_args() {
 
 install_st2_dependencies() {
   sudo apt-get update
-  sudo apt-get install -y curl mongodb-server rabbitmq-server
+  sudo apt-get install -y curl rabbitmq-server
+}
+
+install_mongodb() {
+    # Add key and repo for the latest stable MongoDB (3.x)
+  sudo apt-key adv --fetch-keys https://www.mongodb.org/static/pgp/server-3.2.asc
+  sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/mongodb-org-3.2.list
+deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse
+EOT"
+
+  sudo apt-get update
+  sudo apt-get install -y mongodb-org
 }
 
 get_full_pkg_versions() {
@@ -382,6 +393,7 @@ ok_message() {
 trap 'fail' EXIT
 STEP="Setup args" && setup_args $@
 STEP="Install st2 dependencies" && install_st2_dependencies
+STEP="Install st2 dependencies (MongoDB)" && install_mongodb
 STEP="Install st2" && install_st2
 STEP="Configure st2 user" && configure_st2_user
 STEP="Configure st2 auth" && configure_st2_authentication

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -186,11 +186,26 @@ install_st2_dependencies() {
   if [[ -z "$is_epel_installed" ]]; then
     sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
   fi
-  sudo yum -y install curl mongodb-server rabbitmq-server
-  sudo service mongod start
+  sudo yum -y install curl -server rabbitmq-server
   sudo service rabbitmq-server start
-  sudo chkconfig mongod on
   sudo chkconfig rabbitmq-server on
+}
+
+install_mongodb() {
+  # Add key and repo for the latest stable MongoDB (3.2)
+  sudo rpm --import https://www.mongodb.org/static/pgp/server-3.2.asc
+  sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
+[mongodb-org-3.2]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
+EOT"
+
+  sudo yum -y install mongodb-org
+  sudo service mongod start
+  sudo chkconfig mongod on
 }
 
 install_st2() {
@@ -454,6 +469,7 @@ STEP='Adjust SELinux policies' && adjust_selinux_policies
 STEP='Install repoquery tool' && install_yum_utils
 
 STEP="Install st2 dependencies" && install_st2_dependencies
+STEP="Install st2 dependencies (MongoDB)" && install_mongodb
 STEP="Install st2" && install_st2
 STEP="Configure st2 user" && configure_st2_user
 STEP="Configure st2 auth" && configure_st2_authentication

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -186,7 +186,7 @@ install_st2_dependencies() {
   if [[ -z "$is_epel_installed" ]]; then
     sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
   fi
-  sudo yum -y install curl -server rabbitmq-server
+  sudo yum -y install curl rabbitmq-server
   sudo service rabbitmq-server start
   sudo chkconfig rabbitmq-server on
 }

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -197,7 +197,7 @@ install_mongodb() {
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
 [mongodb-org-3.2]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/6Server/mongodb-org/3.2/x86_64/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -169,9 +169,26 @@ install_st2_dependencies() {
   if [[ -z "$is_epel_installed" ]]; then
     sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   fi
-  sudo yum -y install curl mongodb-server rabbitmq-server
-  sudo systemctl start mongod rabbitmq-server
-  sudo systemctl enable mongod rabbitmq-server
+  sudo yum -y install curl rabbitmq-server
+  sudo systemctl start rabbitmq-server
+  sudo systemctl enable rabbitmq-server
+}
+
+install_mongodb() {
+  # Add key and repo for the latest stable MongoDB (3.2)
+  sudo rpm --import https://www.mongodb.org/static/pgp/server-3.2.asc
+  sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
+[mongodb-org-3.2]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
+EOT"
+
+  sudo yum -y install mongodb-org
+  sudo systemctl start mongod
+  sudo systemctl enable mongod
 }
 
 install_st2() {
@@ -427,6 +444,7 @@ STEP='Adjust SELinux policies' && adjust_selinux_policies
 STEP='Install repoquery tool' && install_yum_utils
 
 STEP="Install st2 dependencies" && install_st2_dependencies
+STEP="Install st2 dependencies (MongoDB)" && install_mongodb
 STEP="Install st2" && install_st2
 STEP="Configure st2 user" && configure_st2_user
 STEP="Configure st2 auth" && configure_st2_authentication

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -180,7 +180,7 @@ install_mongodb() {
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
 [mongodb-org-3.2]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/7Server/mongodb-org/3.2/x86_64/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc


### PR DESCRIPTION
This pull request updates our installer scripts to install MongoDb 3.2 by default. Going forward with StackStorm v1.6, MongoDB 3.2 will be our preferred (and only supported) version of MongoDB.

Note: Because of the way our documentation works right now (we don't version installer scripts, we just point to the latest master), this can only be merged after StackStorm v1.6 is released (or when we change / fix versioning).

## TODO

- [x] Manual test on Ubuntu 12.04
- [x] Manual test on RHEL 6
- [x] Manual test on RHEL 7
- [x] Update documentation
- [ ] Update e2e tests to use MongoDB 3.2