### PR TITLE
Symlink new CLI tools / binaries into usr/local/bin

### DIFF
--- a/packages/st2/debian/st2.links
+++ b/packages/st2/debian/st2.links
@@ -8,6 +8,6 @@ opt/stackstorm/st2/bin/st2-bootstrap-rmq usr/bin/st2-bootstrap-rmq
 opt/stackstorm/st2/bin/st2-submit-debug-info usr/bin/st2-submit-debug-info
 opt/stackstorm/st2/bin/st2-generate-symmetric-crypto-key usr/bin/st2-generate-symmetric-crypto-key
 opt/stackstorm/st2/bin/st2-self-check usr/bin/st2-self-check
-opt/stackstorm/st2/bin/st2-validate-pack-config /bin/st2-validate-pack-config
-opt/stackstorm/st2/bin/st2-check-license /bin/st2-check-license
+opt/stackstorm/st2/bin/st2-validate-pack-config usr/bin/st2-validate-pack-config
+opt/stackstorm/st2/bin/st2-check-license usr/bin/st2-check-license
 opt/stackstorm/st2/bin/st2ctl usr/bin/st2ctl

--- a/packages/st2/debian/st2.links
+++ b/packages/st2/debian/st2.links
@@ -8,4 +8,6 @@ opt/stackstorm/st2/bin/st2-bootstrap-rmq usr/bin/st2-bootstrap-rmq
 opt/stackstorm/st2/bin/st2-submit-debug-info usr/bin/st2-submit-debug-info
 opt/stackstorm/st2/bin/st2-generate-symmetric-crypto-key usr/bin/st2-generate-symmetric-crypto-key
 opt/stackstorm/st2/bin/st2-self-check usr/bin/st2-self-check
+opt/stackstorm/st2/bin/st2-validate-pack-config /bin/st2-validate-pack-config
+opt/stackstorm/st2/bin/st2-check-license /bin/st2-check-license
 opt/stackstorm/st2/bin/st2ctl usr/bin/st2ctl

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -65,12 +65,12 @@ class ST2Spec
     },
 
     package_has_binaries: {
-      st2common: %w(st2-bootstrap-rmq st2-register-content st2-self-check st2ctl),
+      st2common: %w(st2-bootstrap-rmq st2-register-content st2-self-check st2ctl st2-validate-pack-config st2-check-license),
       st2reactor: %w(st2-rule-tester st2-trigger-refire),
       st2client: %w(st2),
       st2debug: %w(st2-submit-debug-info),
       st2: %w(st2-bootstrap-rmq st2-register-content st2-rule-tester
-              st2-apply-rbac-definitions st2-trigger-refire st2 st2-self-check st2ctl
+              st2-apply-rbac-definitions st2-trigger-refire st2 st2-self-check st2-validate-pack-config st2-check-license st2ctl
               st2-generate-symmetric-crypto-key st2-submit-debug-info),
       mistral: %w(mistral)
     },

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -160,12 +160,11 @@ shared_examples 'script or binary' do
   if described_class.content.match(shebang)
     # Note: We skip /usr/bin/env lines
     interpreter_path = Regexp.last_match[:interpreter]
-    if Regexp.last_match[:interpreter].start_with?("/usr/bin/env")
-        return
-    end
+    if not Regexp.last_match[:interpreter].start_with?("/usr/bin/env")
 
-    describe file(interpreter_path) do
-      it { is_expected.to be_file & be_executable }
+      describe file(interpreter_path) do
+        it { is_expected.to be_file & be_executable }
+      end
     end
   end
 end

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -158,7 +158,13 @@ shared_examples 'script or binary' do
 
   shebang = /^#!(?<interpreter>.*?)$/m
   if described_class.content.match(shebang)
-    describe file(Regexp.last_match[:interpreter]) do
+    # Note: We skip /usr/bin/env lines
+    interpreter_path = Regexp.last_match[:interpreter]
+    if Regexp.last_match[:interpreter].start_with?("/usr/bin/env")
+        return
+    end
+
+    describe file(interpreter_path) do
       it { is_expected.to be_file & be_executable }
     end
   end


### PR DESCRIPTION
Packages change for https://github.com/StackStorm/st2/pull/3033.

I also noticed we forgot to do that for `st2-check-license` binary so I also did it here.