### PR TITLE
Use docker-compose 0.14.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -54,7 +54,7 @@ dependencies:
     - sudo .circle/fix-cache-permissions.sh
     - sudo apt-get -y install parallel jq
     - gem install package_cloud
-    - sudo pip install wheel docker-compose
+    - sudo pip install wheel "docker-compose==1.14.0"
     - docker-compose version
     - docker version
   override:


### PR DESCRIPTION
Our builds started failing today with the error mentioned below and new version of docker compose was released yesterday (https://pypi.python.org/pypi/docker-compose/1.15.0).

```bash
.circle/docker-compose.sh pull ${DISTRO} || .circle/docker-compose.sh pull ${DISTRO}
+ case "$1" in
+ echo Pulling dependent Docker images for trusty ...
Pulling dependent Docker images for trusty ...
+ docker-compose -f docker-compose.circle.yml run -e ST2_GITURL=https://github.com/StackStorm/st2 -e ST2_GITREV=mistral-jinja-filter-itests -e ST2PKG_VERSION=2.4dev -e ST2PKG_RELEASE=58 -e RABBITMQHOST=172.18.0.1 -e POSTGRESHOST=172.18.0.1 -e MONGODBHOST=172.18.0.1 -e ST2_CIRCLE_URL=https://circleci.com/gh/StackStorm/st2-packages/2648 trusty /bin/true
ERROR: Cannot extend service 'suite' in /home/ubuntu/st2-packages/docker-compose.override.yml: Service not found
+ case "$1" in
+ echo Pulling dependent Docker images for trusty ...
Pulling dependent Docker images for trusty ...
+ docker-compose -f docker-compose.circle.yml run -e ST2_GITURL=https://github.com/StackStorm/st2 -e ST2_GITREV=mistral-jinja-filter-itests -e ST2PKG_VERSION=2.4dev -e ST2PKG_RELEASE=58 -e RABBITMQHOST=172.18.0.1 -e POSTGRESHOST=172.18.0.1 -e MONGODBHOST=172.18.0.1 -e ST2_CIRCLE_URL=https://circleci.com/gh/StackStorm/st2-packages/2648 trusty /bin/true
ERROR: Cannot extend service 'suite' in /home/ubuntu/st2-packages/docker-compose.override.yml: Service not found

.circle/docker-compose.sh pull ${DISTRO} || .circle/docker-compose.sh pull ${DISTRO} returned exit code 1

Action failed: .circle/docker-compose.sh pull ${DISTRO} || .circle/docker-compose.sh pull ${DISTRO}
```

https://circleci.com/gh/StackStorm/st2-packages/2648

Coincidence? Unlikely :P