### PR TITLE
Disable upstart logging on Ubuntu for st2 services

### DIFF
--- a/packages/st2/debian/st2.st2actionrunner-worker.upstart
+++ b/packages/st2/debian/st2.st2actionrunner-worker.upstart
@@ -3,6 +3,9 @@
 
 description     "StackStorm actionrunner worker task"
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 setuid root
 setgid st2packs
 respawn
@@ -12,7 +15,7 @@ umask 002
 kill timeout 60
 
 instance $WORKERID
- 
+
 script
   NAME=st2actionrunner
   DAEMON_ARGS="--config-file /etc/st2/st2.conf"

--- a/packages/st2/debian/st2.st2actionrunner.upstart
+++ b/packages/st2/debian/st2.st2actionrunner.upstart
@@ -7,6 +7,9 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 # We don't directly invoke runners.sh, rather then use for loop in here.
 # yeap... upstart is weird.
 

--- a/packages/st2/debian/st2.st2api.upstart
+++ b/packages/st2/debian/st2.st2api.upstart
@@ -4,6 +4,9 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 setuid st2
 setgid st2
 respawn

--- a/packages/st2/debian/st2.st2auth.upstart
+++ b/packages/st2/debian/st2.st2auth.upstart
@@ -4,6 +4,9 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 setuid st2
 setgid st2
 respawn

--- a/packages/st2/debian/st2.st2exporter.upstart
+++ b/packages/st2/debian/st2.st2exporter.upstart
@@ -4,6 +4,9 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 setuid st2
 setgid st2
 respawn

--- a/packages/st2/debian/st2.st2garbagecollector.upstart
+++ b/packages/st2/debian/st2.st2garbagecollector.upstart
@@ -4,6 +4,9 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 setuid st2
 setgid st2
 respawn

--- a/packages/st2/debian/st2.st2notifier.upstart
+++ b/packages/st2/debian/st2.st2notifier.upstart
@@ -4,6 +4,9 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 setuid st2
 setgid st2
 respawn

--- a/packages/st2/debian/st2.st2resultstracker.upstart
+++ b/packages/st2/debian/st2.st2resultstracker.upstart
@@ -4,6 +4,9 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 setuid st2
 setgid st2
 respawn

--- a/packages/st2/debian/st2.st2rulesengine.upstart
+++ b/packages/st2/debian/st2.st2rulesengine.upstart
@@ -4,6 +4,9 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 setuid st2
 setgid st2
 respawn

--- a/packages/st2/debian/st2.st2sensorcontainer.upstart
+++ b/packages/st2/debian/st2.st2sensorcontainer.upstart
@@ -4,6 +4,9 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 setuid st2
 setgid st2
 respawn

--- a/packages/st2/debian/st2.st2stream.upstart
+++ b/packages/st2/debian/st2.st2stream.upstart
@@ -4,6 +4,9 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 setuid st2
 setgid st2
 respawn

--- a/packages/st2mistral/debian/mistral-api.upstart
+++ b/packages/st2mistral/debian/mistral-api.upstart
@@ -1,6 +1,9 @@
 description     "Mistral workflow api job"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 # This doesn't start/stop by itself (AND SHOULD NOT!),
 # use mistral job instead.
 start on mistral-api

--- a/packages/st2mistral/debian/mistral-server.upstart
+++ b/packages/st2mistral/debian/mistral-server.upstart
@@ -1,6 +1,9 @@
 description     "Mistral workflow engine and executor job"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
+# Note: We disable upstart logging since the services manage logs themselves
+console none
+
 # This doesn't start/stop by itself (AND SHOULD NOT!),
 # use mistral job instead.
 start on mistral-server


### PR DESCRIPTION
This pull request disables automatic upstart logging for st2 services into `/var/log/upstart`. With newer versions of upstart, default behavior is `console log` (http://upstart.ubuntu.com/cookbook/#console-log).

We had exactly the same issue with old packages which I have fixed, but it looks like we missed this when moving to new packages.

The problem with leaving upstart logging enabled is that we have duplicated logs now and if user doesn't set up logrotate for `/var/log/upstart/` disk space could fill up. This basically means server DDoS...

I noticed this when randomly debugging build server - build server got stuck because disk filled up (https://gist.github.com/Kami/143447694bfbc8d77cbc62fc38120151).

I will cherry pick this into v1.6.0 once I verify everything is working.