### PR TITLE
Do not install linux-image-extra

### DIFF
--- a/scripts/setup-vagrant.sh
+++ b/scripts/setup-vagrant.sh
@@ -24,10 +24,10 @@ echo "[Install] dependencies"
 sudo $INSTALL_CMD update
 if [[ $ST2_TARGET != 'el7' ]]; then
   sudo apt-get -y autoremove
+  sudo apt-get install -y gdebi-core
 fi
 
-sudo $INSTALL_CMD install -y linux-image-extra-$(uname -r)
-sudo $INSTALL_CMD install -y git curl wget gdebi-core
+sudo $INSTALL_CMD install -y git curl wget
 
 # Install docker-compose
 DC_BIN="/usr/local/bin/docker-compose"


### PR DESCRIPTION
Additionally, the gdebi-core package does not exist on centos (el7).
So while attempting to install the package did not cause any failure,
we may as well not even try.