### PR TITLE
Stop mistral-server with SIGINT instead of SIGTERM

### DIFF
--- a/packages/st2mistral/rpm/mistral-server.service
+++ b/packages/st2mistral/rpm/mistral-server.service
@@ -10,6 +10,7 @@ Environment="SERVER_ARGS=--config-file /etc/mistral/mistral.conf --log-file /var
 Environment="COMPONENTS=api,engine,executor"
 EnvironmentFile=-/etc/sysconfig/mistral
 ExecStart=/bin/sh -c ". /opt/stackstorm/mistral/share/sysvinit/helpers; enabled_list -q server || exit 0; exec /opt/stackstorm/mistral/bin/mistral-server --server $(enabled_list server) $SERVER_ARGS"
+KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I couldn't find any signal handling in Mistral but did find handling for `KeyboardInterrupt` and verified that Ctrl-C would successfully stop mistral-server. This change uses the same SIGINT signal to stop mistral-server from systemd.