### PR TITLE
Remove default ST2_GITREV from circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,6 @@ machine:
     DISTROS: "wheezy jessie trusty xenial el6 el7"
     NOTESTS: "xenial el7"
     ST2_GITURL: https://github.com/StackStorm/st2
-    ST2_GITREV: master
     ST2MISTRAL_GITREV: master
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     ST2_PACKAGES: "st2 st2mistral"


### PR DESCRIPTION
It prevents env variable to be overloaded during manual builds and gets substituted later in scripts with $CIRCLE_BRANCH anyway.
