### PR TITLE
Fix port status check

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -134,7 +134,7 @@ function port_status() {
   #
   # Sample output:
   #   0.0.0.0:25000 7506/sshd
-  ret=$(sudo netstat -tunlp --inet | awk -v port=$1 '$4 ~ port && $6 ~ /LISTEN/ { print $4 " " $7 }' || echo 'Unbound');
+  ret=$(sudo netstat -tunlp --inet | awk -v port=:$1 '$4 ~ port && $6 ~ /LISTEN/ { print $4 " " $7 }' || echo 'Unbound');
   echo "$ret";
 }
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -219,7 +219,7 @@ function port_status() {
   #
   # Sample output:
   #   0.0.0.0:25000 7506/sshd
-  ret=$(sudo netstat -tunlp --inet | awk -v port=$1 '$4 ~ port && $6 ~ /LISTEN/ { print $4 " " $7 }' || echo 'Unbound');
+  ret=$(sudo netstat -tunlp --inet | awk -v port=:$1 '$4 ~ port && $6 ~ /LISTEN/ { print $4 " " $7 }' || echo 'Unbound');
   echo "$ret";
 }
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -202,7 +202,7 @@ function port_status() {
   #
   # Sample output:
   #   0.0.0.0:25000 7506/sshd
-  ret=$(sudo netstat -tunlp --inet | awk -v port=$1 '$4 ~ port && $6 ~ /LISTEN/ { print $4 " " $7 }' || echo 'Unbound');
+  ret=$(sudo netstat -tunlp --inet | awk -v port=:$1 '$4 ~ port && $6 ~ /LISTEN/ { print $4 " " $7 }' || echo 'Unbound');
   echo "$ret";
 }
 


### PR DESCRIPTION
The awk statement will report failure if the port appears as substring. For example, check for port 80 will failed on "0.0.0.0:38013 1161/rpc.statd".