### PR TITLE
Revert "Fixes for recent build container changes"

### DIFF
--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -112,25 +112,25 @@ centos7build:
 ## Package testing nodes
 #
 wheezytest:
-  image: stackstorm/packagingtest:wheezy-sshd
+  image: stackstorm/packagingtest:wheezy
   extends:
     file: docker-compose.override.yml
     service: volumes-circle
 
 jessietest:
-  image: stackstorm/packagingtest:jessie-sshd
+  image: stackstorm/packagingtest:jessie
   extends:
     file: docker-compose.override.yml
     service: volumes-circle
 
 trustytest:
-  image: stackstorm/packagingtest:trusty-upstart
+  image: stackstorm/packagingtest:trusty
   extends:
     file: docker-compose.override.yml
     service: volumes-circle
 
 xenialtest:
-  image: stackstorm/packagingtest:xenial-systemd
+  image: stackstorm/packagingtest:xenial
   privileged: true
   extends:
     file: docker-compose.override.yml
@@ -139,13 +139,13 @@ xenialtest:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 centos6test:
-  image: stackstorm/packagingtest:centos6-sshd
+  image: stackstorm/packagingtest:centos6
   extends:
     file: docker-compose.override.yml
     service: volumes-circle
 
 centos7test:
-  image: stackstorm/packagingtest:centos7-systemd
+  image: stackstorm/packagingtest:centos7
   extends:
     file: docker-compose.override.yml
     service: volumes-circle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,25 +130,25 @@ centos7build:
 ## Package testing nodes
 #
 wheezytest:
-  image: stackstorm/packagingtest:wheezy-sshd
+  image: quay.io/dennybaa/droneunit:wheezy-sshd
   extends:
     file: docker-compose.override.yml
     service: volumes-compose
 
 jessietest:
-  image: stackstorm/packagingtest:jessie-sshd
+  image: quay.io/dennybaa/droneunit:jessie-sshd
   extends:
     file: docker-compose.override.yml
     service: volumes-compose
 
 trustytest:
-  image: stackstorm/packagingtest:trusty-upstart
+  image: quay.io/dennybaa/droneunit:trusty-upstart
   extends:
     file: docker-compose.override.yml
     service: volumes-compose
 
 xenialtest:
-  image: stackstorm/packagingtest:xenial-systemd
+  image: stackstorm/packagingtest:xenial
   privileged: true
   extends:
     file: docker-compose.override.yml
@@ -157,13 +157,13 @@ xenialtest:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 centos6test:
-  image: stackstorm/packagingtest:centos6-sshd
+  image: quay.io/dennybaa/droneunit:centos6-sshd
   extends:
     file: docker-compose.override.yml
     service: volumes-compose
 
 centos7test:
-  image: stackstorm/packagingtest:centos7-systemd
+  image: quay.io/dennybaa/droneunit:centos7-systemd
   privileged: true
   extends:
     file: docker-compose.override.yml

--- a/packages/st2/debian/st2actionrunner.service
+++ b/packages/st2/debian/st2actionrunner.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-EnvironmentFile=-/etc/default/st2actionrunner
+EnvironmentFile=-/etc/sysconfig/st2actionrunner
 ExecStart=/bin/bash /opt/stackstorm/st2/bin/runners.sh start
 ExecStop=/bin/bash /opt/stackstorm/st2/bin/runners.sh stop
 RemainAfterExit=true

--- a/packages/st2/debian/st2actionrunner@.service
+++ b/packages/st2/debian/st2actionrunner@.service
@@ -9,7 +9,7 @@ Group=st2packs
 UMask=002
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
 Environment="WORKERID=%i"
-EnvironmentFile=-/etc/default/st2actionrunner
+EnvironmentFile=-/etc/sysconfig/st2actionrunner
 ExecStart=/opt/stackstorm/st2/bin/st2actionrunner $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2api.service
+++ b/packages/st2/debian/st2api.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
-EnvironmentFile=-/etc/default/st2api
+EnvironmentFile=-/etc/sysconfig/st2api
 ExecStart=/opt/stackstorm/st2/bin/gunicorn_pecan /opt/stackstorm/st2/lib/python2.7/site-packages/st2api/gunicorn_config.py $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2auth.service
+++ b/packages/st2/debian/st2auth.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
-EnvironmentFile=-/etc/default/st2auth
+EnvironmentFile=-/etc/sysconfig/st2auth
 ExecStart=/opt/stackstorm/st2/bin/gunicorn_pecan /opt/stackstorm/st2/lib/python2.7/site-packages/st2auth/gunicorn_config.py $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2exporter.service
+++ b/packages/st2/debian/st2exporter.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/default/st2exporter
+EnvironmentFile=-/etc/sysconfig/st2exporter
 ExecStart=/opt/stackstorm/st2/bin/st2exporter $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2garbagecollector.service
+++ b/packages/st2/debian/st2garbagecollector.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/default/st2garbagecollector
+EnvironmentFile=-/etc/sysconfig/st2garbagecollector
 ExecStart=/opt/stackstorm/st2/bin/st2garbagecollector $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2notifier.service
+++ b/packages/st2/debian/st2notifier.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/default/st2notifier
+EnvironmentFile=-/etc/sysconfig/st2notifier
 ExecStart=/opt/stackstorm/st2/bin/st2notifier $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2resultstracker.service
+++ b/packages/st2/debian/st2resultstracker.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/default/st2resultstracker
+EnvironmentFile=-/etc/sysconfig/st2resultstracker
 ExecStart=/opt/stackstorm/st2/bin/st2resultstracker $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2rulesengine.service
+++ b/packages/st2/debian/st2rulesengine.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/default/st2rulesengine
+EnvironmentFile=-/etc/sysconfig/st2rulesengine
 ExecStart=/opt/stackstorm/st2/bin/st2rulesengine $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2sensorcontainer.service
+++ b/packages/st2/debian/st2sensorcontainer.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/default/st2sensorcontainer
+EnvironmentFile=-/etc/sysconfig/st2sensorcontainer
 ExecStart=/opt/stackstorm/st2/bin/st2sensorcontainer $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2stream.service
+++ b/packages/st2/debian/st2stream.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30"
-EnvironmentFile=-/etc/default/st2stream
+EnvironmentFile=-/etc/sysconfig/st2stream
 ExecStart=/opt/stackstorm/st2/bin/gunicorn_pecan /opt/stackstorm/st2/lib/python2.7/site-packages/st2stream/gunicorn_config.py $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true


### PR DESCRIPTION
Reverts StackStorm/st2-packages#328

Build process failing. Probably due to recent mongo changes. Requires more investigation.