### PR TITLE
Fix CI docker volumes cleanup

### DIFF
--- a/.circle/docker-compose2.sh
+++ b/.circle/docker-compose2.sh
@@ -18,8 +18,7 @@ case "$1" in
   # containers running from the previous cached build
   clean)
     echo Cleaning cached Docker containers which could be there from the previous build ...
-    docker-compose -f docker-compose.circle2.yml -f docker-compose.override.yml kill
-    docker-compose -f docker-compose.circle2.yml -f docker-compose.override.yml rm -f
+    docker-compose -f docker-compose.circle2.yml -f docker-compose.override.yml rm -v --stop --force || true
   ;;
   # Perform fake command invocation, technically provides images "pull" phase.
   pull)

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -2,7 +2,7 @@ trusty:
   image: quay.io/stackstorm/packagingrunner
   working_dir: /root/st2-packages
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
   environment:
     - BUILDNODE=trustybuild
     - TESTNODE=trustytest
@@ -17,7 +17,7 @@ xenial:
   image: quay.io/stackstorm/packagingrunner
   working_dir: /root/st2-packages
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
   environment:
     - BUILDNODE=xenialbuild
     - TESTNODE=xenialtest
@@ -32,7 +32,7 @@ el7:
   image: quay.io/stackstorm/packagingrunner
   working_dir: /root/st2-packages
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
   environment:
     - BUILDNODE=centos7build
     - TESTNODE=centos7test
@@ -47,7 +47,7 @@ el6:
   image: quay.io/stackstorm/packagingrunner
   working_dir: /root/st2-packages
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
   environment:
     - ST2_PYTHON=1
     - BUILDNODE=centos6build
@@ -64,47 +64,47 @@ el6:
 trustybuild:
   image: stackstorm/packagingbuild:trusty
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
 
 xenialbuild:
   image: stackstorm/packagingbuild:xenial
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
 
 centos6build:
   image: stackstorm/packagingbuild:centos6
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
 
 centos7build:
   image: stackstorm/packagingbuild:centos7
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
 
 ## Package testing nodes
 #
 trustytest:
   image: stackstorm/packagingtest:trusty-upstart
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
 
 xenialtest:
   image: stackstorm/packagingtest:xenial-systemd
   privileged: true
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 centos6test:
   image: stackstorm/packagingtest:centos6-sshd
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
 
 centos7test:
   image: stackstorm/packagingtest:centos7-systemd
   privileged: true
   volumes_from:
-    - st2-packages-vol
+    - container:st2-packages-vol
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -2,7 +2,7 @@ trusty:
   image: quay.io/stackstorm/packagingrunner
   working_dir: /root/st2-packages
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
   environment:
     - BUILDNODE=trustybuild
     - TESTNODE=trustytest
@@ -17,7 +17,7 @@ xenial:
   image: quay.io/stackstorm/packagingrunner
   working_dir: /root/st2-packages
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
   environment:
     - BUILDNODE=xenialbuild
     - TESTNODE=xenialtest
@@ -32,7 +32,7 @@ el7:
   image: quay.io/stackstorm/packagingrunner
   working_dir: /root/st2-packages
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
   environment:
     - BUILDNODE=centos7build
     - TESTNODE=centos7test
@@ -47,7 +47,7 @@ el6:
   image: quay.io/stackstorm/packagingrunner
   working_dir: /root/st2-packages
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
   environment:
     - ST2_PYTHON=1
     - BUILDNODE=centos6build
@@ -64,47 +64,47 @@ el6:
 trustybuild:
   image: stackstorm/packagingbuild:trusty
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
 
 xenialbuild:
   image: stackstorm/packagingbuild:xenial
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
 
 centos6build:
   image: stackstorm/packagingbuild:centos6
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
 
 centos7build:
   image: stackstorm/packagingbuild:centos7
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
 
 ## Package testing nodes
 #
 trustytest:
   image: stackstorm/packagingtest:trusty-upstart
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
 
 xenialtest:
   image: stackstorm/packagingtest:xenial-systemd
   privileged: true
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 centos6test:
   image: stackstorm/packagingtest:centos6-sshd
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
 
 centos7test:
   image: stackstorm/packagingtest:centos7-systemd
   privileged: true
   volumes_from:
-    - container:st2-packages-vol
+    - st2-packages-vol
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup


### PR DESCRIPTION
Associated change in st2: https://github.com/StackStorm/st2/pull/3668

Don't fail when cleaning up via docker-compose.
See: https://discuss.circleci.com/t/no-space-left-on-device-while-creating-mongo/11532/13