### PR TITLE
Added architecture check

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -3,6 +3,7 @@
 BASE_PATH="https://raw.githubusercontent.com/StackStorm/st2-packages"
 BOOTSTRAP_FILE='st2bootstrap.sh'
 
+ARCH=`arch`
 DEBTEST=`lsb_release -a 2> /dev/null | grep Distributor | awk '{print $3}'`
 RHTEST=`cat /etc/redhat-release 2> /dev/null | sed -e "s~\(.*\)release.*~\1~g"`
 VERSION=''
@@ -95,6 +96,11 @@ fi
 
 USERNAME="--user=${USERNAME}"
 PASSWORD="--password=${PASSWORD}"
+
+if [[ "$ARCH" != 'x86_64' ]]; then
+  echo "Unsupported architecture. Please use a 64-bit OS! Aborting!"
+  exit 2
+fi
 
 if [[ -n "$RHTEST" ]]; then
   TYPE="rpms"


### PR DESCRIPTION
Modified bootstrap script to check that system is 64-bit before proceeding with the install.

We document the 64-bit requirement, but people still miss that. This will at least make it fail early if they are using a 32-bit OS