### PR TITLE
Temporary hack for Xenial failing to register rules

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -329,6 +329,10 @@ install_st2() {
   sudo crudini --set /etc/st2/st2.conf database password "${ST2_MONGODB_PASSWORD}"
 
   sudo st2ctl start
+  # TODO: Fix https://github.com/StackStorm/st2-packages/issues/445
+  if [[ "$SUBTYPE" == 'xenial' ]]; then
+    sleep 5
+  fi
   sudo st2ctl reload --register-all
 }
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -329,7 +329,7 @@ install_st2() {
   sudo crudini --set /etc/st2/st2.conf database password "${ST2_MONGODB_PASSWORD}"
 
   sudo st2ctl start
-  # TODO: Fix https://github.com/StackStorm/st2-packages/issues/445
+  # TODO: Fix https://github.com/StackStorm/st2-packages/issues/445 (under xenial register content fails on first boot)
   if [[ "$SUBTYPE" == 'xenial' ]]; then
     sleep 5
   fi


### PR DESCRIPTION
Regression I didn't catch after removing this line: https://github.com/StackStorm/st2-packages/pull/435/files#diff-0cc9e53cba1b060958ebffa16eb85cb5L332

Merging it now to make the current build GREEN, revert when https://github.com/StackStorm/st2-packages/issues/445 is fully investigated and fixed.