### PR TITLE
Added default null values for gitrefs to satisfy prep task sed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,11 +22,12 @@ machine:
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     ST2_PACKAGES: "st2 st2mistral"
 
-    # These should be set to an empty string, so that st2cd prep tasks are able to replace this
-    # with real gitrevs during releases. However, when not doing a release, .circle/buildenv_st2.sh
-    # will still default to using `master` for these if they are left empty.
-    ST2_GITREV: ""
-    ST2MISTRAL_GITREV: ""
+    # These should be set to an empty string, so that st2cd prep tasks are able to replace these
+    # with real gitrevs during releases. Note that they are commented out, so that they do not interfere
+    # with build parameters. st2cd prep tasks will uncomment these on a branch, and replace with proper
+    # gitrefs.
+    # ST2_GITREV: ""
+    # ST2MISTRAL_GITREV: ""
 
   pre:
     - mkdir -p ~/packages

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,13 @@ machine:
     ST2_GITURL: https://github.com/StackStorm/st2
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     ST2_PACKAGES: "st2 st2mistral"
+
+    # These should be set to an empty string, so that st2cd prep tasks are able to replace this
+    # with real gitrevs during releases. However, when not doing a release, .circle/buildenv_st2.sh
+    # will still default to using `master` for these if they are left empty.
+    ST2_GITREV: ""
+    ST2MISTRAL_GITREV: ""
+
   pre:
     - mkdir -p ~/packages
     # Need latest Docker version for some features to work (CircleCI by default works with outdated version)


### PR DESCRIPTION
https://github.com/StackStorm/st2-packages/pull/393 changed `ST2_GITREV` and `ST2MISTRAL_GITREV` to default to `master` when not set.

[The release prep scripts in place today](https://github.com/StackStorm/st2cd/blob/master/actions/st2_prep_release_for_st2_pkg.sh#L104) currently work by setting these lines in circle.yml so that these environment variables are populated, and therefore the right branch will be used. However, the existing sed only works if those two variables are already in circle.yml definition.

So, in order to preserve the spirit of #393, this PR adds these two variables back in, but commented out. So, those variables can still be overridden in normal development, but in release, the prep tasks will still have something to replace. I have also opened https://github.com/StackStorm/st2cd/pull/249 to reflect the changes made here so that this can happen automatically for the next review

So, this PR simply sets those two vars with empty values. This should still allow statements like `ST2MISTRAL_GITREV=${ST2MISTRAL_GITREV:-master}` to default to master, but it will also allow the line replacements in release prep scripts to work as well.