### PR TITLE
corrected to load system locale settings on Ubuntu environment

### DIFF
--- a/packages/st2/debian/st2.st2actionrunner-worker.upstart
+++ b/packages/st2/debian/st2.st2actionrunner-worker.upstart
@@ -23,5 +23,8 @@ script
   # Read configuration variable file if it is present
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
-  exec /opt/stackstorm/st2/bin/$NAME ${DAEMON_ARGS}
+  # Load global locale settings
+  test -f /etc/default/locale && . /etc/default/locale || true
+
+  LANG=$LANG LC_ALL=$LANG exec /opt/stackstorm/st2/bin/$NAME ${DAEMON_ARGS}
 end script

--- a/rake/spec/default/70-st2_actions-integrity_spec.rb
+++ b/rake/spec/default/70-st2_actions-integrity_spec.rb
@@ -7,11 +7,11 @@ describe 'st2 actions integrity checks' do
     its(:exit_status) { is_expected.to eq 0 }
   end
 
-  describe command("st2 run core.local cmd='locale'") do
+  describe command("st2 run core.local cmd=locale") do
     its(:stdout) { should match /UTF-8/ }
   end
 
-  describe command("st2 run core.local cmd='echo ¯\_(ツ)_/¯'") do
+  describe command("st2 run core.local cmd=\"echo '¯\_(ツ)_/¯'\"") do
     its(:exit_status) { is_expected.to eq 0 }
   end
 end

--- a/rake/spec/default/70-st2_actions-integrity_spec.rb
+++ b/rake/spec/default/70-st2_actions-integrity_spec.rb
@@ -6,4 +6,12 @@ describe 'st2 actions integrity checks' do
   describe command("st2 run packs.install packs=github") do
     its(:exit_status) { is_expected.to eq 0 }
   end
+
+  describe command("st2 run core.local cmd='locale'") do
+    its(:stdout) { should match /UTF-8/ }
+  end
+
+  describe command("st2 run core.local cmd='echo ｈｏｇｅ'") do
+    its(:exit_status) { is_expected.to eq 0 }
+  end
 end

--- a/rake/spec/default/70-st2_actions-integrity_spec.rb
+++ b/rake/spec/default/70-st2_actions-integrity_spec.rb
@@ -11,7 +11,7 @@ describe 'st2 actions integrity checks' do
     its(:stdout) { should match /UTF-8/ }
   end
 
-  describe command("st2 run core.local cmd='echo ｈｏｇｅ'") do
+  describe command("st2 run core.local cmd='echo ¯\_(ツ)_/¯'") do
     its(:exit_status) { is_expected.to eq 0 }
   end
 end

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -17,7 +17,7 @@ SSH_OPTIONS = {
 set :backend, :ssh
 set :host, ENV['TESTNODE']
 set :ssh_options, SSH_OPTIONS
-
+set :env, LANG: 'en_US.UTF-8', LC_ALL: 'en_US.UTF-8'
 
 # ST2Spec
 class ST2Spec


### PR DESCRIPTION
This is the correction of following issue. 
https://github.com/StackStorm/st2/issues/3107

Currently, we can't execute actions normally when an unicode-format parameter is passed on the environment of Ubuntu Trusty.

This is because the st2actionrunner doesn't load the system locale settings.

A similar problem is reported in here.
https://bugs.launchpad.net/mythbuntu/+bug/541042

This patch corrects the Upstart configuration file to load system locale settings on the pattern of the above.

After applying this patch, we can execute an action that has unicode arguments on Ubuntu like this.
```
vagrant@st2-node:~$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=14.04
DISTRIB_CODENAME=trusty
DISTRIB_DESCRIPTION="Ubuntu 14.04.5 LTS"
vagrant@st2-node:~$ cat /etc/default/locale 
# Created by cloud-init v. 0.7.5 on Wed, 14 Dec 2016 02:49:04 +0000
LANG=en_US.UTF-8
vagrant@st2-node:~$ st2 run core.local cmd='locale'
.
id: 58621a346f086f548e43be0b
status: succeeded
parameters: 
  cmd: locale
result: 
  failed: false
  return_code: 0
  stderr: ''
  stdout: 'LANG=en_US.UTF-8

    LANGUAGE=

    LC_CTYPE="en_US.UTF-8"

    LC_NUMERIC="en_US.UTF-8"

    LC_TIME="en_US.UTF-8"

    LC_COLLATE="en_US.UTF-8"

    LC_MONETARY="en_US.UTF-8"

    LC_MESSAGES="en_US.UTF-8"

    LC_PAPER="en_US.UTF-8"

    LC_NAME="en_US.UTF-8"

    LC_ADDRESS="en_US.UTF-8"

    LC_TELEPHONE="en_US.UTF-8"

    LC_MEASUREMENT="en_US.UTF-8"

    LC_IDENTIFICATION="en_US.UTF-8"

    LC_ALL=en_US.UTF-8'
  succeeded: true
vagrant@st2-node:~$ st2 run core.local cmd='echo ｈｏｇｅ'
.
id: 58621a436f086f548e43be0e
status: succeeded
parameters: 
  cmd: "echo ｈｏｇｅ"
result: 
  failed: false
  return_code: 0
  stderr: ''
  stdout: "ｈｏｇｅ"
  succeeded: true
vagrant@st2-node:~$ 
```