### PR TITLE
Use safer default values

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -430,7 +430,7 @@ install_st2mistral_depdendencies() {
   sudo apt-get install -y postgresql
 
   cat << EHD | sudo -u postgres psql
-CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD 'StackStorm';
+CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD '${ST2_POSTGRESQL_PASSWORD}';
 CREATE DATABASE mistral OWNER mistral;
 EHD
 }
@@ -449,8 +449,12 @@ install_st2mistral() {
     rm ${PACKAGE_FILENAME}
   fi
 
+  # Configure database settings
+  sudo crudini --set /etc/st2/st2.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@localhost/mistral"
+
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
+
   # Register mistral actions
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -202,9 +202,6 @@ install_mongodb() {
   # Configure MongoDB to listen on localhost only
   sudo sed -i -e "s#bindIp:.*#bindIp: 127.0.0.1#g" /etc/mongod.conf
 
-  # Generate random password used for user authentication
-  ST2_MONGODB_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 ; echo '')
-
   # Create admin user and user used by StackStorm
   mongo <<EOF
 use admin;

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -470,7 +470,7 @@ install_st2mistral() {
   fi
 
   # Configure database settings
-  sudo crudini --set /etc/st2/st2.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@localhost/mistral"
+  sudo crudini --set /etc/mistral/mistral.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@localhost/mistral"
 
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -202,7 +202,16 @@ install_mongodb() {
   # Configure MongoDB to listen on localhost only
   sudo sed -i -e "s#bindIp:.*#bindIp: 127.0.0.1#g" /etc/mongod.conf
 
-  # Create admin user and user used by StackStorm
+  if [[ "$SUBTYPE" == 'xenial' ]]; then
+    sudo systemctl enable mongod
+    sudo systemctl start mongod
+  else
+    sudo service mongod start
+  fi
+
+  sleep 5
+
+  # Create admin user and user used by StackStorm (MongoDB needs to be running)
   mongo <<EOF
 use admin;
 db.createUser({
@@ -230,13 +239,17 @@ EOF
   # Require authentication to be able to acccess the database
   sudo sh -c 'echo "security:\n  authorization: enabled" >> /etc/mongod.conf'
 
+  # MongoDB needs to be restarted after enabling auth
+
   if [[ "$SUBTYPE" == 'xenial' ]]; then
     sudo systemctl enable mongod
-    sudo systemctl start mongod
+    sudo systemctl restart mongod
   else
     sudo service mongod restart
   fi
+
 }
+
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -200,6 +200,9 @@ install_st2_dependencies() {
   sudo apt-get install -y gnupg-curl
   sudo apt-get install -y curl
   sudo apt-get install -y rabbitmq-server
+
+  # Various other dependencies needed by st2 and installer script
+  sudo apt-get install -y crudini
 }
 
 install_mongodb() {
@@ -344,8 +347,8 @@ configure_st2_user () {
 }
 
 configure_st2_authentication() {
-  # Install htpasswd and tool for editing ini files
-  sudo apt-get install -y apache2-utils crudini
+  # Install htpasswd tool for editing ini files
+  sudo apt-get install -y apache2-utils
 
   # Create a user record in a password file.
   sudo echo "${PASSWORD}" | sudo htpasswd -i /etc/st2/htpasswd $USERNAME

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -240,7 +240,6 @@ EOF
   sudo sh -c 'echo "security:\n  authorization: enabled" >> /etc/mongod.conf'
 
   # MongoDB needs to be restarted after enabling auth
-
   if [[ "$SUBTYPE" == 'xenial' ]]; then
     sudo systemctl enable mongod
     sudo systemctl restart mongod
@@ -430,6 +429,11 @@ generate_symmetric_crypto_key_for_datastore() {
 
 install_st2mistral_depdendencies() {
   sudo apt-get install -y postgresql
+
+  # Configure service only listens on localhost
+  sudo crudini --set /etc/postgresql/9.3/main/postgresql.conf '' listen_address "127.0.0.1"
+
+  sudo service postgresql restart
 
   cat << EHD | sudo -u postgres psql
 CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD '${ST2_POSTGRESQL_PASSWORD}';

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -105,6 +105,11 @@ setup_args() {
     echo "Press \"ENTER\" to continue or \"CTRL+C\" to exit/abort"
     read -e -p "Admin username: " -i "st2admin" USERNAME
     read -e -s -p "Password: " PASSWORD
+
+    if [ "${PASSWORD}" = '' ]; then
+        echo "Password cannot be empty."
+        exit 1
+    fi
   fi
 }
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -220,7 +220,7 @@ install_mongodb() {
     sudo systemctl enable mongod
     sudo systemctl start mongod
   else
-    sudo service mongod start
+    sudo service mongod restart
   fi
 
   sleep 5
@@ -255,7 +255,6 @@ EOF
 
   # MongoDB needs to be restarted after enabling auth
   if [[ "$SUBTYPE" == 'xenial' ]]; then
-    sudo systemctl enable mongod
     sudo systemctl restart mongod
   else
     sudo service mongod restart

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -445,7 +445,7 @@ install_st2mistral_depdendencies() {
   sudo apt-get install -y postgresql
 
   # Configure service only listens on localhost
-  sudo crudini --set /etc/postgresql/9.3/main/postgresql.conf '' listen_address "127.0.0.1"
+  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_address "127.0.0.1"
 
   sudo service postgresql restart
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -187,6 +187,15 @@ install_st2_dependencies() {
   sudo apt-get install -y curl
   sudo apt-get install -y rabbitmq-server
 
+  # Configure RabbitMQ to listen on localhost only
+  sudo sh -c 'echo "RABBITMQ_NODE_IP_ADDRESS=127.0.0.1" >> /etc/rabbitmq/rabbitmq-env.conf'
+
+  if [[ "$SUBTYPE" == 'xenial' ]]; then
+    sudo systemctl restart rabbitmq-server
+  else
+    sudo service rabbitmq-server restart
+  fi
+
   # Various other dependencies needed by st2 and installer script
   sudo apt-get install -y crudini
 }

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -320,6 +320,10 @@ install_st2() {
     rm ${PACKAGE_FILENAME}
   fi
 
+  # Configure [database] section in st2.conf (username password for MongoDB access)
+  sudo crudini --set /etc/st2/st2.conf database username "stackstorm"
+  sudo crudini --set /etc/st2/st2.conf database password "${ST2_MONGODB_PASSWORD}"
+
   sudo st2ctl start
   sleep 5
   sudo st2ctl reload --register-all
@@ -364,10 +368,6 @@ configure_st2_authentication() {
   sudo crudini --set /etc/st2/st2.conf auth enable 'True'
   sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
   sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
-
-  # Configure [database] section in st2.conf (username password for MongoDB access)
-  sudo crudini --set /etc/st2/st2.conf database username "stackstorm"
-  sudo crudini --set /etc/st2/st2.conf database password "${ST2_MONGODB_PASSWORD}"
 
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2stream

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -189,9 +189,14 @@ install_mongodb() {
   sudo apt-get update
   sudo apt-get install -y mongodb-org
 
+  # Configure MongoDB to listen on localhost only
+  sudo sed -i -e "s#bindIp:.*#bindIp: 127.0.0.1#g" /etc/mongod.conf
+
   if [[ "$SUBTYPE" == 'xenial' ]]; then
     sudo systemctl enable mongod
     sudo systemctl start mongod
+  else
+    sudo service mongod restart
   fi
 }
 get_full_pkg_versions() {

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -470,7 +470,7 @@ install_st2mistral() {
   fi
 
   # Configure database settings
-  sudo crudini --set /etc/mistral/mistral.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@localhost/mistral"
+  sudo crudini --set /etc/mistral/mistral.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@127.0.0.1/mistral"
 
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -445,7 +445,7 @@ install_st2mistral_depdendencies() {
   sudo apt-get install -y postgresql
 
   # Configure service only listens on localhost
-  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_address "127.0.0.1"
+  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_addresses "'127.0.0.1'"
 
   sudo service postgresql restart
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -504,7 +504,7 @@ install_st2mistral_depdendencies() {
   sudo service postgresql-9.4 initdb
 
   # Configure service only listens on localhost
-  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_addresses "'127.0.0.1'"
+  sudo crudini --set /var/lib/pgsql/data/postgresql.conf '' listen_addresses "'127.0.0.1'"
 
   # Make localhost connections to use an MD5-encrypted password for authentication
   sudo sed -i "s/\(host.*all.*all.*127.0.0.1\/32.*\)ident/\1md5/" /var/lib/pgsql/9.4/data/pg_hba.conf

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -504,7 +504,7 @@ install_st2mistral_depdendencies() {
   sudo service postgresql-9.4 initdb
 
   # Configure service only listens on localhost
-  sudo crudini --set /etc/postgresql/9.4/main/postgresql.conf '' listen_address "127.0.0.1"
+  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_address "127.0.0.1"
 
   # Make localhost connections to use an MD5-encrypted password for authentication
   sudo sed -i "s/\(host.*all.*all.*127.0.0.1\/32.*\)ident/\1md5/" /var/lib/pgsql/9.4/data/pg_hba.conf

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -294,7 +294,12 @@ EOT"
   # Configure MongoDB to listen on localhost only
   sudo sed -i -e "s#bindIp:.*#bindIp: 127.0.0.1#g" /etc/mongod.conf
 
-  # Create admin user and user used by StackStorm
+  sudo service mongod start
+  sudo chkconfig mongod on
+
+  sleep 5
+
+  # Create admin user and user used by StackStorm (MongoDB needs to be running)
   mongo <<EOF
 use admin;
 db.createUser({
@@ -322,8 +327,8 @@ EOF
   # Require authentication to be able to acccess the database
   sudo sh -c 'echo "security:\n  authorization: enabled" >> /etc/mongod.conf'
 
-  sudo service mongod start
-  sudo chkconfig mongod on
+  # MongoDB needs to be restarted after enabling auth
+  sudo service mongod restart
 }
 
 install_st2() {

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -531,7 +531,7 @@ install_st2mistral() {
   fi
 
   # Configure database settings
-  sudo crudini --set /etc/mistral/mistral.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@localhost/mistral"
+  sudo crudini --set /etc/mistral/mistral.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@127.0.0.1/mistral"
 
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -95,6 +95,11 @@ setup_args() {
     echo "Press \"ENTER\" to continue or \"CTRL+C\" to exit/abort"
     read -e -p "Admin username: " -i "st2admin" USERNAME
     read -e -s -p "Password: " PASSWORD
+
+    if [ "${PASSWORD}" = '' ]; then
+        echo "Password cannot be empty."
+        exit 1
+    fi
   fi
 }
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -504,7 +504,7 @@ install_st2mistral_depdendencies() {
   sudo service postgresql-9.4 initdb
 
   # Configure service only listens on localhost
-  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_address "127.0.0.1"
+  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_addresses "'127.0.0.1'"
 
   # Make localhost connections to use an MD5-encrypted password for authentication
   sudo sed -i "s/\(host.*all.*all.*127.0.0.1\/32.*\)ident/\1md5/" /var/lib/pgsql/9.4/data/pg_hba.conf

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -334,7 +334,7 @@ quit();
 EOF
 
   # Require authentication to be able to acccess the database
-  sudo sh -c 'echo "security:\n  authorization: enabled" >> /etc/mongod.conf'
+  sudo sh -c 'echo -e "security:\n  authorization: enabled" >> /etc/mongod.conf'
 
   # MongoDB needs to be restarted after enabling auth
   sudo service mongod restart

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -504,7 +504,7 @@ install_st2mistral_depdendencies() {
   sudo service postgresql-9.4 initdb
 
   # Configure service only listens on localhost
-  sudo sh -c "echo \"listen_addresses = '127.0.0.1'\" >> /var/lib/pgsql/data/postgresql.conf"
+  sudo sh -c "echo \"listen_addresses = '127.0.0.1'\" >> /var/lib/pgsql/9.4/data/postgresql.conf"
 
   # Make localhost connections to use an MD5-encrypted password for authentication
   sudo sed -i "s/\(host.*all.*all.*127.0.0.1\/32.*\)ident/\1md5/" /var/lib/pgsql/9.4/data/pg_hba.conf

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -283,7 +283,7 @@ install_st2_dependencies() {
   sudo chkconfig rabbitmq-server on
 
   # Various other dependencies needed by st2 and installer script
-  sudo yum -y install -tools crudini
+  sudo yum -y install crudini
 }
 
 install_mongodb() {

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -531,7 +531,7 @@ install_st2mistral() {
   fi
 
   # Configure database settings
-  sudo crudini --set /etc/st2/st2.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@localhost/mistral"
+  sudo crudini --set /etc/mistral/mistral.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@localhost/mistral"
 
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -504,7 +504,7 @@ install_st2mistral_depdendencies() {
   sudo service postgresql-9.4 initdb
 
   # Configure service only listens on localhost
-  sudo crudini --set /var/lib/pgsql/data/postgresql.conf '' listen_addresses "'127.0.0.1'"
+  sudo sh -c "echo \"listen_addresses = '127.0.0.1'\" >> /var/lib/pgsql/data/postgresql.conf"
 
   # Make localhost connections to use an MD5-encrypted password for authentication
   sudo sed -i "s/\(host.*all.*all.*127.0.0.1\/32.*\)ident/\1md5/" /var/lib/pgsql/9.4/data/pg_hba.conf

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -347,6 +347,10 @@ install_st2() {
     sudo yum -y install ${PACKAGE_URL}
   fi
 
+  # Configure [database] section in st2.conf (username password for MongoDB access)
+  sudo crudini --set /etc/st2/st2.conf database username "stackstorm"
+  sudo crudini --set /etc/st2/st2.conf database password "${ST2_MONGODB_PASSWORD}"
+
   sudo st2ctl start
   sleep 5
   sudo st2ctl reload --register-all

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -281,6 +281,10 @@ gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
 EOT"
 
   sudo yum -y install mongodb-org
+
+  # Configure MongoDB to listen on localhost only
+  sudo sed -i -e "s#bindIp:.*#bindIp: 127.0.0.1#g" /etc/mongod.conf
+
   sudo service mongod start
   sudo chkconfig mongod on
 }

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -490,6 +490,9 @@ install_st2mistral_depdendencies() {
   # Setup postgresql at a first time
   sudo service postgresql-9.4 initdb
 
+  # Configure service only listens on localhost
+  sudo crudini --set /etc/postgresql/9.4/main/postgresql.conf '' listen_address "127.0.0.1"
+
   # Make localhost connections to use an MD5-encrypted password for authentication
   sudo sed -i "s/\(host.*all.*all.*127.0.0.1\/32.*\)ident/\1md5/" /var/lib/pgsql/9.4/data/pg_hba.conf
   sudo sed -i "s/\(host.*all.*all.*::1\/128.*\)ident/\1md5/" /var/lib/pgsql/9.4/data/pg_hba.conf

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -270,6 +270,10 @@ install_st2_dependencies() {
     sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
   fi
   sudo yum -y install curl rabbitmq-server
+
+  # Configure RabbitMQ to listen on localhost only
+  sudo sh -c 'echo "RABBITMQ_NODE_IP_ADDRESS=127.0.0.1" >> /etc/rabbitmq/rabbitmq-env.conf'
+
   sudo service rabbitmq-server start
   sudo chkconfig rabbitmq-server on
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -330,6 +330,10 @@ install_st2() {
     sudo yum -y install ${PACKAGE_URL}
   fi
 
+  # Configure [database] section in st2.conf (username password for MongoDB access)
+  sudo crudini --set /etc/st2/st2.conf database username "stackstorm"
+  sudo crudini --set /etc/st2/st2.conf database password "${ST2_MONGODB_PASSWORD}"
+
   sudo st2ctl start
   sleep 5
   sudo st2ctl reload --register-all

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -482,7 +482,7 @@ install_st2mistral_depdendencies() {
   sudo sed -i "s/\(host.*all.*all.*::1\/128.*\)ident/\1md5/" /var/lib/pgsql/data/pg_hba.conf
 
   # Configure service only listens on localhost
-  sudo crudini --set /etc/postgresql/9.4/main/postgresql.conf '' listen_address "127.0.0.1"
+  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_address "127.0.0.1"
 
   # Start PostgreSQL service
   sudo systemctl start postgresql

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -505,7 +505,7 @@ install_st2mistral() {
   fi
 
   # Configure database settings
-  sudo crudini --set /etc/mistral/mistral.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@localhost/mistral"
+  sudo crudini --set /etc/mistral/mistral.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@127.0.0.1/mistral"
 
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -95,6 +95,11 @@ setup_args() {
     echo "Press \"ENTER\" to continue or \"CTRL+C\" to exit/abort"
     read -e -p "Admin username: " -i "st2admin" USERNAME
     read -e -s -p "Password: " PASSWORD
+
+    if [ "${PASSWORD}" = '' ]; then
+        echo "Password cannot be empty."
+        exit 1
+    fi
   fi
 }
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -505,7 +505,7 @@ install_st2mistral() {
   fi
 
   # Configure database settings
-  sudo crudini --set /etc/st2/st2.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@localhost/mistral"
+  sudo crudini --set /etc/mistral/mistral.conf database connection "postgresql://mistral:${ST2_POSTGRESQL_PASSWORD}@localhost/mistral"
 
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -482,7 +482,7 @@ install_st2mistral_depdendencies() {
   sudo sed -i "s/\(host.*all.*all.*::1\/128.*\)ident/\1md5/" /var/lib/pgsql/data/pg_hba.conf
 
   # Configure service only listens on localhost
-  sudo crudini --set /var/lib/pgsql/data/postgresql.conf '' listen_addresses "'127.0.0.1'"
+  sudo sh -c "echo \"listen_addresses = '127.0.0.1'\" >> /var/lib/pgsql/data/postgresql.conf"
 
   # Start PostgreSQL service
   sudo systemctl start postgresql

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -266,7 +266,7 @@ install_st2_dependencies() {
   sudo systemctl enable rabbitmq-server
 
   # Various other dependencies needed by st2 and installer script
-  sudo yum -y install -tools crudini
+  sudo yum -y install crudini
 }
 
 install_mongodb() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -317,7 +317,7 @@ quit();
 EOF
 
   # Require authentication to be able to acccess the database
-  sudo sh -c 'echo "security:\n  authorization: enabled" >> /etc/mongod.conf'
+  sudo sh -c 'echo -e "security:\n  authorization: enabled" >> /etc/mongod.conf'
 
   # MongoDB needs to be restarted after enabling auth
   sudo systemctl restart mongod

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -482,7 +482,7 @@ install_st2mistral_depdendencies() {
   sudo sed -i "s/\(host.*all.*all.*::1\/128.*\)ident/\1md5/" /var/lib/pgsql/data/pg_hba.conf
 
   # Configure service only listens on localhost
-  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_addresses "'127.0.0.1'"
+  sudo crudini --set /var/lib/pgsql/data/postgresql.conf '' listen_addresses "'127.0.0.1'"
 
   # Start PostgreSQL service
   sudo systemctl start postgresql

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -468,6 +468,9 @@ install_st2mistral_depdendencies() {
   sudo sed -i "s/\(host.*all.*all.*127.0.0.1\/32.*\)ident/\1md5/" /var/lib/pgsql/data/pg_hba.conf
   sudo sed -i "s/\(host.*all.*all.*::1\/128.*\)ident/\1md5/" /var/lib/pgsql/data/pg_hba.conf
 
+  # Configure service only listens on localhost
+  sudo crudini --set /etc/postgresql/9.4/main/postgresql.conf '' listen_address "127.0.0.1"
+
   # Start PostgreSQL service
   sudo systemctl start postgresql
   sudo systemctl enable postgresql

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -482,7 +482,7 @@ install_st2mistral_depdendencies() {
   sudo sed -i "s/\(host.*all.*all.*::1\/128.*\)ident/\1md5/" /var/lib/pgsql/data/pg_hba.conf
 
   # Configure service only listens on localhost
-  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_address "127.0.0.1"
+  sudo crudini --set /etc/postgresql/*/main/postgresql.conf '' listen_addresses "'127.0.0.1'"
 
   # Start PostgreSQL service
   sudo systemctl start postgresql

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -264,6 +264,10 @@ gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
 EOT"
 
   sudo yum -y install mongodb-org
+
+  # Configure MongoDB to listen on localhost only
+  sudo sed -i -e "s#bindIp:.*#bindIp: 127.0.0.1#g" /etc/mongod.conf
+
   sudo systemctl start mongod
   sudo systemctl enable mongod
 }

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -277,7 +277,12 @@ EOT"
   # Configure MongoDB to listen on localhost only
   sudo sed -i -e "s#bindIp:.*#bindIp: 127.0.0.1#g" /etc/mongod.conf
 
-  # Create admin user and user used by StackStorm
+  sudo systemctl start mongod
+  sudo systemctl enable mongod
+
+  sleep 5
+
+  # Create admin user and user used by StackStorm (MongoDB needs to be running)
   mongo <<EOF
 use admin;
 db.createUser({
@@ -305,8 +310,8 @@ EOF
   # Require authentication to be able to acccess the database
   sudo sh -c 'echo "security:\n  authorization: enabled" >> /etc/mongod.conf'
 
-  sudo systemctl start mongod
-  sudo systemctl enable mongod
+  # MongoDB needs to be restarted after enabling auth
+  sudo systemctl restart mongod
 }
 
 install_st2() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -477,12 +477,12 @@ install_st2mistral_depdendencies() {
   # Setup postgresql at a first time
   sudo postgresql-setup initdb
 
+  # Configure service only listens on localhost
+  sudo sh -c "echo \"listen_addresses = '127.0.0.1'\" >> /var/lib/pgsql/data/postgresql.conf"
+
   # Make localhost connections to use an MD5-encrypted password for authentication
   sudo sed -i "s/\(host.*all.*all.*127.0.0.1\/32.*\)ident/\1md5/" /var/lib/pgsql/data/pg_hba.conf
   sudo sed -i "s/\(host.*all.*all.*::1\/128.*\)ident/\1md5/" /var/lib/pgsql/data/pg_hba.conf
-
-  # Configure service only listens on localhost
-  sudo sh -c "echo \"listen_addresses = '127.0.0.1'\" >> /var/lib/pgsql/data/postgresql.conf"
 
   # Start PostgreSQL service
   sudo systemctl start postgresql

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -253,6 +253,10 @@ install_st2_dependencies() {
     sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   fi
   sudo yum -y install curl rabbitmq-server
+
+  # Configure RabbitMQ to listen on localhost only
+  sudo sh -c 'echo "RABBITMQ_NODE_IP_ADDRESS=127.0.0.1" >> /etc/rabbitmq/rabbitmq-env.conf'
+
   sudo systemctl start rabbitmq-server
   sudo systemctl enable rabbitmq-server
 


### PR DESCRIPTION
This pull request updates the installer script to use more sane and safer default values.

It includes the following changes:

1. Update MongoDB to listen on localhost only (this is already the case in some versions but not all of them and it's better to be safe than sorry).
2. Enable authentication for MongoDB and create two users (admin and stackstorm). "stackstorm" user only has access to "st2" database and it's used by StackStorm components to authenticate against MongoDB.
3. Update RabbitMQ config to listen on localhost only by default (previously it listened on all the interfaces)
3. Update PostgreSQL config to listen on localhost only by default  (already a default value on some distros)
4. Generate and use random password for Mistral PostgreSQL authentication.

Keep in mind that since those changes are done in the installer script, the only apply to single box installer only installation (doh). When users performs advanced / custom installation, package responsibility is only to get StackStorm components installed on the system - it's up to the user to handle authentication, configuration, etc.

## TODO

- [x] Documentation changes
  - [x] Documentation on where users can find the password when using the installer script (note) - https://github.com/StackStorm/st2docs/pull/363
  - [x] Update reference deployment and distributed / HA installation page and add a big red warning / notice which warns the user that they should enable authentication for MongoDB (point them to MongoDB docs) - https://github.com/StackStorm/st2docs/pull/363
- [x] Tests which verify those three services are listening on localhost only - https://github.com/StackStorm/st2ci/pull/71