### PR TITLE
Revert Xenial sleep hack in 'curl|bash' installer

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -553,6 +553,13 @@ configure_st2chatops() {
 }
 
 verify_st2() {
+
+  # TODO: This is a temporary and nasty workaround for xenial CI failures.
+  # TODO: Fix https://github.com/StackStorm/st2/issues/3290
+  if [[ "$SUBTYPE" == 'xenial' ]]; then
+    sleep 30
+  fi
+
   st2 --version
   st2 -h
 


### PR DESCRIPTION
This reverts old hack which I tried to remove here: https://github.com/StackStorm/st2-packages/pull/435/files#diff-0cc9e53cba1b060958ebffa16eb85cb5L554

See https://github.com/StackStorm/st2/issues/3290 for more detailed debugging information, explanation and steps to reproduce.