### PR TITLE
Make installer better handle multiple runs

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -339,17 +339,17 @@ configure_st2_user () {
     sudo useradd stanley
   fi
 
-  sudo mkdir -p /home/stanley/.ssh
+  sudo mkdir -p ~stanley/.ssh
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
-  sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
-  #sudo cp ${KEY_LOCATION}/stanley_rsa.pub /home/stanley/.ssh/stanley_rsa.pub
+  sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
+  #sudo cp ${KEY_LOCATION}/stanley_rsa.pub ~stanley/.ssh/stanley_rsa.pub
 
-  # Authorize key-base acces
-  sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-  sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-  sudo chmod 0700 /home/stanley/.ssh
-  sudo chown -R stanley:stanley /home/stanley
+  # Authorize key-based access
+  sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
+  sudo chmod 0600 ~stanley/.ssh/authorized_keys
+  sudo chmod 0700 ~stanley/.ssh
+  sudo chown -R stanley ~stanley
 
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
@@ -384,7 +384,7 @@ configure_st2_cli_config() {
 
   : "${HOME:=`eval echo ~$(whoami)`}"
 
-  ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
+  ROOT_USER_CLI_CONFIG_DIRECTORY="~root/.st2"
   ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
 
   CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
@@ -516,7 +516,7 @@ install_st2chatops() {
 }
 
 configure_st2chatops() {
-  # set API keys. This should work since CLI is configuered already.
+  # set API keys. This should work since CLI is configured already.
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -339,17 +339,22 @@ configure_st2_user () {
     sudo useradd stanley
   fi
 
-  sudo mkdir -p ~stanley/.ssh
+  if sudo test -f "~stanley/.ssh/stanley_rsa"; then
+    # Key already exists, leave as-is
+    :
+  else
+    sudo mkdir -p ~stanley/.ssh
 
-  # Generate ssh keys on StackStorm box and copy over public key into remote box.
-  sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
-  #sudo cp ${KEY_LOCATION}/stanley_rsa.pub ~stanley/.ssh/stanley_rsa.pub
+    # Generate ssh keys on StackStorm box and copy over public key into remote box.
+    sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
+    #sudo cp ${KEY_LOCATION}/stanley_rsa.pub ~stanley/.ssh/stanley_rsa.pub
 
-  # Authorize key-based access
-  sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
-  sudo chmod 0600 ~stanley/.ssh/authorized_keys
-  sudo chmod 0700 ~stanley/.ssh
-  sudo chown -R stanley ~stanley
+    # Authorize key-based access
+    sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
+    sudo chmod 0600 ~stanley/.ssh/authorized_keys
+    sudo chmod 0700 ~stanley/.ssh
+    sudo chown -R stanley ~stanley
+  fi
 
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
@@ -425,7 +430,7 @@ generate_symmetric_crypto_key_for_datastore() {
   DATASTORE_ENCRYPTION_KEY_PATH="${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}/datastore_key.json"
 
   sudo mkdir -p ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
-  sudo st2-generate-symmetric-crypto-key --key-path ${DATASTORE_ENCRYPTION_KEY_PATH}
+  sudo st2-generate-symmetric-crypto-key --force --key-path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # Make sure only st2 user can read the file
   sudo usermod -a -G st2 st2

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -367,16 +367,20 @@ configure_st2_user() {
     sudo useradd stanley
   fi
 
-  sudo mkdir -p ~stanley/.ssh
-  sudo chmod 0700 ~stanley/.ssh
+  if sudo test -f "~stanley/.ssh/stanley_rsa"; then
+    # Key already exists, leave as-is
+  else
+    sudo mkdir -p ~stanley/.ssh
+    sudo chmod 0700 ~stanley/.ssh
 
-  # On StackStorm host, generate ssh keys
-  sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
+    # On StackStorm host, generate ssh keys
+    sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
 
-  # Authorize key-based access
-  sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
-  sudo chmod 0600 ~stanley/.ssh/authorized_keys
-  sudo chown -R stanley ~stanley
+    # Authorize key-based access
+    sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
+    sudo chmod 0600 ~stanley/.ssh/authorized_keys
+    sudo chown -R stanley ~stanley
+  fi
 
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
@@ -450,7 +454,7 @@ generate_symmetric_crypto_key_for_datastore() {
   DATASTORE_ENCRYPTION_KEY_PATH="${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}/datastore_key.json"
 
   sudo mkdir -p ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
-  sudo st2-generate-symmetric-crypto-key --key-path ${DATASTORE_ENCRYPTION_KEY_PATH}
+  sudo st2-generate-symmetric-crypto-key --force --key-path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # Make sure only st2 user can read the file
   sudo usermod -a -G st2 st2

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -367,16 +367,16 @@ configure_st2_user() {
     sudo useradd stanley
   fi
 
-  sudo mkdir -p /home/stanley/.ssh
-  sudo chmod 0700 /home/stanley/.ssh
+  sudo mkdir -p ~stanley/.ssh
+  sudo chmod 0700 ~stanley/.ssh
 
   # On StackStorm host, generate ssh keys
-  sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
+  sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
 
-  # Authorize key-base acces
-  sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-  sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-  sudo chown -R stanley:stanley /home/stanley
+  # Authorize key-based access
+  sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
+  sudo chmod 0600 ~stanley/.ssh/authorized_keys
+  sudo chown -R stanley ~stanley
 
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
@@ -409,7 +409,7 @@ configure_st2_cli_config() {
 
   : "${HOME:=`eval echo ~$(whoami)`}"
 
-  ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
+  ROOT_USER_CLI_CONFIG_DIRECTORY="~root/.st2"
   ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
 
   CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
@@ -582,7 +582,7 @@ install_st2chatops() {
 }
 
 configure_st2chatops() {
-  # set API keys. This should work since CLI is configuered already.
+  # set API keys. This should work since CLI is configured already.
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -353,16 +353,21 @@ configure_st2_user() {
     sudo useradd stanley
   fi
 
-  sudo mkdir -p ~stanley/.ssh
-  sudo chmod 0700 ~stanley/.ssh
+  if sudo test if "~stanley/.ssh/stanley_rsa"; then
+    # Key already exists, leave as-is
+    :
+  else
+    sudo mkdir -p ~stanley/.ssh
+    sudo chmod 0700 ~stanley/.ssh
 
-  # On StackStorm host, generate ssh keys
-  sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
+    # On StackStorm host, generate ssh keys
+    sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
 
-  # Authorize key-based access
-  sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
-  sudo chmod 0600 ~stanley/.ssh/authorized_keys
-  sudo chown -R stanley ~stanley
+    # Authorize key-based access
+    sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
+    sudo chmod 0600 ~stanley/.ssh/authorized_keys
+    sudo chown -R stanley ~stanley
+  fi
 
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
@@ -460,7 +465,7 @@ generate_symmetric_crypto_key_for_datastore() {
   DATASTORE_ENCRYPTION_KEY_PATH="${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}/datastore_key.json"
 
   sudo mkdir -p ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
-  sudo st2-generate-symmetric-crypto-key --key-path ${DATASTORE_ENCRYPTION_KEY_PATH}
+  sudo st2-generate-symmetric-crypto-key --force --key-path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # Make sure only st2 user can read the file
   sudo usermod -a -G st2 st2

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -353,16 +353,16 @@ configure_st2_user() {
     sudo useradd stanley
   fi
 
-  sudo mkdir -p /home/stanley/.ssh
-  sudo chmod 0700 /home/stanley/.ssh
+  sudo mkdir -p ~stanley/.ssh
+  sudo chmod 0700 ~stanley/.ssh
 
   # On StackStorm host, generate ssh keys
-  sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
+  sudo ssh-keygen -f ~stanley/.ssh/stanley_rsa -P ""
 
-  # Authorize key-base acces
-  sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-  sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-  sudo chown -R stanley:stanley /home/stanley
+  # Authorize key-based access
+  sudo sh -c 'cat ~stanley/.ssh/stanley_rsa.pub >> ~stanley/.ssh/authorized_keys'
+  sudo chmod 0600 ~stanley/.ssh/authorized_keys
+  sudo chown -R stanley ~stanley
 
   # Enable passwordless sudo
   sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
@@ -419,7 +419,7 @@ configure_st2_cli_config() {
 
   : "${HOME:=`eval echo ~$(whoami)`}"
 
-  ROOT_USER_CLI_CONFIG_DIRECTORY="/root/.st2"
+  ROOT_USER_CLI_CONFIG_DIRECTORY="~root/.st2"
   ROOT_USER_CLI_CONFIG_PATH="${ROOT_USER_CLI_CONFIG_DIRECTORY}/config"
 
   CURRENT_USER_CLI_CONFIG_DIRECTORY="${HOME}/.st2"
@@ -559,7 +559,7 @@ install_st2chatops() {
 }
 
 configure_st2chatops() {
-  # set API keys. This should work since CLI is configuered already.
+  # set API keys. This should work since CLI is configured already.
   ST2_API_KEY=`st2 apikey create -k`
   sudo sed -i -r "s/^(export ST2_API_KEY.).*/\1$ST2_API_KEY/" /opt/stackstorm/chatops/st2chatops.env
 


### PR DESCRIPTION
If the bootstrap script is re-run, e.g. due to a failed installation, it generally exits at one of two points:
- When generating the datastore encryption key
- When generating stanley's SSH key.

This PR adds two changes:
- Add `--force` to crypto key generate command, so it will over-write existing key. Yes, this could cause problems if you had values encrypted with the old key
- Adds checks to see if stanley's RSA key exists, and to bypass generating/copying a new key if so.

These fixes are not about true idempotence - it's just about about making the script more robust, and better handle situations where it gets re-run due to a failed install.

Note this builds upon https://github.com/StackStorm/st2-packages/pull/440