### PR TITLE
Fix user's group creation for rpm

### DIFF
--- a/packages/st2/rpm/preinst_script.spec
+++ b/packages/st2/rpm/preinst_script.spec
@@ -17,7 +17,7 @@ EHD
 create_users() {
   # create st2 user (services user)
   (id $ST2_USER 1>/dev/null 2>&1) ||
-    adduser --no-create-home --system $ST2_USER
+    adduser --no-create-home --system --user-group $ST2_USER
 
   # make st2 member of st2packs group
   (getent group $PACKS_GROUP 1>/dev/null 2>&1) || groupadd -r $PACKS_GROUP

--- a/packages/st2mistral/rpm/st2mistral.spec
+++ b/packages/st2mistral/rpm/st2mistral.spec
@@ -42,7 +42,7 @@ Summary: Mistral workflow service
   rm -rf %{buildroot}
 
 %pre
-  adduser --no-create-home --system %{svc_user} 2>/dev/null
+  adduser --no-create-home --system --user-group %{svc_user} 2>/dev/null
   exit 0
 
 %post


### PR DESCRIPTION
Address #361 bug

Specify `--user-group` flag for `adduser`, so the group with the same name is created for sure.

If not specified, the default group defined by `USERS_GID` in the configuration file `/etc/adduser.conf` might be created, instead of `st2` group.

> Apparently, the logic is already included in `deb` packages ([via `--group` flag](https://github.com/StackStorm/st2-packages/blob/49f3b45deb02f68aeb8ff301176602c674e7b890/packages/st2/debian/preinst#L35)), so it might be oversight in `rpm`.