### PR TITLE
Fix to circumvent pbr related bug in mistral-db-manage populate

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -474,8 +474,9 @@ install_st2mistral() {
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
 
-  # Register mistral actions
-  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+  # Register mistral actions. Init of git is added here to temporarily fix
+  # a bug in one of the OpenStack dependency related to pbr version checking.
+  git init && /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate && rm -rf .git
 
   # Start Mistral
   sudo service mistral start

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -536,8 +536,10 @@ install_st2mistral() {
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
 
-  # Register mistral actions
-  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+  # Register mistral actions. Init of git is added here to temporarily fix
+  # a bug in one of the OpenStack dependency related to pbr version checking.
+  git init && /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate && rm -rf .git
+
 
   # start mistral
   sudo service mistral start

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -510,8 +510,9 @@ install_st2mistral() {
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
 
-  # Register mistral actions
-  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+  # Register mistral actions. Init of git is added here to temporarily fix
+  # a bug in one of the OpenStack dependency related to pbr version checking.
+  git init && /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate && rm -rf .git
 
   # start mistral
   sudo systemctl start mistral


### PR DESCRIPTION
Init of git is added here to temporarily fix a bug in python-muranoclient during pbr version checking on OpenStack action generations.