### PR TITLE
Add support for sharing the 'st2' and 'st2mistral' code, instead of checkout

### DIFF
--- a/rake/build/environment.rb
+++ b/rake/build/environment.rb
@@ -70,7 +70,7 @@ end
 
 pipeopts 'st2' do
   env :components, ST2_COMPONENTS, proc: convert_to_array
-  checkout true
+  envpass :checkout,  1,                                  from: 'ST2_CHECKOUT', proc: convert_to_int
   envpass :giturl,   'https://github.com/StackStorm/st2', from: 'ST2_GITURL'
   envpass :gitrev,   'master',                            from: 'ST2_GITREV'
   envpass :gitdir,    make_tmpname('st2-'),               from: 'ST2_GITDIR'
@@ -80,10 +80,10 @@ pipeopts 'st2' do
 end
 
 pipeopts 'st2mistral' do
-  checkout true
+  envpass :checkout, 1,                                      from: 'ST2MISTRAL_CHECKOUT', proc: convert_to_int
   envpass :giturl,  'https://github.com/StackStorm/mistral', from: 'ST2MISTRAL_GITURL'
   envpass :gitrev,  'master',                                from: 'ST2MISTRAL_GITREV'
-  envpass :gitdir,  make_tmpname('mistral-')
+  envpass :gitdir,  make_tmpname('mistral-'),                from: 'ST2MISTRAL_GITDIR'
   envpass :mistral_version, '2.4dev'
   envpass :mistral_release, 1
 end

--- a/rake/build/upload_checkout.rake
+++ b/rake/build/upload_checkout.rake
@@ -38,7 +38,7 @@ namespace :upload do
 
   ## Multitask checks out git source of a package (if pipopts.checkout == true)
   #
-  package_list = pipeopts.packages.select {|p| pipeopts(p).checkout}
+  package_list = pipeopts.packages.select {|p| defined?(pipeopts(p).checkout)}
   multitask :checkout => package_list.map {|p| :"%checkout_#{p}"}
 
   ## Rule generates %checkout_* tasks.
@@ -52,7 +52,9 @@ namespace :upload do
         with opts.env do
           execute :mkdir, '-p $ARTIFACT_DIR'
           within opts.basedir do
-            execute :git, :clone, '--depth 1 -b $GITREV $GITURL $GITDIR'
+            if opts.checkout == 1
+              execute :git, :clone, '--depth 1 -b $GITREV $GITURL $GITDIR'
+            end
           end
         end
       end

--- a/rake/pipeline_options.rb
+++ b/rake/pipeline_options.rb
@@ -91,6 +91,9 @@ module Pipeline
         if opts[:reset]
           # don't parse env variable, just set value
           [caseattr, default, opts]
+        elsif value == ""
+          # use default, when passed env is empty
+          [caseattr, default, opts]
         else
           [caseattr, value || default, opts]
         end

--- a/rake/remote.rb
+++ b/rake/remote.rb
@@ -11,7 +11,7 @@ class Remote
     attr_reader :backend, :default_command_options
 
     # Methods which are passed as is
-    def_delegators  :backend, :as, :with, :within, :upload!, :download!
+    def_delegators  :backend, :as, :with, :within, :upload!, :download!, :debug, :info, :warn, :error, :fatal
 
     # Customized delegated methods, they automatically inject
     # options into the call argument list.


### PR DESCRIPTION
Closes https://github.com/StackStorm/st2-packages/issues/148
Will help shipping the https://github.com/StackStorm/st2/pull/3561/ 

Currently the build is designed to always `git clone` the `st2` or `st2mistral` code.

This PR allows sharing the `st2` or `st2mistral` code, when build triggered in repo.
Also fixes running `st2-packages` builds in forked PRs under the `stackstorm/st2` repo (contributions).

### Examples
* `ST2_CHECKOUT=0 ST2_GITDIR="/tmp/st2"`
* `ST2MISTRAL_CHECKOUT=0 ST2MISTRAL_GITDIR="/tmp/st2mistral"`

Will use existing dirs `/tmp/st2` `/tmp/st2mistral`, instead of relying on remote github.