### PR TITLE
Fix st2mistral CI failure, pin 'olso.messaging'

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -74,10 +74,10 @@ inject-deps: .stamp-inject-deps
 	echo "$$INJECT_DEPS" >> requirements.txt
 	grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
 	grep -q 'psycopg2' requirements.txt || echo "psycopg2>=2.6.2,<2.7.0" >> requirements.txt
+	sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
 
 ifeq (,$(findstring dev,$(MISTRAL_VERSION)))
 	sed -i "s/^python-mistralclient.*/git+https:\/\/github.com\/StackStorm\/python-mistralclient.git@st2-$(MISTRAL_VERSION)\#egg=python-mistralclient/g" requirements.txt
-	sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
 endif
 
 	touch $@

--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -77,6 +77,7 @@ inject-deps: .stamp-inject-deps
 
 ifeq (,$(findstring dev,$(MISTRAL_VERSION)))
 	sed -i "s/^python-mistralclient.*/git+https:\/\/github.com\/StackStorm\/python-mistralclient.git@st2-$(MISTRAL_VERSION)\#egg=python-mistralclient/g" requirements.txt
+	sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
 endif
 
 	touch $@


### PR DESCRIPTION
> Opened in favor of https://github.com/StackStorm/mistral/pull/22

Latest `oslo.messaging` `5.25.0+` breaks the st2mistral, `5.24.2` is one that really worked.

Easy to reproduce:
```sh
$ mistral run-action std.echo '{"output":"test"}'
ERROR (app) 1
```

Discussion details: https://stackstorm.slack.com/archives/C029K4CBU/p1496758762973704


WIP: Checking if this is the right place to edit the requirements.