### PR TITLE
Prevent logrotate removal on RPM upgrade

### DIFF
--- a/packages/st2/rpm/st2.spec
+++ b/packages/st2/rpm/st2.spec
@@ -60,8 +60,10 @@ Conflicts: st2common
 %postun
   %service_postun st2actionrunner %{worker_name} st2api st2stream st2auth st2notifier
   %service_postun st2resultstracker st2rulesengine st2sensorcontainer st2garbagecollector
-  # Wipe out st2 logrotate config, since there's no analog of apt-get purge avaialable
-  [ ! -f /etc/logrotate.d/st2 ] || rm /etc/logrotate.d/st2
+  # Remove st2 logrotate config, since there's no analog of apt-get purge available
+  if [ $1 -eq 0 ]; then
+    [ ! -f /etc/logrotate.d/st2 ] || rm /etc/logrotate.d/st2
+  fi
 
 %files
   %defattr(-,root,root,-)


### PR DESCRIPTION
The `%postun` step gets run at the end of an upgrade (confusing, I know). 

So if a user has an existing ST2 system, and upgrades, we run the step that removes `/etc/logrotate.d/st2`. The correct approach is to check how many packages will be left on the system after this operation, and only run the removal step if this is the removal of the final version of st2. 

All users who have installed previous versions of ST2, and then upgraded, will no longer have a log rotate configuration. After this change gets merged, and they upgrade again, they will have a working logrotate config again. 

As a workaround, they can manually copy https://github.com/StackStorm/st2/blob/master/conf/logrotate.conf to `/etc/logrotate.d/conf` if they do not wish to upgrade.

Related issues: https://github.com/StackStorm/st2/issues/3213 and https://github.com/StackStorm/st2-packages/issues/418