### PR TITLE
Fix st2mistral version defaults

### DIFF
--- a/rake/build/environment.rb
+++ b/rake/build/environment.rb
@@ -81,8 +81,8 @@ end
 pipeopts 'st2mistral' do
   checkout true
   envpass :giturl,  'https://github.com/StackStorm/mistral', from: 'ST2MISTRAL_GITURL'
-  envpass :gitrev,  'st2-2.2.0',                                from: 'ST2MISTRAL_GITREV'
+  envpass :gitrev,  'master',                                from: 'ST2MISTRAL_GITREV'
   envpass :gitdir,  make_tmpname('mistral-')
-  envpass :mistral_version, '2.2.0'
+  envpass :mistral_version, '2.3dev'
   envpass :mistral_release, 1
 end


### PR DESCRIPTION
This reverts wrong automation (@StorminStanley) commit https://github.com/StackStorm/st2-packages/commit/788761323d3402c29efa87c2678de684a77eb6f6

See: https://github.com/StackStorm/st2/blob/a54561f5995d94d10ff3db6458d50059f067558b/st2common/st2common/__init__.py#L16

