### PR TITLE
Switch to st2 pack install

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -573,7 +573,7 @@ verify_st2() {
   st2 run core.remote hosts='127.0.0.1' -- uname -a
 
   # Install a pack
-  st2 run packs.install packs=st2
+  st2 pack install st2
 }
 
 ok_message() {

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -486,7 +486,7 @@ verify_st2() {
   st2 run core.remote hosts='127.0.0.1' -- uname -a
 
   # Install a pack
-  st2 run packs.install packs=st2
+  st2 pack install st2
 }
 
 install_st2mistral_depdendencies() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -409,7 +409,7 @@ verify_st2() {
   st2 run core.remote hosts='127.0.0.1' -- uname -a
 
   # Install a pack
-  st2 run packs.install packs=st2
+  st2 pack install st2
 }
 
 configure_st2_cli_config() {


### PR DESCRIPTION
Switch to using `st2 pack install` rather than legacy `st2 run packs.install`

Fixes #482 