### PR TITLE
Suppress mistral db errors in bootstrap script

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -475,7 +475,7 @@ install_st2mistral() {
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
 
   # Register mistral actions.
-  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate | grep -v openstack
 
   # Start Mistral
   sudo service mistral start

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -537,7 +537,7 @@ install_st2mistral() {
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
 
   # Register mistral actions.
-  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate | grep -v openstack
 
   # start mistral
   sudo service mistral start

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -514,7 +514,7 @@ install_st2mistral() {
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
 
   # Register mistral actions.
-  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate | grep -v openstack
 
   # start mistral
   sudo systemctl start mistral


### PR DESCRIPTION
Lots of errors when populating Mistral's DB:

```
......
2017-08-18 17:08:02.272 17431 ERROR mistral.actions.openstack.action_generator.base [-] Failed to create action: neutron.update_policy_profile: AttributeError: 'Client' object has no attribute 'update_policy_profile'
2017-08-18 17:08:02.272 17431 ERROR mistral.actions.openstack.action_generator.base Traceback (most recent call last):
2017-08-18 17:08:02.272 17431 ERROR mistral.actions.openstack.action_generator.base   File "/opt/stackstorm/mistral/lib/python2.7/site-packages/mistral/actions/openstack/action_generator/base.py", line 143, in create_actions
2017-08-18 17:08:02.272 17431 ERROR mistral.actions.openstack.action_generator.base     client_method = class_.get_fake_client_method()
2017-08-18 17:08:02.272 17431 ERROR mistral.actions.openstack.action_generator.base   File "/opt/stackstorm/mistral/lib/python2.7/site-packages/mistral/actions/openstack/base.py", line 75, in get_fake_client_method
2017-08-18 17:08:02.272 17431 ERROR mistral.actions.openstack.action_generator.base     return cls._get_client_method(cls._get_fake_client())
2017-08-18 17:08:02.272 17431 ERROR mistral.actions.openstack.action_generator.base   File "/opt/stackstorm/mistral/lib/python2.7/site-packages/mistral/actions/openstack/base.py", line 59, in _get_client_method
2017-08-18 17:08:02.272 17431 ERROR mistral.actions.openstack.action_generator.base     attribute = getattr(attribute, attr)
2017-08-18 17:08:02.272 17431 ERROR mistral.actions.openstack.action_generator.base AttributeError: 'Client' object has no attribute 'update_policy_profile'
2017-08-18 17:08:02.272 17431 ERROR mistral.actions.openstack.action_generator.base
2017-08-18 17:08:02.273 17431 ERROR mistral.actions.openstack.action_generator.base [-] Failed to create action: neutron.show_policy_profile: AttributeError: 'Client' object has no attribute 'show_policy_profile'
2017-08-18 17:08:02.273 17431 ERROR mistral.actions.openstack.action_generator.base Traceback (most recent call last):
2017-08-18 17:08:02.273 17431 ERROR mistral.actions.openstack.action_generator.base   File "/opt/stackstorm/mistral/lib/python2.7/site-packages/mistral/actions/openstack/action_generator/base.py", line 143, in create_actions
2017-08-18 17:08:02.273 17431 ERROR mistral.actions.openstack.action_generator.base     client_method = class_.get_fake_client_method()
2017-08-18 17:08:02.273 17431 ERROR mistral.actions.openstack.action_generator.base   File "/opt/stackstorm/mistral/lib/python2.7/site-packages/mistral/actions/openstack/base.py", line 75, in get_fake_client_method
2017-08-18 17:08:02.273 17431 ERROR mistral.actions.openstack.action_generator.base     return cls._get_client_method(cls._get_fake_client())
2017-08-18 17:08:02.273 17431 ERROR mistral.actions.openstack.action_generator.base   File "/opt/stackstorm/mistral/lib/python2.7/site-packages/mistral/actions/openstack/base.py", line 59, in _get_client_method
2017-08-18 17:08:02.273 17431 ERROR mistral.actions.openstack.action_generator.base     attribute = getattr(attribute, attr)
2017-08-18 17:08:02.273 17431 ERROR mistral.actions.openstack.action_generator.base AttributeError: 'Client' object has no attribute 'show_policy_profile'
2017-08-18 17:08:02.273 17431 ERROR mistral.actions.openstack.action_generator.base
.....
```

This is expected behavior, but extremely distracting, and potentially going to turn some heads. To avoid the riots, we can suppress these messages by piping to `grep` and excluding anything with `openstack` in it:

```
[ec2-user@ip-10-0-4-82 ~]$ /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate | grep -v openstack
2017-08-18 17:15:28.496 17586 INFO mistral.db.sqlalchemy.migration.cli [-] populating db
2017-08-18 17:15:28.498 17586 WARNING oslo_db.sqlalchemy.engines [-] URL postgresql://mistral:***@127.0.0.1/mistral does not contain a '+drivername' portion, and will make use of a default driver.  A full dbname+drivername:// protocol is recommended.
[ec2-user@ip-10-0-4-82 ~]$
```