### PR TITLE
Refine NodeJS dependency

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -301,9 +301,8 @@ EOT"
 }
 
 install_st2chatops() {
-  # Install Node
+  # Add NodeJS 4 repo
   curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
-  sudo apt-get install -y nodejs
 
   # Install st2chatops
   sudo apt-get install -y st2chatops${ST2CHATOPS_PKG_VERSION}

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -395,9 +395,8 @@ EOT"
 }
 
 install_st2chatops() {
-  # Install Node
+  # Add NodeJS 4 repo
   curl -sL https://rpm.nodesource.com/setup_4.x | sudo -E bash -
-  sudo yum install -y nodejs
 
   # Install st2chatops
   sudo yum install -y ${ST2CHATOPS_PKG}

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -370,9 +370,8 @@ EOT"
 }
 
 install_st2chatops() {
-  # Install Node
+  # Add NodeJS 4 repo
   curl -sL https://rpm.nodesource.com/setup_4.x | sudo -E bash -
-  sudo yum install -y nodejs
 
   # Install st2chatops
   sudo yum install -y ${ST2CHATOPS_PKG}


### PR DESCRIPTION
Since `nodejs >= 4.0` package is now a dependency for `st2chatops` (added in https://github.com/StackStorm/st2chatops/pull/46), there is no need to install `nodejs` package by hand, - just add a correct repository.