### PR TITLE
Fix escape of $ in el7 bootstrap

### DIFF
--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -180,7 +180,7 @@ install_mongodb() {
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
 [mongodb-org-3.2]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/\$releasever/mongodb-org/3.2/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/\\\$releasever/mongodb-org/3.2/x86_64/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc


### PR DESCRIPTION
Since the cat is nested, the back slash needs to be escaped twice.