### PR TITLE
Workaround kombu and amqp dependencies in st2mistral

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -69,5 +69,6 @@ inject-deps: .stamp-inject-deps
 	echo "$$INJECT_DEPS" >> requirements.txt
 	grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
 	grep -q 'psycopg2' requirements.txt || echo "psycopg2" >> requirements.txt
+	grep -q 'kombu' requirements.txt || echo "kombu>=3.0.0,<4.0.0" >> requirements.txt
 	grep -q 'amqp' requirements.txt || echo "amqp>=1.4.0,<2.0.0" >> requirements.txt
 	touch $@


### PR DESCRIPTION
The oslo.messaging dependency has requirements kombu>=3.0.0 which installs kombu 4.0.0. Some other dependencies in this version of mistral require amqp 1.4.9. But kombu 4.0.0 requires a higher version of amqp. This patch pins the kombu dependency to kombu>=3.0.0,<4.0.0 so it won't conflict with amqp requirement.