### PR TITLE
Remove sleep timeout before Register content

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -329,10 +329,6 @@ install_st2() {
   sudo crudini --set /etc/st2/st2.conf database password "${ST2_MONGODB_PASSWORD}"
 
   sudo st2ctl start
-  # TODO: Fix https://github.com/StackStorm/st2-packages/issues/445 (under xenial register content fails on first boot)
-  if [[ "$SUBTYPE" == 'xenial' ]]; then
-    sleep 5
-  fi
   sudo st2ctl reload --register-all
 }
 


### PR DESCRIPTION
Bug https://github.com/StackStorm/st2-packages/issues/445 was fixed by @Kami in https://github.com/StackStorm/st2/pull/3542 so we can remove this ugly `sleep 5` timeout from our `curl | bash` installer.

+1 step to improve & stablizie st2 availability/deployments/HA/prod.