### PR TITLE
Dependencies requirements for RabbitMQ and MongoDB

### DIFF
--- a/packages/st2/debian/st2.st2actionrunner.upstart
+++ b/packages/st2/debian/st2.st2actionrunner.upstart
@@ -4,7 +4,7 @@
 description     "StackStorm actionrunner task"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on filesystem and net-device-up IFACE!=lo
+start on rabbitmq-server-running and started mongodb filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
 # Note: We disable upstart logging since the services manage logs themselves

--- a/packages/st2/debian/st2.st2api.upstart
+++ b/packages/st2/debian/st2.st2api.upstart
@@ -1,7 +1,7 @@
 description     "StackStorm st2api service"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on filesystem and net-device-up IFACE!=lo
+start on rabbitmq-server-running and started mongodb filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
 # Note: We disable upstart logging since the services manage logs themselves

--- a/packages/st2/debian/st2.st2auth.upstart
+++ b/packages/st2/debian/st2.st2auth.upstart
@@ -1,7 +1,7 @@
 description     "StackStorm st2auth service"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on filesystem and net-device-up IFACE!=lo
+start on rabbitmq-server-running and started mongodb filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
 # Note: We disable upstart logging since the services manage logs themselves

--- a/packages/st2/debian/st2.st2exporter.upstart
+++ b/packages/st2/debian/st2.st2exporter.upstart
@@ -1,7 +1,7 @@
 description     "StackStorm st2exporter service"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on filesystem and net-device-up IFACE!=lo
+start on rabbitmq-server-running and started mongodb filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
 # Note: We disable upstart logging since the services manage logs themselves

--- a/packages/st2/debian/st2.st2garbagecollector.upstart
+++ b/packages/st2/debian/st2.st2garbagecollector.upstart
@@ -1,7 +1,7 @@
 description     "StackStorm st2garbagecollector service"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on filesystem and net-device-up IFACE!=lo
+start on rabbitmq-server-running and started mongodb filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
 # Note: We disable upstart logging since the services manage logs themselves

--- a/packages/st2/debian/st2.st2notifier.upstart
+++ b/packages/st2/debian/st2.st2notifier.upstart
@@ -1,7 +1,7 @@
 description     "StackStorm st2notifier service"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on filesystem and net-device-up IFACE!=lo
+start on rabbitmq-server-running and started mongodb filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
 # Note: We disable upstart logging since the services manage logs themselves

--- a/packages/st2/debian/st2.st2resultstracker.upstart
+++ b/packages/st2/debian/st2.st2resultstracker.upstart
@@ -1,7 +1,7 @@
 description     "StackStorm st2resultstracker service"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on filesystem and net-device-up IFACE!=lo
+start on rabbitmq-server-running and started mongodb filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
 # Note: We disable upstart logging since the services manage logs themselves

--- a/packages/st2/debian/st2.st2rulesengine.upstart
+++ b/packages/st2/debian/st2.st2rulesengine.upstart
@@ -1,7 +1,7 @@
 description     "StackStorm st2rulesengine service"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on filesystem and net-device-up IFACE!=lo
+start on rabbitmq-server-running and started mongodb filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
 # Note: We disable upstart logging since the services manage logs themselves

--- a/packages/st2/debian/st2.st2sensorcontainer.upstart
+++ b/packages/st2/debian/st2.st2sensorcontainer.upstart
@@ -1,7 +1,7 @@
 description     "StackStorm st2sensorcontainer service"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on filesystem and net-device-up IFACE!=lo
+start on rabbitmq-server-running and started mongodb filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
 # Note: We disable upstart logging since the services manage logs themselves

--- a/packages/st2/debian/st2.st2stream.upstart
+++ b/packages/st2/debian/st2.st2stream.upstart
@@ -1,7 +1,7 @@
 description     "StackStorm st2stream service"
 author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
-start on filesystem and net-device-up IFACE!=lo
+start on rabbitmq-server-running and started mongodb filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
 
 # Note: We disable upstart logging since the services manage logs themselves

--- a/packages/st2/debian/st2actionrunner.service
+++ b/packages/st2/debian/st2actionrunner.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2actionrunner
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=oneshot

--- a/packages/st2/debian/st2actionrunner@.service
+++ b/packages/st2/debian/st2actionrunner@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2actionrunner
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/debian/st2api.service
+++ b/packages/st2/debian/st2api.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2api
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/debian/st2auth.service
+++ b/packages/st2/debian/st2auth.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2auth
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/debian/st2exporter.service
+++ b/packages/st2/debian/st2exporter.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2exporter
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/debian/st2garbagecollector.service
+++ b/packages/st2/debian/st2garbagecollector.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2garbagecollector
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/debian/st2notifier.service
+++ b/packages/st2/debian/st2notifier.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2notifier
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/debian/st2resultstracker.service
+++ b/packages/st2/debian/st2resultstracker.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2resultstracker
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/debian/st2rulesengine.service
+++ b/packages/st2/debian/st2rulesengine.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2rulesengine
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/debian/st2sensorcontainer.service
+++ b/packages/st2/debian/st2sensorcontainer.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2sensorcontainer
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/debian/st2stream.service
+++ b/packages/st2/debian/st2stream.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2stream
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2actionrunner.service
+++ b/packages/st2/rpm/st2actionrunner.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2actionrunner
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=oneshot

--- a/packages/st2/rpm/st2actionrunner@.service
+++ b/packages/st2/rpm/st2actionrunner@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2actionrunner
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2api.service
+++ b/packages/st2/rpm/st2api.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2api
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2auth.service
+++ b/packages/st2/rpm/st2auth.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2auth
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2exporter.service
+++ b/packages/st2/rpm/st2exporter.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2exporter
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2garbagecollector.service
+++ b/packages/st2/rpm/st2garbagecollector.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2garbagecollector
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2notifier.service
+++ b/packages/st2/rpm/st2notifier.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2notifier
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2resultstracker.service
+++ b/packages/st2/rpm/st2resultstracker.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2resultstracker
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2rulesengine.service
+++ b/packages/st2/rpm/st2rulesengine.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2rulesengine
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2sensorcontainer.service
+++ b/packages/st2/rpm/st2sensorcontainer.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2sensorcontainer
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2stream.service
+++ b/packages/st2/rpm/st2stream.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2stream
-After=network.target
+After=rabbitmq-server.service
+After=mongod.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
This PR adds dependencies to upstart and systemd service definitions. The change requires RabbitMQ and MongoDB be up prior to starting the service. 
