### PR TITLE
Remove the st2actionrunner worker from the post section of rpm spec

### DIFF
--- a/packages/st2/rpm/st2.spec
+++ b/packages/st2/rpm/st2.spec
@@ -49,7 +49,7 @@ Conflicts: st2common
   %include rpm/preinst_script.spec
 
 %post
-  %service_post st2actionrunner %{worker_name} st2api st2stream st2auth st2notifier
+  %service_post st2actionrunner st2api st2stream st2auth st2notifier
   %service_post st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
 
 %preun


### PR DESCRIPTION
The worker is started by the main st2actionrunner service and the @ sign is causing systemctl operations to fail.