### PR TITLE
Trigger e2etests for PR in st2 repo Changes

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -37,6 +37,9 @@ setup_args() {
           REPO_TYPE='staging'
           shift
           ;;
+          # Used to install the packages from CircleCI build artifacts
+          # Examples: 'st2/5017', 'mistral/1012', 'st2-packages/3021',
+          # where first part is repository name, second is CircleCI build number.
           --dev=*)
           DEV_BUILD="${i#*=}"
           shift

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -311,12 +311,13 @@ install_st2() {
   # Following script adds a repo file, registers gpg key and runs apt-get update
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.deb.sh | sudo bash
 
-  if [ "$DEV_BUILD" = '' ]; then
+  # 'mistral' repo builds single 'st2mistral' package and so we have to install 'st2' from repo
+  if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^mistral/.* ]]; then
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
     sudo apt-get install -y st2${ST2_PKG_VERSION}
   else
     sudo apt-get install -y jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "${SUBTYPE}/st2_.*.deb")"
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "${SUBTYPE}/st2_.*.deb")"
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
     sudo dpkg -i --force-depends ${PACKAGE_FILENAME}
@@ -454,12 +455,12 @@ EHD
 }
 
 install_st2mistral() {
-  # install mistral
-  if [ "$DEV_BUILD" = '' ]; then
+  # 'st2' repo builds single 'st2' package and so we have to install 'st2mistral' from repo
+  if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^st2/.* ]]; then
     sudo apt-get install -y st2mistral${ST2MISTRAL_PKG_VERSION}
   else
     sudo apt-get install -y jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "${SUBTYPE}/st2mistral_.*.deb")"
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "${SUBTYPE}/st2mistral_.*.deb")"
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
     sudo dpkg -i --force-depends ${PACKAGE_FILENAME}

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -343,12 +343,13 @@ EOF
 install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.rpm.sh | sudo bash
 
-  if [ "$DEV_BUILD" = '' ]; then
+  # 'mistral' repo builds single 'st2mistral' package and so we have to install 'st2' from repo
+  if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^mistral/.* ]]; then
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
     sudo yum -y install ${ST2_PKG}
   else
     sudo yum -y install jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el6/st2-.*.rpm")"
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el6/st2-.*.rpm")"
     sudo yum -y install ${PACKAGE_URL}
   fi
 
@@ -520,12 +521,12 @@ EHD
 }
 
 install_st2mistral() {
-  # install mistral
-  if [ "$DEV_BUILD" = '' ]; then
+  # 'st2' repo builds single 'st2' package and so we have to install 'st2mistral' from repo
+  if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^st2/.* ]]; then
     sudo yum -y install ${ST2MISTRAL_PKG}
   else
     sudo yum -y install jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el6/st2mistral-.*.rpm")"
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el6/st2mistral-.*.rpm")"
     sudo yum -y install ${PACKAGE_URL}
   fi
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -329,12 +329,13 @@ EOF
 install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.rpm.sh | sudo bash
 
-  if [ "$DEV_BUILD" = '' ]; then
+  # 'mistral' repo builds single 'st2mistral' package and so we have to install 'st2' from repo
+  if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^mistral/.* ]]; then
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
     sudo yum -y install ${ST2_PKG}
   else
     sudo yum -y install jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el7/st2-.*.rpm")"
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el7/st2-.*.rpm")"
     sudo yum -y install ${PACKAGE_URL}
   fi
 
@@ -497,12 +498,12 @@ EHD
 }
 
 install_st2mistral() {
-  # install mistral
-  if [ "$DEV_BUILD" = '' ]; then
+  # 'st2' repo builds single 'st2' package and so we have to install 'st2mistral' from repo
+  if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^st2/.* ]]; then
     sudo yum -y install ${ST2MISTRAL_PKG}
   else
     sudo yum -y install jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/st2-packages/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el7/st2mistral-.*.rpm")"
+    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el7/st2mistral-.*.rpm")"
     sudo yum -y install ${PACKAGE_URL}
   fi
 


### PR DESCRIPTION
These are `curl|bash` changes required to trigger the `e2e` tests in `st2` repo for PRs via https://github.com/StackStorm/st2/pull/3625.

Different repos generate different sets of artifacts:
- `st2` repo generates `st2` deb/rpm packages
- `mistral` repo generates `st2mistral` deb/rpm packages
- `st2-packages` repo generates both `st2` + `st2mistral`


With that, new 'dev' build format for the `curl|bash` installer is the following:
```
 ./st2bootstrap-deb.sh --dev=st2/5017 --staging --unstable
 ./st2bootstrap-deb.sh --dev=mistral/1012 --staging --unstable
 ./st2bootstrap-deb.sh --dev=st2-packages/3021 --staging --unstable
```
which includes both repo + build number in that repo, instead of hardcoding to `st2-packages` build num as it was before.
