### PR TITLE
create HOME var when it doesnt already exist

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -221,6 +221,8 @@ configure_st2_cli_config() {
   ROOT_USER="root"
   CURRENT_USER=$(whoami)
 
+  : "${HOME:=`eval echo ~$(whoami)`}"
+
   ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
   ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
 


### PR DESCRIPTION
https://github.com/StackStorm/st2-packages/issues/385


when running st2bootstrap-deb.sh through ansible it fails with the error 'Failed on step - Configure st2 CLI config'

This is because the script assumes $HOME exists, however under ansible it doesn't seem to exist

All variables should be checked before use, and set to a default if they don't exist