### PR TITLE
Pin Babel dependency since it doesn't work with 2.4.0

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -74,7 +74,8 @@ inject-deps: .stamp-inject-deps
 	echo "$$INJECT_DEPS" >> requirements.txt
 	grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
 	grep -q 'psycopg2' requirements.txt || echo "psycopg2>=2.6.2,<2.7.0" >> requirements.txt
-	sed -i "s/^Babel.*/Babel>=2.3.4,!=2.4.0/g" requirements.txt
+	sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
+	sed -i "s/^Babel.*/Babel>=2.3.4,!=2.4.0 # BSD/g" requirements.txt
 
 ifeq (,$(findstring dev,$(MISTRAL_VERSION)))
 	sed -i "s/^python-mistralclient.*/git+https:\/\/github.com\/StackStorm\/python-mistralclient.git@st2-$(MISTRAL_VERSION)\#egg=python-mistralclient/g" requirements.txt

--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -74,6 +74,7 @@ inject-deps: .stamp-inject-deps
 	echo "$$INJECT_DEPS" >> requirements.txt
 	grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
 	grep -q 'psycopg2' requirements.txt || echo "psycopg2>=2.6.2,<2.7.0" >> requirements.txt
+	grep -q 'Babel' requirements.txt || echo "Babel>=2.3.4,!=2.4.0" >> requirements.txt
 	sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
 
 ifeq (,$(findstring dev,$(MISTRAL_VERSION)))

--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -74,8 +74,7 @@ inject-deps: .stamp-inject-deps
 	echo "$$INJECT_DEPS" >> requirements.txt
 	grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
 	grep -q 'psycopg2' requirements.txt || echo "psycopg2>=2.6.2,<2.7.0" >> requirements.txt
-	grep -q 'Babel' requirements.txt || echo "Babel>=2.3.4,!=2.4.0" >> requirements.txt
-	sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
+	sed -i "s/^Babel.*/Babel>=2.3.4,!=2.4.0/g" requirements.txt
 
 ifeq (,$(findstring dev,$(MISTRAL_VERSION)))
 	sed -i "s/^python-mistralclient.*/git+https:\/\/github.com\/StackStorm\/python-mistralclient.git@st2-$(MISTRAL_VERSION)\#egg=python-mistralclient/g" requirements.txt


### PR DESCRIPTION
python setup.py develop fails with out works.

This is one of the work-around. Best solution would probably be to sync our fork with upstream...