### PR TITLE
Generate datastore encryption key during install inside the install script

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -252,6 +252,20 @@ EOT"
   sudo chown -R ${CURRENT_USER}:${CURRENT_USER} ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
 }
 
+generate_symmetric_crypto_key_for_datastore() {
+  DATASTORE_ENCRYPTION_KEY_PATH="/etc/st2/keys/datastore_key.json"
+
+  sudo mkdir -p /etc/st2/keys/
+  sudo st2-generate-symmetric-crypto-key --key-path ${DATASTORE_ENCRYPTION_KEY_PATH}
+
+  # Make sure only st2 user can read the file
+  sudo chgrp st2 /etc/st2/keys/datastore_key.json
+  sudo chmod o-r /etc/st2/keys/datastore_key.json
+
+  # set path to the key file in the config
+  sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
+}
+
 install_st2mistral_depdendencies() {
   sudo apt-get install -y postgresql
 
@@ -401,6 +415,7 @@ STEP="Install st2" && install_st2
 STEP="Configure st2 user" && configure_st2_user
 STEP="Configure st2 auth" && configure_st2_authentication
 STEP="Configure st2 CLI config" && configure_st2_cli_config
+STEP="Generate symmetric crypto key for datastore" && generate_symmetric_crypto_key_for_datastore
 STEP="Verify st2" && verify_st2
 
 STEP="Install mistral dependencies" && install_st2mistral_depdendencies

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -261,6 +261,8 @@ generate_symmetric_crypto_key_for_datastore() {
 
   # Make sure only st2 user can read the file
   sudo usermod -a -G st2 st2
+  sudo chgrp st2 ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
+  sudo chmod o-r ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
   sudo chgrp st2 ${DATASTORE_ENCRYPTION_KEY_PATH}
   sudo chmod o-r ${DATASTORE_ENCRYPTION_KEY_PATH}
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -268,6 +268,8 @@ generate_symmetric_crypto_key_for_datastore() {
 
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
+
+  sudo st2ctl restart-component st2api
 }
 
 install_st2mistral_depdendencies() {

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -253,14 +253,16 @@ EOT"
 }
 
 generate_symmetric_crypto_key_for_datastore() {
-  DATASTORE_ENCRYPTION_KEY_PATH="/etc/st2/keys/datastore_key.json"
+  DATASTORE_ENCRYPTION_KEYS_DIRECTORY="/etc/st2/keys"
+  DATASTORE_ENCRYPTION_KEY_PATH="${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}/datastore_key.json"
 
-  sudo mkdir -p /etc/st2/keys/
+  sudo mkdir -p ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
   sudo st2-generate-symmetric-crypto-key --key-path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # Make sure only st2 user can read the file
-  sudo chgrp st2 /etc/st2/keys/datastore_key.json
-  sudo chmod o-r /etc/st2/keys/datastore_key.json
+  sudo usermod -a -G st2 st2
+  sudo chgrp st2 ${DATASTORE_ENCRYPTION_KEY_PATH}
+  sudo chmod o-r ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -299,6 +299,26 @@ EOT"
   sudo chown -R ${CURRENT_USER}:${CURRENT_USER} ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
 }
 
+generate_symmetric_crypto_key_for_datastore() {
+  DATASTORE_ENCRYPTION_KEYS_DIRECTORY="/etc/st2/keys"
+  DATASTORE_ENCRYPTION_KEY_PATH="${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}/datastore_key.json"
+
+  sudo mkdir -p ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
+  sudo st2-generate-symmetric-crypto-key --key-path ${DATASTORE_ENCRYPTION_KEY_PATH}
+
+  # Make sure only st2 user can read the file
+  sudo usermod -a -G st2 st2
+  sudo chgrp st2 ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
+  sudo chmod o-r ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
+  sudo chgrp st2 ${DATASTORE_ENCRYPTION_KEY_PATH}
+  sudo chmod o-r ${DATASTORE_ENCRYPTION_KEY_PATH}
+
+  # set path to the key file in the config
+  sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
+
+  sudo st2ctl restart-component st2api
+}
+
 verify_st2() {
   st2 --version
   st2 -h
@@ -473,6 +493,7 @@ STEP="Install st2" && install_st2
 STEP="Configure st2 user" && configure_st2_user
 STEP="Configure st2 auth" && configure_st2_authentication
 STEP="Configure st2 CLI config" && configure_st2_cli_config
+STEP="Generate symmetric crypto key for datastore" && generate_symmetric_crypto_key_for_datastore
 STEP="Verify st2" && verify_st2
 
 STEP="Install mistral dependencies" && install_st2mistral_depdendencies

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -322,6 +322,8 @@ generate_symmetric_crypto_key_for_datastore() {
 
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
+
+  sudo st2ctl restart-component st2api
 }
 install_st2mistral_depdendencies() {
   sudo yum -y install postgresql-server postgresql-contrib postgresql-devel


### PR DESCRIPTION
This script generates symmetric key used for encrypting / decrypting secret values in the datastore inside the install script.

Install script is there to make it easy and fast to get up and running and playing with StackStorm. People who want more control and for production deployments, people should use packages directly and manage rest of the process themselves.

This of course also includes generating an encryption key. I will document this in the docs and make it very clear that for production deployments people should generate the key themselves. People of course also can generate a new key after the install script has finished if they wish so.