### PR TITLE
Teach st2bootstrap to install circleci artifacts

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -46,6 +46,10 @@ setup_args() {
           REPO_TYPE='staging'
           shift
           ;;
+          --dev=*)
+          DEV_BUILD="${i#*=}"
+          shift
+          ;;
           --user=*)
           USERNAME="${i#*=}"
           shift
@@ -85,6 +89,13 @@ setup_args() {
     echo "################################################################"
     echo "### Installing from staging repos!!! USE AT YOUR OWN RISK!!! ###"
     echo "################################################################"
+  fi
+
+  if [ "$DEV_BUILD" != '' ]; then
+    printf "\n\n"
+    echo "###############################################################################"
+    echo "### Installing from dev build artifacts!!! REALLY, ANYTHING COULD HAPPEN!!! ###"
+    echo "###############################################################################"
   fi
 
   if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
@@ -165,8 +176,22 @@ get_full_pkg_versions() {
 install_st2() {
   # Following script adds a repo file, registers gpg key and runs apt-get update
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.deb.sh | sudo bash
-  STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
-  sudo apt-get install -y st2${ST2_PKG_VERSION}
+
+  if [ "$DEV_BUILD" = '' ]; then
+    STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
+    sudo apt-get install -y st2${ST2_PKG_VERSION}
+  else
+    curl -SsL -k -o ./jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+    chmod +x ./jq
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | ./jq -r '.[] | select(.path | test("/home/ubuntu/packages/${SUBTYPE}/st2_.*.deb"; "i")) | .url')"
+    PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
+    curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
+    sudo dpkg -i --force-depends ${PACKAGE_FILENAME}
+    sudo apt-get install -yf
+    rm ${PACKAGE_FILENAME}
+    rm jq
+  fi
+  
   sudo st2ctl start
   sleep 5
   sudo st2ctl reload --register-all
@@ -290,7 +315,19 @@ EHD
 
 install_st2mistral() {
   # install mistral
-  sudo apt-get install -y st2mistral${ST2MISTRAL_PKG_VERSION}
+  if [ "$DEV_BUILD" = '' ]; then
+    sudo apt-get install -y st2mistral${ST2MISTRAL_PKG_VERSION}
+  else
+    curl -SsL -k -o ./jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+    chmod +x ./jq
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | ./jq -r '.[] | select(.path | test("/home/ubuntu/packages/${SUBTYPE}/st2mistral_.*.deb"; "i")) | .url')"
+    PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
+    curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
+    sudo dpkg -i --force-depends ${PACKAGE_FILENAME}
+    sudo apt-get install -yf
+    rm ${PACKAGE_FILENAME}
+    rm jq
+  fi
 
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -181,15 +181,13 @@ install_st2() {
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
     sudo apt-get install -y st2${ST2_PKG_VERSION}
   else
-    curl -SsL -k -o ./jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-    chmod +x ./jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | ./jq -r '.[] | select(.path | test("/home/ubuntu/packages/${SUBTYPE}/st2_.*.deb"; "i")) | .url')"
+    sudo apt-get install -y jq
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "${SUBTYPE}/st2_.*.deb")"
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
     sudo dpkg -i --force-depends ${PACKAGE_FILENAME}
     sudo apt-get install -yf
     rm ${PACKAGE_FILENAME}
-    rm jq
   fi
   
   sudo st2ctl start
@@ -318,15 +316,13 @@ install_st2mistral() {
   if [ "$DEV_BUILD" = '' ]; then
     sudo apt-get install -y st2mistral${ST2MISTRAL_PKG_VERSION}
   else
-    curl -SsL -k -o ./jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-    chmod +x ./jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | ./jq -r '.[] | select(.path | test("/home/ubuntu/packages/${SUBTYPE}/st2mistral_.*.deb"; "i")) | .url')"
+    sudo apt-get install -y jq
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "${SUBTYPE}/st2mistral_.*.deb")"
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
     sudo dpkg -i --force-depends ${PACKAGE_FILENAME}
     sudo apt-get install -yf
     rm ${PACKAGE_FILENAME}
-    rm jq
   fi
 
   # Setup Mistral DB tables, etc.

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -226,11 +226,9 @@ install_st2() {
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
     sudo yum -y install ${ST2_PKG}
   else
-    curl -SsL -k -o ./jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-    chmod +x ./jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | ./jq -r '.[] | select(.path | test("/home/ubuntu/packages/el6/st2-.*.rpm"; "i")) | .url')"
+    sudo yum -y install jq
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el6/st2-.*.rpm")"
     sudo yum -y install ${PACKAGE_URL}
-    rm jq
   fi
 
   sudo st2ctl start
@@ -399,11 +397,9 @@ install_st2mistral() {
   if [ "$DEV_BUILD" = '' ]; then
     sudo yum -y install ${ST2MISTRAL_PKG}
   else
-    curl -SsL -k -o ./jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-    chmod +x ./jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | ./jq -r '.[] | select(.path | test("/home/ubuntu/packages/el6/st2mistral-.*.rpm"; "i")) | .url')"
+    sudo yum -y install jq
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el6/st2mistral-.*.rpm")"
     sudo yum -y install ${PACKAGE_URL}
-    rm jq
   fi
 
   # Setup Mistral DB tables, etc.

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -209,11 +209,9 @@ install_st2() {
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
     sudo yum -y install ${ST2_PKG}
   else
-    curl -SsL -k -o ./jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-    chmod +x ./jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | ./jq -r '.[] | select(.path | test("/home/ubuntu/packages/el7/st2-.*.rpm"; "i")) | .url')"
+    sudo yum -y install jq
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el7/st2-.*.rpm")"
     sudo yum -y install ${PACKAGE_URL}
-    rm jq
   fi
 
   sudo st2ctl start
@@ -373,11 +371,9 @@ install_st2mistral() {
   if [ "$DEV_BUILD" = '' ]; then
     sudo yum -y install ${ST2MISTRAL_PKG}
   else
-    curl -SsL -k -o ./jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-    chmod +x ./jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | ./jq -r '.[] | select(.path | test("/home/ubuntu/packages/el7/st2mistral-.*.rpm"; "i")) | .url')"
+    sudo yum -y install jq
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el7/st2mistral-.*.rpm")"
     sudo yum -y install ${PACKAGE_URL}
-    rm jq
   fi
 
   # Setup Mistral DB tables, etc.

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -36,6 +36,10 @@ setup_args() {
           REPO_TYPE='staging'
           shift
           ;;
+          --dev=*)
+          DEV_BUILD="${i#*=}"
+          shift
+          ;;
           --user=*)
           USERNAME="${i#*=}"
           shift
@@ -75,6 +79,13 @@ setup_args() {
     echo "################################################################"
     echo "### Installing from staging repos!!! USE AT YOUR OWN RISK!!! ###"
     echo "################################################################"
+  fi
+
+  if [ "$DEV_BUILD" != '' ]; then
+    printf "\n\n"
+    echo "###############################################################################"
+    echo "### Installing from dev build artifacts!!! REALLY, ANYTHING COULD HAPPEN!!! ###"
+    echo "###############################################################################"
   fi
 
   if [[ "$USERNAME" = '' || "$PASSWORD" = '' ]]; then
@@ -193,8 +204,18 @@ EOT"
 
 install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.rpm.sh | sudo bash
-  STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
-  sudo yum -y install ${ST2_PKG}
+  
+  if [ "$DEV_BUILD" = '' ]; then
+    STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
+    sudo yum -y install ${ST2_PKG}
+  else
+    curl -SsL -k -o ./jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+    chmod +x ./jq
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | ./jq -r '.[] | select(.path | test("/home/ubuntu/packages/el7/st2-.*.rpm"; "i")) | .url')"
+    sudo yum -y install ${PACKAGE_URL}
+    rm jq
+  fi
+
   sudo st2ctl start
   sleep 5
   sudo st2ctl reload --register-all
@@ -349,7 +370,15 @@ EHD
 
 install_st2mistral() {
   # install mistral
-  sudo yum -y install ${ST2MISTRAL_PKG}
+  if [ "$DEV_BUILD" = '' ]; then
+    sudo yum -y install ${ST2MISTRAL_PKG}
+  else
+    curl -SsL -k -o ./jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+    chmod +x ./jq
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | ./jq -r '.[] | select(.path | test("/home/ubuntu/packages/el7/st2mistral-.*.rpm"; "i")) | .url')"
+    sudo yum -y install ${PACKAGE_URL}
+    rm jq
+  fi
 
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head


### PR DESCRIPTION
This change is required to be able to run tests against the packages that are yet to be deployed to staging repo.

New syntax allows user to define circleci build number with `--dev` key that would override `--unstable --staging` and instead will try to install st2 and st2mistral directly from CircleCI artifacts.