### PR TITLE
Share private /tmp folder between actionrunner instances

### DIFF
--- a/packages/st2/debian/st2actionrunner.service
+++ b/packages/st2/debian/st2actionrunner.service
@@ -7,6 +7,7 @@ Type=oneshot
 EnvironmentFile=-/etc/default/st2actionrunner
 ExecStart=/bin/bash /opt/stackstorm/st2/bin/runners.sh start
 ExecStop=/bin/bash /opt/stackstorm/st2/bin/runners.sh stop
+PrivateTmp=true
 RemainAfterExit=true
 
 [Install]

--- a/packages/st2/debian/st2actionrunner@.service
+++ b/packages/st2/debian/st2actionrunner@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2actionrunner
 After=network.target
+JoinsNamespaceOf=st2actionrunner.service
 
 [Service]
 Type=simple

--- a/packages/st2/rpm/st2actionrunner.service
+++ b/packages/st2/rpm/st2actionrunner.service
@@ -7,6 +7,7 @@ Type=oneshot
 EnvironmentFile=-/etc/sysconfig/st2actionrunner
 ExecStart=/bin/bash /opt/stackstorm/st2/bin/runners.sh start
 ExecStop=/bin/bash /opt/stackstorm/st2/bin/runners.sh stop
+PrivateTmp=true
 RemainAfterExit=true
 
 [Install]

--- a/packages/st2/rpm/st2actionrunner@.service
+++ b/packages/st2/rpm/st2actionrunner@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=StackStorm service st2actionrunner
 After=network.target
+JoinsNamespaceOf=st2actionrunner.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
It's a frequent situation when you putting a file to `/tmp` folder in one action and retrieving it from what you think is the same `/tmp` folder in the following action. Problem is, the expectation is invalid for systemd-based OS with PrivateTmp enabled.

This PR tells different instances of st2actionrunner to share the same network and filesystem namespace.