### PR TITLE
Retry some commands when failed

### DIFF
--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -30,6 +30,10 @@ else
 	DEB_DISTRO := $(shell lsb_release -cs)
 endif
 
+# Makefile function to retry the failed command 'N' times
+# Example: $(call retry,3,some_script.sh)
+retry = $(2) $(foreach t,$(shell seq 1 ${1}),|| (echo -e "\033[33m Failed ($$?): '$(2)'\n Retrying $t ... \033[0m"; $(2)))
+
 .PHONY: all install wheelhouse
 all: install
 
@@ -77,7 +81,7 @@ endif
 wheelhouse: .stamp-wheelhouse
 .stamp-wheelhouse: | populate_version requirements inject-deps
 	cat requirements.txt
-	pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt
+	$(call retry,2,pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt)
 	touch $@
 
 # Note: We want to dynamically inject "st2client" dependency. This way we can

--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -31,6 +31,7 @@ else
 endif
 
 # Makefile function to retry the failed command 'N' times
+# Make sure you use it for nothing but networking stuff (think about race conditons)
 # Example: $(call retry,3,some_script.sh)
 retry = $(2) $(foreach t,$(shell seq 1 ${1}),|| (echo -e "\033[33m Failed ($$?): '$(2)'\n Retrying $t ... \033[0m"; $(2)))
 
@@ -81,7 +82,8 @@ endif
 wheelhouse: .stamp-wheelhouse
 .stamp-wheelhouse: | populate_version requirements inject-deps
 	cat requirements.txt
-	$(call retry,2,pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt)
+	pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt || \
+		pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt
 	touch $@
 
 # Note: We want to dynamically inject "st2client" dependency. This way we can

--- a/packages/st2/component.makefile
+++ b/packages/st2/component.makefile
@@ -22,6 +22,10 @@ else
 	REDHAT := 1
 endif
 
+# Makefile function to retry the failed command 'N' times
+# Example: $(call retry,3,some_script.sh)
+retry = $(2) $(foreach t,$(shell seq 1 ${1}),|| (echo -e "\033[33m Failed ($$?): '$(2)'\n Retrying $t ... \033[0m"; $(2)))
+
 .PHONY: populate_version requirements wheelhouse bdist_wheel
 all: populate_version requirements bdist_wheel
 
@@ -40,13 +44,13 @@ wheelhouse: .stamp-wheelhouse
 .stamp-wheelhouse: | populate_version requirements
 	# Install wheels into shared location
 	cat requirements.txt
-	pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt
+	$(call retry,2,pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt)
 	touch $@
 
 bdist_wheel: .stamp-bdist_wheel
 .stamp-bdist_wheel: | populate_version requirements inject-deps
 	cat requirements.txt
-	python setup.py bdist_wheel -d $(WHEELDIR)
+	$(call retry,1,python setup.py bdist_wheel -d $(WHEELDIR))
 	touch $@
 
 # Note: We want to dynamically inject "st2client" dependency. This way we can

--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -24,10 +24,6 @@ else
 	REDHAT := 1
 endif
 
-# Makefile function to retry the failed command 'N' times
-# Example: $(call retry,3,some_script.sh)
-retry = $(2) $(foreach t,$(shell seq 1 ${1}),|| (echo -e "\033[33m Failed ($$?): '$(2)'\n Retrying $t ... \033[0m"; $(2)))
-
 all: install
 .PHONY: all install changelog pre_install post_install
 
@@ -52,19 +48,22 @@ populate_version: .stamp-populate_version
 .stamp-populate_version:
 	sed -i "/^pbr.*/d" requirements.txt
 	sed -i "s/setup_requires=\[.*\]/setup_requires=\['pbr'\]/" setup.py
-	$(call retry,1,pip install $(PBR_GITURL))
+	pip install $(PBR_GITURL) || \
+		pip install $(PBR_GITURL)
 	touch $@
 
 wheelhouse: .stamp-wheelhouse
 .stamp-wheelhouse: | populate_version inject-deps bdist_wheel
 	# Install wheels into shared location
-	$(call retry,2,pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt)
+	pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt || \
+		pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt
 	touch $@
 
 bdist_wheel: .stamp-bdist_wheel
 .stamp-bdist_wheel: | populate_version
 	# python setup.py bdist_wheel -d $(WHEELDIR)
-	$(call retry,2,pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt)
+	pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt || \
+		pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt
 	touch $@
 
 # We need to create bdist, before mangling requirements and running pip,

--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -24,6 +24,10 @@ else
 	REDHAT := 1
 endif
 
+# Makefile function to retry the failed command 'N' times
+# Example: $(call retry,3,some_script.sh)
+retry = $(2) $(foreach t,$(shell seq 1 ${1}),|| (echo -e "\033[33m Failed ($$?): '$(2)'\n Retrying $t ... \033[0m"; $(2)))
+
 all: install
 .PHONY: all install changelog pre_install post_install
 
@@ -48,19 +52,19 @@ populate_version: .stamp-populate_version
 .stamp-populate_version:
 	sed -i "/^pbr.*/d" requirements.txt
 	sed -i "s/setup_requires=\[.*\]/setup_requires=\['pbr'\]/" setup.py
-	pip install $(PBR_GITURL)
+	$(call retry,1,pip install $(PBR_GITURL))
 	touch $@
 
 wheelhouse: .stamp-wheelhouse
 .stamp-wheelhouse: | populate_version inject-deps bdist_wheel
 	# Install wheels into shared location
-	pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt
+	$(call retry,2,pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt)
 	touch $@
 
 bdist_wheel: .stamp-bdist_wheel
 .stamp-bdist_wheel: | populate_version
 	# python setup.py bdist_wheel -d $(WHEELDIR)
-	pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt
+	$(call retry,2,pip wheel --wheel-dir=$(WHEELDIR) --find-links=$(WHEELDIR) -r requirements.txt)
 	touch $@
 
 # We need to create bdist, before mangling requirements and running pip,


### PR DESCRIPTION
> This PR is start of series to improve the builds in general and let them suck less
> In 90% cases what we do to fix the build: retry manually

Brings function to retry failing command in Makefile.


And while `pip` has its own connection-retrying mechanism (with `--retries <retries>` default `5`), most probably something wrong with it or it's not enough (?).
Anyways, experimenting. It's strange how frequently we have upstream connection errors like: 
![](https://i.imgur.com/tk4waqt.png)

----

More technical debt that is good to address in future: 
- https://github.com/StackStorm/st2-packages/issues/365 less distros/builds will decrease number of failures
- https://github.com/StackStorm/st2-packages/issues/343 to upgrade all Docker build environment, which wasn't touched for months (half of year+).

