### PR TITLE
Change python-mistralclient in requirements.txt

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -69,5 +69,11 @@ inject-deps: .stamp-inject-deps
 	echo "$$INJECT_DEPS" >> requirements.txt
 	grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
 	grep -q 'psycopg2' requirements.txt || echo "psycopg2" >> requirements.txt
+	grep -q 'kombu' requirements.txt || echo "kombu>=3.0.0,<4.0.0" >> requirements.txt
 	grep -q 'amqp' requirements.txt || echo "amqp>=1.4.0,<2.0.0" >> requirements.txt
+
+ifneq (,$(findstring dev,$(MISTRAL_VERSION)))
+	sed -i "s/^python-mistralclient.*/git+https:\/\/github.com\/StackStorm\/python-mistralclient.git@st2-$(MISTRAL_VERSION)\#egg=python-mistralclient/g" requirements.txt
+endif
+
 	touch $@


### PR DESCRIPTION
There is a version conflict between OpenStack python-mistralclient and StackStorm fork. This patch changes the python-mistralclient in requirements.txt to use the StackStorm fork on make.