### PR TITLE
Allow overriding defaults with build parameters

### DIFF
--- a/.circle/buildenv_mistral.sh
+++ b/.circle/buildenv_mistral.sh
@@ -30,7 +30,7 @@ mistral_giturl() {
 
 # Mistral versioning
 ST2MISTRAL_GITURL=${ST2MISTRAL_GITURL:-https://github.com/StackStorm/mistral}
-ST2MISTRAL_GITREV=${ST2MISTRAL_GITREV:-$CIRCLE_BRANCH}
+ST2MISTRAL_GITREV=${ST2MISTRAL_GITREV:-master}
 MISTRAL_VERSION=$(fetch_version)
 if [ -n "$PACKAGECLOUD_TOKEN" ]; then
   MISTRAL_RELEASE=$(.circle/packagecloud.sh next-revision ${DISTRO} ${MISTRAL_VERSION} st2mistral)

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -36,8 +36,8 @@ st2_giturl() {
 # ST2PKG_RELEASE - Release number aka revision number for `st2` package, will be reused in Docker metadata (ex: 4)
 # ST2_WAITFORSTART - Delay between st2 start and service checks
 
-ST2_GITURL=${ST2_GITURL:-$(st2_giturl)}
-ST2_GITREV=${ST2_GITREV:-$CIRCLE_BRANCH}
+ST2_GITURL=${ST2_GITURL:-https://github.com/StackStorm/st2}
+ST2_GITREV=${ST2_GITREV:-master}
 ST2PKG_VERSION=$(fetch_version)
 # for Bintray
 #ST2PKG_RELEASE=$(.circle/bintray.sh next-revision ${DISTRO}_staging ${ST2PKG_VERSION} st2)

--- a/.circle/docker.sh
+++ b/.circle/docker.sh
@@ -22,8 +22,8 @@ set -e
 # docker.sh test st2api 'st2 --version' - Exec command inside already started `st2api` Docker container
 # docker.sh deploy st2api st2auth st2exporter st2notifier st2resultstracker st2rulesengine st2sensorcontainer - Push images to Docker Hub
 
-: ${BUILD_DOCKER:=1}
-: ${DEPLOY_DOCKER:=1}
+: ${BUILD_DOCKER:=0}
+: ${DEPLOY_DOCKER:=0}
 
 if [ ${DISTRO} != 'wheezy' ]; then
     echo "Skipping the Docker stage for ${DISTRO}."

--- a/circle.yml
+++ b/circle.yml
@@ -24,9 +24,6 @@ machine:
     ST2MISTRAL_GITREV: master
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     ST2_PACKAGES: "st2 st2mistral"
-    BUILD_DOCKER: 0
-    DEPLOY_DOCKER: 0
-    DEPLOY_PACKAGES: 1
   pre:
     - mkdir -p ~/packages
     # Need latest Docker version for some features to work (CircleCI by default works with outdated version)

--- a/circle.yml
+++ b/circle.yml
@@ -15,13 +15,10 @@ notify:
     - url: https://webhooks.stackstorm.net:8531/webhooks/build/events
 
 machine:
-  # Overwrite these ENV variables in parametrized (manual/API) builds
   environment:
     DISTROS: "wheezy jessie trusty xenial el6 el7"
     NOTESTS: "xenial el7"
     ST2_GITURL: https://github.com/StackStorm/st2
-    ST2_GITREV: master
-    ST2MISTRAL_GITREV: master
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     ST2_PACKAGES: "st2 st2mistral"
   pre:


### PR DESCRIPTION
Variables defined in `machine.environment` can't be overridden with build parameters. By removing this env variables, we now have better control over the build process. In particular, we can now say to circleci not to publish packages. The change is essential for new CI process since deploying every PR package to staging will make it useless for pretty much every other purpose.