### PR TITLE
changed setup-chatops link to OS-specific

### DIFF
--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -613,7 +613,7 @@ configure_st2chatops() {
     echo "  $ sudo service st2chatops restart"
     echo ""
     echo "For more information, please refer to documentation at  "
-    echo "https://docs.stackstorm.com/install/deb.html#setup-chatops"
+    echo "https://docs.stackstorm.com/install/rhel6.html#setup-chatops"
     echo "########################################################"
   fi
 }

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -596,7 +596,7 @@ configure_st2chatops() {
     echo "  $ sudo service st2chatops restart"
     echo ""
     echo "For more information, please refer to documentation at  "
-    echo "https://docs.stackstorm.com/install/deb.html#setup-chatops"
+    echo "https://docs.stackstorm.com/install/rhel7.html#setup-chatops"
     echo "########################################################"
   fi
 }


### PR DESCRIPTION
ChatOps setup link was to Ubuntu page. Have changed RHEL pages to appropriate link.