### PR TITLE
Fix outdated package lists during install script

### DIFF
--- a/scripts/install_os_packages.sh
+++ b/scripts/install_os_packages.sh
@@ -10,8 +10,14 @@ version_delemiter() {
   [ "$(platform)" = "deb" ] && echo '_' || echo '-'
 }
 
-install_rpm() { sudo yum -y install $(lookup_fullnames $@); }
+install_rpm() {
+  sudo yum -y update
+  sudo yum -y install $(lookup_fullnames $@);
+}
+
 install_deb() {
+  sudo apt-get -y update
+
   for fpath in $(lookup_fullnames $@); do
     gdebi -qn "$fpath"
   done


### PR DESCRIPTION
The image has outdated package lists and causes install of dependencies to fail. Add update prior to install.