### PR TITLE
Fix CentOS7 st2chatops installation failure

### DIFF
--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -554,6 +554,11 @@ EOT"
 }
 
 install_st2chatops() {
+  # Temporary hack until proper upstream fix https://bugs.centos.org/view.php?id=13669
+  if ! yum list http-parser 1>/dev/null 2>&1; then
+    sudo yum install -y https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
+  fi
+
   # Add NodeJS 6 repo
   curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash -
 


### PR DESCRIPTION
Temporary hack to install removed in EPEL repository `http-parser` package `nodejs` depends on until proper upstream fix https://bugs.centos.org/view.php?id=13669 is released.

From the above link: 
> As it was explained to me... http-parser was added to the RedHat Base repository for 7.4, therefore EPEL removed it.
This results in a gap in time where CentOS 7.4 has not yet been released, and the EPEL has a Nodejs package with http-parser as a dependency which cannot be resolved.

which looks pathological.

----

TODO: revert when CentOS 7.4 is relased.