### PR TITLE
Include st2tests Python component in final st2 package distribution

### DIFF
--- a/packages/st2/in-requirements.txt
+++ b/packages/st2/in-requirements.txt
@@ -6,4 +6,5 @@ st2auth
 st2reactor
 st2exporter
 st2debug
+st2tests
 git+https://github.com/StackStorm/st2-auth-backend-pam.git@master#egg=st2-auth-backend-pam

--- a/rake/build/environment.rb
+++ b/rake/build/environment.rb
@@ -10,7 +10,8 @@ ST2_COMPONENTS = %w(
   st2api st2stream st2actions st2common
   st2auth st2client st2exporter
   st2reactor
-  st2debug)
+  st2debug
+  st2tests)
 
 # Default list of packages to build
 BUILDLIST = 'st2 st2mistral'


### PR DESCRIPTION
This will allow users to run `st2-run-pack-tests` command out of the box without needing to set anything up on servers where StackStorm is installed using packages.

Related to https://github.com/StackStorm/st2/pull/3263