### PR TITLE
Retry docker pull 1 time

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -58,7 +58,8 @@ dependencies:
     - docker-compose version
     - docker version
   override:
-    - .circle/docker-compose.sh pull ${DISTRO}
+    # retry it 1 time
+    - .circle/docker-compose.sh pull ${DISTRO} || .circle/docker-compose.sh pull ${DISTRO}
   post:
     - .circle/docker-compose.sh build ${DISTRO}
 


### PR DESCRIPTION
At the moment we're using outdated Docker `v1.9.0` version due to CircleCI old platform. It seems that newer Docker versions has better mechanism for retrying on failure: 
```
Using default tag: latest
latest: Pulling from library/nginx
efd26ecc9548: Downloading 523.2 kB/51.34 MB
a3ed95caeb02: Download complete
a48df1751a97: Downloading 212.1 kB/19.82 MB
8ddc2d7beb91: Retrying in 1 seconds <--- in newer Docker versions
```

Short-term solution is to add "dumb" retry for docker pull until we upgrade to newer newer CircleCI 2.0 and new Docker version which has ehanced built-ins.

See retry logic https://github.com/docker/docker/pull/18353 which was introduced in Docker `v1.10` (we're on 1.9.0) and slightly improved in next versions.

So the long-term solution is to use CircleCI 2.0 and new Docker.
