### PR TITLE
Remove 'sleep 30' timeout hack for Xenial

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -553,13 +553,6 @@ configure_st2chatops() {
 }
 
 verify_st2() {
-
-  # TODO: This is a temporary and nasty workaround for xenial CI failures.
-  # TODO: Fix https://github.com/StackStorm/st2/issues/3290
-  if [[ "$SUBTYPE" == 'xenial' ]]; then
-    sleep 30
-  fi
-
   st2 --version
   st2 -h
 


### PR DESCRIPTION
Xenial stuck bug is fixed in https://github.com/StackStorm/st2/issues/3290 so we can remove nasty `sleep 30` hack from our `curl|bash` installer.

Big thanks @Kami for diving deep to find the root cause & fixing it.