### PR TITLE
modified homedir refs

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -339,17 +339,17 @@ configure_st2_user () {
     sudo useradd stanley
   fi
 
-  sudo mkdir -p /home/stanley/.ssh
+  sudo mkdir -p ~stanley/.ssh
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
-  sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
-  #sudo cp ${KEY_LOCATION}/stanley_rsa.pub /home/stanley/.ssh/stanley_rsa.pub
+  sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
+  #sudo cp ${KEY_LOCATION}/stanley_rsa.pub ~stanley/.ssh/stanley_rsa.pub
 
-  # Authorize key-base acces
-  sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-  sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-  sudo chmod 0700 /home/stanley/.ssh
-  sudo chown -R stanley:stanley /home/stanley
+  # Authorize key-based access
+  sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
+  sudo chmod 0600 ~stanley/.ssh/authorized_keys
+  sudo chmod 0700 ~stanley/.ssh
+  sudo chown -R stanley ~stanley
 
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
@@ -384,7 +384,7 @@ configure_st2_cli_config() {
 
   : "${HOME:=`eval echo ~$(whoami)`}"
 
-  ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
+  ROOT_USER_CLI_CONFIG_DIRECTORY="~root/.st2"
   ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
 
   CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
@@ -516,7 +516,7 @@ install_st2chatops() {
 }
 
 configure_st2chatops() {
-  # set API keys. This should work since CLI is configuered already.
+  # set API keys. This should work since CLI is configured already.
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -367,16 +367,16 @@ configure_st2_user() {
     sudo useradd stanley
   fi
 
-  sudo mkdir -p /home/stanley/.ssh
-  sudo chmod 0700 /home/stanley/.ssh
+  sudo mkdir -p ~stanley/.ssh
+  sudo chmod 0700 ~stanley/.ssh
 
   # On StackStorm host, generate ssh keys
-  sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
+  sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
 
-  # Authorize key-base acces
-  sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-  sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-  sudo chown -R stanley:stanley /home/stanley
+  # Authorize key-based access
+  sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
+  sudo chmod 0600 ~stanley/.ssh/authorized_keys
+  sudo chown -R stanley ~stanley
 
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
@@ -409,7 +409,7 @@ configure_st2_cli_config() {
 
   : "${HOME:=`eval echo ~$(whoami)`}"
 
-  ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
+  ROOT_USER_CLI_CONFIG_DIRECTORY="~root/.st2"
   ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
 
   CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
@@ -582,7 +582,7 @@ install_st2chatops() {
 }
 
 configure_st2chatops() {
-  # set API keys. This should work since CLI is configuered already.
+  # set API keys. This should work since CLI is configured already.
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -353,16 +353,16 @@ configure_st2_user() {
     sudo useradd stanley
   fi
 
-  sudo mkdir -p /home/stanley/.ssh
-  sudo chmod 0700 /home/stanley/.ssh
+  sudo mkdir -p ~stanley/.ssh
+  sudo chmod 0700 ~stanley/.ssh
 
   # On StackStorm host, generate ssh keys
-  sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
+  sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
 
-  # Authorize key-base acces
-  sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-  sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-  sudo chown -R stanley:stanley /home/stanley
+  # Authorize key-based access
+  sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
+  sudo chmod 0600 ~stanley/.ssh/authorized_keys
+  sudo chown -R stanley ~stanley
 
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
@@ -419,7 +419,7 @@ configure_st2_cli_config() {
 
   : "${HOME:=`eval echo ~$(whoami)`}"
 
-  ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
+  ROOT_USER_CLI_CONFIG_DIRECTORY="~root/.st2"
   ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
 
   CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
@@ -559,7 +559,7 @@ install_st2chatops() {
 }
 
 configure_st2chatops() {
-  # set API keys. This should work since CLI is configuered already.
+  # set API keys. This should work since CLI is configured already.
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 


### PR DESCRIPTION
Modified references to user's home directories to use ~stanley, rather than /home/stanley, and ~root rather than /root. 

Some environments use a different directory for the base $HOME dir - e.g. /users. By changing to ~user, we can cope with those differences.

Related to that, some environments have changed the default so that new users do not get created with a machine group. Instead they share a common group, e.g. `users`. By changing the `chown -R stanley:stanley` line to `chown -R stanley` we can cope with those differences. Note that the permissions for `~/.ssh/authorized_keys` are still acceptable - OpenSSH only checks the user and mode, it doesn't seem to care about the group.

This will make our one-line installer slightly more robust, and able to cope with different environments. A few more PRs to come :)

Also fixed up a couple of small typos in comments.