### PR TITLE
Fix ply version conflict for yaql

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -76,6 +76,7 @@ inject-deps: .stamp-inject-deps
 	grep -q 'psycopg2' requirements.txt || echo "psycopg2" >> requirements.txt
 	grep -q 'kombu' requirements.txt || echo "kombu>=3.0.0,<4.0.0" >> requirements.txt
 	grep -q 'amqp' requirements.txt || echo "amqp>=1.4.0,<2.0.0" >> requirements.txt
+	grep -q 'ply' requirements.txt || echo "ply<3.10" >> requirements.txt
 
 ifeq (,$(findstring dev,$(MISTRAL_VERSION)))
 	sed -i "s/^python-mistralclient.*/git+https:\/\/github.com\/StackStorm\/python-mistralclient.git@st2-$(MISTRAL_VERSION)\#egg=python-mistralclient/g" requirements.txt


### PR DESCRIPTION
New version ply 3.10 breaks evaluation of $ in yaql. Add a line entry in requirements.txt to cap ply at 3.9.