### PR TITLE
Fix psycopg2 version for st2mistral

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -73,7 +73,7 @@ inject-deps: .stamp-inject-deps
 .stamp-inject-deps: | bdist_wheel
 	echo "$$INJECT_DEPS" >> requirements.txt
 	grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
-	grep -q 'psycopg2' requirements.txt || echo "psycopg2" >> requirements.txt
+	grep -q 'psycopg2' requirements.txt || echo "psycopg2>=2.6.2,<2.7.0" >> requirements.txt
 	grep -q 'kombu' requirements.txt || echo "kombu>=3.0.0,<4.0.0" >> requirements.txt
 	grep -q 'amqp' requirements.txt || echo "amqp>=1.4.0,<2.0.0" >> requirements.txt
 


### PR DESCRIPTION
`st2mistral` build (https://circleci.com/gh/StackStorm/st2-packages/1997) failed with the following error:
```cpp
[wheelhouse: st2mistral]        building 'psycopg2._psycopg' extension
[wheelhouse: st2mistral]        creating build/temp.linux-x86_64-2.7
[wheelhouse: st2mistral]        creating build/temp.linux-x86_64-2.7/psycopg
[wheelhouse: st2mistral]        gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.7 (dt dec pq3 ext)" -DPG_VERSION_NUM=90215 -I/usr/include/python2.7 -I. -I/usr/include -I/usr/include/pgsql/server -c psycopg/psycopgmodule.c -o build/temp.linux-x86_64-2.7/psycopg/psycopgmodule.o -Wdeclaration-after-statement
[wheelhouse: st2mistral]        In file included from ./psycopg/replication_cursor.h:30:0,
[wheelhouse: st2mistral]                         from psycopg/psycopgmodule.c:32:
[wheelhouse: st2mistral]        ./psycopg/libpq_support.h:31:32: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'XLogRecPtr'
[wheelhouse: st2mistral]         typedef unsigned PG_INT64_TYPE XLogRecPtr;
[wheelhouse: st2mistral]                                        ^
[wheelhouse: st2mistral]        In file included from psycopg/psycopgmodule.c:32:0:
[wheelhouse: st2mistral]        ./psycopg/replication_cursor.h:47:5: error: unknown type name 'XLogRecPtr'
[wheelhouse: st2mistral]             XLogRecPtr  write_lsn;        /* LSNs for replication feedback messages */
[wheelhouse: st2mistral]             ^
[wheelhouse: st2mistral]        ./psycopg/replication_cursor.h:48:5: error: unknown type name 'XLogRecPtr'
[wheelhouse: st2mistral]             XLogRecPtr  flush_lsn;
[wheelhouse: st2mistral]             ^
[wheelhouse: st2mistral]        ./psycopg/replication_cursor.h:49:5: error: unknown type name 'XLogRecPtr'
[wheelhouse: st2mistral]             XLogRecPtr  apply_lsn;
[wheelhouse: st2mistral]             ^
[wheelhouse: st2mistral]        In file included from psycopg/psycopgmodule.c:33:0:
[wheelhouse: st2mistral]        ./psycopg/replication_message.h:46:5: error: unknown type name 'XLogRecPtr'
[wheelhouse: st2mistral]             XLogRecPtr  data_start;
[wheelhouse: st2mistral]             ^
[wheelhouse: st2mistral]        ./psycopg/replication_message.h:47:5: error: unknown type name 'XLogRecPtr'
[wheelhouse: st2mistral]             XLogRecPtr  wal_end;
[wheelhouse: st2mistral]             ^
[wheelhouse: st2mistral]        error: command 'gcc' failed with exit status 1
[wheelhouse: st2mistral]        
[wheelhouse: st2mistral]        ----------------------------------------
[wheelhouse: st2mistral]        Failed building wheel for psycopg2
[wheelhouse: st2mistral]      Successfully built st2mistral pbr
[wheelhouse: st2mistral]      Failed to build psycopg2
[wheelhouse: st2mistral]      ERROR: Failed to build one or more wheels
[wheelhouse: st2mistral]      You are using pip version 7.1.2, however version 9.0.1 is available.
[wheelhouse: st2mistral]      You should consider upgrading via the 'pip install --upgrade pip' command.
[wheelhouse: st2mistral]      make: *** [.stamp-wheelhouse] Error 1
```

The reason is that new version `psycopg2-2.7` was released 1 Mar (today).

Switch to previously working `2.6.2` version.

cc @m4dcoder 