### PR TITLE
Add policy.json to mistral for default access control

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -33,6 +33,7 @@ post_install:
 	# leave empty if no steps are required
 
 pre_install:
+	install -D conf/policy.json $(DESTDIR)/etc/mistral/policy.json
 	install -D etc/logging.conf.sample $(DESTDIR)/etc/mistral/logging.conf
 	install -D etc/wf_trace_logging.conf.sample $(DESTDIR)/etc/mistral/wf_trace_logging.conf
 	install -D -m644 conf/helpers-sysvinit $(DESTDIR)/opt/stackstorm/mistral/share/sysvinit/helpers

--- a/packages/st2mistral/conf/policy.json
+++ b/packages/st2mistral/conf/policy.json
@@ -1,0 +1,58 @@
+{
+    "admin_only": "is_admin:True",
+    "admin_or_owner":  "is_admin:True or project_id:%(project_id)s",
+    "default": "rule:admin_or_owner",
+
+    "action_executions:delete": "rule:admin_or_owner",
+    "action_execution:create": "rule:admin_or_owner",
+    "action_executions:get": "rule:admin_or_owner",
+    "action_executions:list": "rule:admin_or_owner",
+    "action_executions:update": "rule:admin_or_owner",
+
+    "actions:create": "rule:admin_or_owner",
+    "actions:delete": "rule:admin_or_owner",
+    "actions:get": "rule:admin_or_owner",
+    "actions:list": "rule:admin_or_owner",
+    "actions:update": "rule:admin_or_owner",
+
+    "cron_triggers:create": "rule:admin_or_owner",
+    "cron_triggers:delete": "rule:admin_or_owner",
+    "cron_triggers:get": "rule:admin_or_owner",
+    "cron_triggers:list": "rule:admin_or_owner",
+
+    "environments:create": "rule:admin_or_owner",
+    "environments:delete": "rule:admin_or_owner",
+    "environments:get": "rule:admin_or_owner",
+    "environments:list": "rule:admin_or_owner",
+    "environments:update": "rule:admin_or_owner",
+
+    "executions:create": "rule:admin_or_owner",
+    "executions:delete": "rule:admin_or_owner",
+    "executions:get": "rule:admin_or_owner",
+    "executions:list": "rule:admin_or_owner",
+    "executions:update": "rule:admin_or_owner",
+
+    "members:create": "rule:admin_or_owner",
+    "members:delete": "rule:admin_or_owner",
+    "members:get": "rule:admin_or_owner",
+    "members:list": "rule:admin_or_owner",
+    "members:update": "rule:admin_or_owner",
+
+    "services:list": "rule:admin_or_owner",
+
+    "tasks:get": "rule:admin_or_owner",
+    "tasks:list": "rule:admin_or_owner",
+    "tasks:update": "rule:admin_or_owner",
+
+    "workbooks:create": "rule:admin_or_owner",
+    "workbooks:delete": "rule:admin_or_owner",
+    "workbooks:get": "rule:admin_or_owner",
+    "workbooks:list": "rule:admin_or_owner",
+    "workbooks:update": "rule:admin_or_owner",
+
+    "workflows:create": "rule:admin_or_owner",
+    "workflows:delete": "rule:admin_or_owner",
+    "workflows:get": "rule:admin_or_owner",
+    "workflows:list": "rule:admin_or_owner",
+    "workflows:update": "rule:admin_or_owner"
+}

--- a/packages/st2mistral/debian/install
+++ b/packages/st2mistral/debian/install
@@ -1,2 +1,3 @@
 conf/mistral.conf /etc/mistral
 bin/mistral /usr/bin
+conf/policy.json /etc/mistral


### PR DESCRIPTION
The policy.json is required by default whether authentication is enabled or not in mistral.