### PR TITLE
Modified git URL to include proper mistral version [v2.2]

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -8,7 +8,7 @@ PBR_GITURL := git+https://github.com/openstack-dev/pbr@d19459daa8616dd18fde016c2
 
 # We use special additional requirements in our mistral bundle!
 define INJECT_DEPS
-git+https://github.com/StackStorm/st2mistral.git@$(GITREV)#egg=st2mistral
+git+https://github.com/StackStorm/st2mistral.git@st2-$(MISTRAL_VERSION)#egg=st2mistral
 $(PBR_GITURL)
 endef
 export INJECT_DEPS


### PR DESCRIPTION
During e2e testing for 2.2.1, the wrong version of st2mistral was being packaged. This should resolve this.

Note that this is for v2.2 release branch. #450 will take care of this change in `master`