### PR TITLE
Install MongoDB 3.4 by default

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -46,7 +46,7 @@ rabbitmq:
     - "5672:5672"
 
 mongodb:
-  image: mongo:3.2
+  image: mongo:3.4
   ports:
     - "27017:27017"
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -171,7 +171,7 @@ check_st2_host_dependencies() {
   VAR_SPACE=`df -Pk /var/lib | grep -vE '^Filesystem|tmpfs|cdrom' | awk '{print $4}'`
   if [ ${VAR_SPACE} -lt 358400 ]; then
     echo ""
-    echo "MongoDB 3.2 requires at least 350MB free in /var/lib/mongodb"
+    echo "MongoDB 3.4 requires at least 350MB free in /var/lib/mongodb"
     echo "There is not enough space for MongoDB. It will fail to start."
     echo "Please, add some space to /var or clean it up."
     exit 1
@@ -206,9 +206,9 @@ install_st2_dependencies() {
 }
 
 install_mongodb() {
-  # Add key and repo for the latest stable MongoDB (3.2)
+  # Add key and repo for the latest stable MongoDB (3.4)
   sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
-  echo "deb http://repo.mongodb.org/apt/ubuntu ${SUBTYPE}/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+  echo "deb http://repo.mongodb.org/apt/ubuntu ${SUBTYPE}/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
 
   sudo apt-get update
   sudo apt-get install -y mongodb-org

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -256,7 +256,7 @@ check_st2_host_dependencies() {
   VAR_SPACE=`df -Pk /var/lib | grep -vE '^Filesystem|tmpfs|cdrom' | awk '{print $4}'`
   if [ ${VAR_SPACE} -lt 358400 ]; then
     echo ""
-    echo "MongoDB 3.2 requires at least 350MB free in /var/lib/mongodb"
+    echo "MongoDB 3.4 requires at least 350MB free in /var/lib/mongodb"
     echo "There is not enough space for MongoDB. It will fail to start."
     echo "Please, add some space to /var or clean it up."
     exit 1
@@ -287,15 +287,15 @@ install_st2_dependencies() {
 }
 
 install_mongodb() {
-  # Add key and repo for the latest stable MongoDB (3.2)
-  sudo rpm --import https://www.mongodb.org/static/pgp/server-3.2.asc
-  sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
-[mongodb-org-3.2]
+  # Add key and repo for the latest stable MongoDB (3.4)
+  sudo rpm --import https://www.mongodb.org/static/pgp/server-3.4.asc
+  sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.4.repo
+[mongodb-org-3.4]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/6Server/mongodb-org/3.2/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/6Server/mongodb-org/3.4/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
+gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
 EOT"
 
   sudo yum -y install mongodb-org

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -242,7 +242,7 @@ check_st2_host_dependencies() {
   VAR_SPACE=`df -Pk /var/lib | grep -vE '^Filesystem|tmpfs|cdrom' | awk '{print $4}'`
   if [ ${VAR_SPACE} -lt 358400 ]; then
     echo ""
-    echo "MongoDB 3.2 requires at least 350MB free in /var/lib/mongodb"
+    echo "MongoDB 3.4 requires at least 350MB free in /var/lib/mongodb"
     echo "There is not enough space for MongoDB. It will fail to start."
     echo "Please, add some space to /var or clean it up."
     exit 1
@@ -273,15 +273,15 @@ install_st2_dependencies() {
 }
 
 install_mongodb() {
-  # Add key and repo for the latest stable MongoDB (3.2)
-  sudo rpm --import https://www.mongodb.org/static/pgp/server-3.2.asc
-  sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
-[mongodb-org-3.2]
+  # Add key and repo for the latest stable MongoDB (3.4)
+  sudo rpm --import https://www.mongodb.org/static/pgp/server-3.4.asc
+  sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.4.repo
+[mongodb-org-3.4]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.2/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.4/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
+gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
 EOT"
 
   sudo yum -y install mongodb-org


### PR DESCRIPTION
Our code has supported 3.4 and we have been running tests with MongoDB 3.4 for a long time so it's time to switch to it in StackStorm v2.4.0.

Resolves https://github.com/StackStorm/st2/issues/3592.