### PR TITLE
Use correct environment files for Debian-family systems

### DIFF
--- a/.circle/buildenv_mistral.sh
+++ b/.circle/buildenv_mistral.sh
@@ -32,7 +32,7 @@ mistral_giturl() {
 ST2MISTRAL_GITURL=${ST2MISTRAL_GITURL:-https://github.com/StackStorm/mistral}
 ST2MISTRAL_GITREV=${ST2MISTRAL_GITREV:-$CIRCLE_BRANCH}
 MISTRAL_VERSION=$(fetch_version)
-if [ -z "$CIRCLE_PR_REPONAME" ]; then
+if [ -n "$PACKAGECLOUD_TOKEN" ]; then
   MISTRAL_RELEASE=$(.circle/packagecloud.sh next-revision ${DISTRO} ${MISTRAL_VERSION} st2mistral)
 else
   # is fork

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -42,7 +42,7 @@ ST2PKG_VERSION=$(fetch_version)
 # for Bintray
 #ST2PKG_RELEASE=$(.circle/bintray.sh next-revision ${DISTRO}_staging ${ST2PKG_VERSION} st2)
 # for PackageCloud
-if [ -z "$CIRCLE_PR_REPONAME" ]; then
+if [ -n "$PACKAGECLOUD_TOKEN" ]; then
   ST2PKG_RELEASE=$(.circle/packagecloud.sh next-revision ${DISTRO} ${ST2PKG_VERSION} st2)
 else
   # is fork

--- a/packages/st2/debian/st2actionrunner.service
+++ b/packages/st2/debian/st2actionrunner.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-EnvironmentFile=-/etc/sysconfig/st2actionrunner
+EnvironmentFile=-/etc/default/st2actionrunner
 ExecStart=/bin/bash /opt/stackstorm/st2/bin/runners.sh start
 ExecStop=/bin/bash /opt/stackstorm/st2/bin/runners.sh stop
 RemainAfterExit=true

--- a/packages/st2/debian/st2actionrunner@.service
+++ b/packages/st2/debian/st2actionrunner@.service
@@ -9,7 +9,7 @@ Group=st2packs
 UMask=002
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
 Environment="WORKERID=%i"
-EnvironmentFile=-/etc/sysconfig/st2actionrunner
+EnvironmentFile=-/etc/default/st2actionrunner
 ExecStart=/opt/stackstorm/st2/bin/st2actionrunner $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2api.service
+++ b/packages/st2/debian/st2api.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
-EnvironmentFile=-/etc/sysconfig/st2api
+EnvironmentFile=-/etc/default/st2api
 ExecStart=/opt/stackstorm/st2/bin/gunicorn_pecan /opt/stackstorm/st2/lib/python2.7/site-packages/st2api/gunicorn_config.py $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2auth.service
+++ b/packages/st2/debian/st2auth.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
-EnvironmentFile=-/etc/sysconfig/st2auth
+EnvironmentFile=-/etc/default/st2auth
 ExecStart=/opt/stackstorm/st2/bin/gunicorn_pecan /opt/stackstorm/st2/lib/python2.7/site-packages/st2auth/gunicorn_config.py $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2exporter.service
+++ b/packages/st2/debian/st2exporter.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/sysconfig/st2exporter
+EnvironmentFile=-/etc/default/st2exporter
 ExecStart=/opt/stackstorm/st2/bin/st2exporter $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2garbagecollector.service
+++ b/packages/st2/debian/st2garbagecollector.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/sysconfig/st2garbagecollector
+EnvironmentFile=-/etc/default/st2garbagecollector
 ExecStart=/opt/stackstorm/st2/bin/st2garbagecollector $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2notifier.service
+++ b/packages/st2/debian/st2notifier.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/sysconfig/st2notifier
+EnvironmentFile=-/etc/default/st2notifier
 ExecStart=/opt/stackstorm/st2/bin/st2notifier $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2resultstracker.service
+++ b/packages/st2/debian/st2resultstracker.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/sysconfig/st2resultstracker
+EnvironmentFile=-/etc/default/st2resultstracker
 ExecStart=/opt/stackstorm/st2/bin/st2resultstracker $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2rulesengine.service
+++ b/packages/st2/debian/st2rulesengine.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/sysconfig/st2rulesengine
+EnvironmentFile=-/etc/default/st2rulesengine
 ExecStart=/opt/stackstorm/st2/bin/st2rulesengine $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2sensorcontainer.service
+++ b/packages/st2/debian/st2sensorcontainer.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=--config-file /etc/st2/st2.conf"
-EnvironmentFile=-/etc/sysconfig/st2sensorcontainer
+EnvironmentFile=-/etc/default/st2sensorcontainer
 ExecStart=/opt/stackstorm/st2/bin/st2sensorcontainer $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true

--- a/packages/st2/debian/st2stream.service
+++ b/packages/st2/debian/st2stream.service
@@ -7,7 +7,7 @@ Type=simple
 User=st2
 Group=st2
 Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30"
-EnvironmentFile=-/etc/sysconfig/st2stream
+EnvironmentFile=-/etc/default/st2stream
 ExecStart=/opt/stackstorm/st2/bin/gunicorn_pecan /opt/stackstorm/st2/lib/python2.7/site-packages/st2stream/gunicorn_config.py $DAEMON_ARGS
 TimeoutSec=60
 PrivateTmp=true


### PR DESCRIPTION
As said before https://github.com/StackStorm/st2-packages/pull/326#discussion_r71686505, init configs should use correct files for default environment variables.

Different distributions have different conventions where env should be placed: 
* `/etc/sysconfig` - is used for redhat family OS
* `/etc/default` - is used for debian family OS

This PR fixes it for deb.

----

I saw there were reverts in master https://github.com/StackStorm/st2-packages/pull/329.
Let's include this important fix and change once thing at a time (ENVs in one PR, container changes in another).