### PR TITLE
Revert fix to mistral db populate script

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -474,9 +474,8 @@ install_st2mistral() {
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
 
-  # Register mistral actions. Init of git is added here to temporarily fix
-  # a bug in one of the OpenStack dependency related to pbr version checking.
-  git init && /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate && rm -rf .git
+  # Register mistral actions.
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
 
   # Start Mistral
   sudo service mistral start

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -536,10 +536,8 @@ install_st2mistral() {
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
 
-  # Register mistral actions. Init of git is added here to temporarily fix
-  # a bug in one of the OpenStack dependency related to pbr version checking.
-  git init && /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate && rm -rf .git
-
+  # Register mistral actions.
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
 
   # start mistral
   sudo service mistral start

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -510,9 +510,8 @@ install_st2mistral() {
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
 
-  # Register mistral actions. Init of git is added here to temporarily fix
-  # a bug in one of the OpenStack dependency related to pbr version checking.
-  git init && /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate && rm -rf .git
+  # Register mistral actions.
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
 
   # start mistral
   sudo systemctl start mistral


### PR DESCRIPTION
Upstream mistral database management script is refactored to print the error instead of abend on import of OpenStack client modules during action registration. The fix is at https://github.com/openstack/mistral/commit/f9cf665a482c29c211bb0ade828cf29c6d78b78b.