### PR TITLE
Fix Bootstrap script Branch

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -14,7 +14,7 @@ USERNAME=''
 PASSWORD=''
 
 # Note: This variable needs to default to a branch of the latest stable release
-BRANCH='v2.0'
+BRANCH='v2.1'
 
 setup_args() {
   for i in "$@"


### PR DESCRIPTION
Trusty `MongoDB` and `nginx` are installed when running bootstrap in Xenial.
As a result, `st2` fails to start