### PR TITLE
Remove old st2 build webhook URL

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,6 @@ general:
 
 notify:
   webhooks:
-    - url: https://webhooks.stackstorm.net:8531/webhooks/build/events
     - url: https://ci-webhooks.stackstorm.net/webhooks/build/events
 
 machine:


### PR DESCRIPTION
Removes outdated st2 webhook URL. It shows up in CircleCI UI with 503 status.