### PR TITLE
Print a more user-friendly error message in case we fail to retrieve package version

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -52,6 +52,7 @@ setup_args() {
           --password=*)
           PASSWORD="${i#*=}"
           shift
+          ;;
           --force-branch=*)
           FORCE_BRANCH="${i#*=}"
           shift

--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -16,6 +16,7 @@ PASSWORD=''
 
 # Note: This variable needs to default to a branch of the latest stable release
 BRANCH='v2.4'
+FORCE_BRANCH=""
 
 setup_args() {
   for i in "$@"
@@ -50,6 +51,9 @@ setup_args() {
           ;;
           --password=*)
           PASSWORD="${i#*=}"
+          shift
+          --force-branch=*)
+          FORCE_BRANCH="${i#*=}"
           shift
           ;;
           *)
@@ -119,6 +123,11 @@ fi
 
 if [[ "$DEV_BUILD" != '' ]]; then
   DEV_BUILD="--dev=${DEV_BUILD}"
+fi
+
+if [[ "${FORCE_BRANCH}" != "" ]]; then
+    echo "Using branch ${FORCE_BRANCH}"
+    BRANCH=${FORCE_BRANCH}
 fi
 
 USERNAME="--user=${USERNAME}"

--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -127,8 +127,7 @@ if [[ "$DEV_BUILD" != '' ]]; then
 fi
 
 if [[ "${FORCE_BRANCH}" != "" ]]; then
-    echo "Using branch ${FORCE_BRANCH}"
-    BRANCH=${FORCE_BRANCH}
+  BRANCH=${FORCE_BRANCH}
 fi
 
 USERNAME="--user=${USERNAME}"

--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -53,6 +53,9 @@ setup_args() {
           PASSWORD="${i#*=}"
           shift
           ;;
+          # Used to specify which branch of st2-packages repo to use. This comes handy when you
+          # need to use a non-master branch of st2-package repo (e.g. when testing installer script
+          # changes which are in a branch)
           --force-branch=*)
           FORCE_BRANCH="${i#*=}"
           shift

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -317,7 +317,19 @@ install_st2() {
     sudo apt-get install -y st2${ST2_PKG_VERSION}
   else
     sudo apt-get install -y jq
+
+    echo "Retrieving package from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts"
+
+    # Note: We disable global error handler because we want a more user-friendly error message
+    set +e
     PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "${SUBTYPE}/st2_.*.deb")"
+    set -e
+
+    if [ ! ${PACKAGE_URL} ]; then
+        echo "Failed to retrieve package from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts"
+        exit 2
+    fi
+
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
     sudo dpkg -i --force-depends ${PACKAGE_FILENAME}

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -127,7 +127,7 @@ function get_package_url() {
   fi
 
   PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
-  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/.*${PACKAGE_NAME_REGEX}")
+  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/${PACKAGE_NAME_REGEX}")
 
   if [ -z "${PACKAGE_URL}" ]; then
       echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})"

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -333,6 +333,7 @@ install_st2() {
 
     if [ -z "${PACKAGE_URL}" ]; then
         echo "Failed to find url for ${SUBTYPE} deb package"
+        echo "Circle CI response: ${PACKAGES_METADATA}"
         exit 2
     fi
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -122,17 +122,17 @@ function get_package_url() {
   PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)
 
   if [ -z "${PACKAGES_METADATA}" ]; then
-      echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts"
-      exit 2
+      echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts" 1>&2
+      return 2
   fi
 
   PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
   PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/${PACKAGE_NAME_REGEX}")
 
   if [ -z "${PACKAGE_URL}" ]; then
-      echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})"
-      echo "Circle CI response: ${PACKAGES_METADATA}"
-      exit 2
+      echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})" 1>&2
+      echo "Circle CI response: ${PACKAGES_METADATA}" 1>&2
+      return 2
   fi
 
   echo ${PACKAGE_URL}
@@ -343,16 +343,7 @@ install_st2() {
   else
     sudo apt-get install -y jq
 
-    # Note: We disable global error handler because we want to print a more user-friendly error message
-    set +e
     PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "${SUBTYPE}" "st2_.*.deb")
-
-    if [ -z "${PACKAGE_URL}" ]; then
-        exit 2
-    fi
-    # Re-enable a global error handler
-    set -e
-
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
     sudo dpkg -i --force-depends ${PACKAGE_FILENAME}
@@ -496,16 +487,7 @@ install_st2mistral() {
   else
     sudo apt-get install -y jq
 
-    # Note: We disable global error handler because we want to print a more user-friendly error message
-    set +e
     PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "${SUBTYPE}" "st2mistral_.*.deb")
-
-    if [ -z "${PACKAGE_URL}" ]; then
-        exit 2
-    fi
-    # Re-enable a global error handler
-    set -e
-
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
     sudo dpkg -i --force-depends ${PACKAGE_FILENAME}

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -116,7 +116,7 @@ setup_args() {
 function get_package_url() {
   # Retrieve direct package URL for the provided dev build, subtype and package name regex.
   DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
-  SUBTYPE=$2
+  DISTRO=$2  # Distro name (e.g. trusty,xenial,el6,el7)
   PACKAGE_NAME_REGEX=$3
 
   PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)
@@ -127,10 +127,10 @@ function get_package_url() {
   fi
 
   PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
-  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${SUBTYPE}/.*${PACKAGE_NAME_REGEX}")
+  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/.*${PACKAGE_NAME_REGEX}")
 
   if [ -z "${PACKAGE_URL}" ]; then
-      echo "Failed to find url for ${SUBTYPE} deb package (${PACKAGE_NAME_REGEX})"
+      echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})"
       echo "Circle CI response: ${PACKAGES_METADATA}"
       exit 2
   fi

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -113,6 +113,32 @@ setup_args() {
   fi
 }
 
+function get_package_url() {
+  # Retrieve direct package URL for the provided dev build, subtype and package name regex.
+  DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
+  SUBTYPE=$2
+  PACKAGE_NAME_REGEX=$3
+
+  PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)
+
+  if [ -z "${PACKAGES_METADATA}" ]; then
+      echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts"
+      exit 2
+  fi
+
+  PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
+  PACKAGE_URL=$(echo ${PACKAGES_URLS} | egrep "${SUBTYPE}/${PACKAGE_NAME_REGEX}")
+
+
+  if [ -z "${PACKAGE_URL}" ]; then
+      echo "Failed to find url for ${SUBTYPE} deb package (${PACKAGE_NAME_REGEX})"
+      echo "Circle CI response: ${PACKAGES_METADATA}"
+      exit 2
+  fi
+
+  echo ${PACKAGE_URL}
+}
+
 function port_status() {
   # If the specified tcp4 port is bound, then return the "port pid/procname",
   # else if a pipe command fails, return "Unbound",
@@ -318,25 +344,15 @@ install_st2() {
   else
     sudo apt-get install -y jq
 
-    echo "Retrieving packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts"
 
-    # Note: We disable global error handler because we want a more user-friendly error message
+    # Note: We disable global error handler because we want to print a more user-friendly error message
     set +e
-    PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)
-
-    if [ -z "${PACKAGES_METADATA}" ]; then
-        echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts"
-        exit 2
-    fi
-
-    PACKAGE_URL="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url' | egrep "${SUBTYPE}/st2_.*.deb")"
+    PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "${SUBTYPE}" "st2_.*.deb")
 
     if [ -z "${PACKAGE_URL}" ]; then
-        echo "Failed to find url for ${SUBTYPE} deb package"
-        echo "Circle CI response: ${PACKAGES_METADATA}"
         exit 2
     fi
-
+    # Re-enable a global error handler
     set -e
 
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
@@ -481,7 +497,17 @@ install_st2mistral() {
     sudo apt-get install -y st2mistral${ST2MISTRAL_PKG_VERSION}
   else
     sudo apt-get install -y jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "${SUBTYPE}/st2mistral_.*.deb")"
+
+    # Note: We disable global error handler because we want to print a more user-friendly error message
+    set +e
+    PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "${SUBTYPE}" "st2mistral_.*.deb")
+
+    if [ -z "${PACKAGE_URL}" ]; then
+        exit 2
+    fi
+    # Re-enable a global error handler
+    set -e
+
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
     sudo dpkg -i --force-depends ${PACKAGE_FILENAME}

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -127,7 +127,7 @@ function get_package_url() {
   fi
 
   PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
-  PACKAGE_URL=$(echo ${PACKAGES_URLS} | egrep "${SUBTYPE}/${PACKAGE_NAME_REGEX}")
+  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${SUBTYPE}/build/${PACKAGE_NAME_REGEX}")
 
 
   if [ -z "${PACKAGE_URL}" ]; then

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -324,14 +324,14 @@ install_st2() {
     set +e
     PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)
 
-    if [ ! ${PACKAGES_METADATA} ]; then
+    if [ -z "${PACKAGES_METADATA}" ]; then
         echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts"
         exit 2
     fi
 
     PACKAGE_URL="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url' | egrep "${SUBTYPE}/st2_.*.deb")"
 
-    if [ ! ${PACKAGE_URL} ]; then
+    if [ -z "${PACKAGE_URL}" ]; then
         echo "Failed to find url for ${SUBTYPE} deb package"
         exit 2
     fi

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -127,8 +127,7 @@ function get_package_url() {
   fi
 
   PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
-  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${SUBTYPE}/build/${PACKAGE_NAME_REGEX}")
-
+  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${SUBTYPE}/.*${PACKAGE_NAME_REGEX}")
 
   if [ -z "${PACKAGE_URL}" ]; then
       echo "Failed to find url for ${SUBTYPE} deb package (${PACKAGE_NAME_REGEX})"
@@ -343,7 +342,6 @@ install_st2() {
     sudo apt-get install -y st2${ST2_PKG_VERSION}
   else
     sudo apt-get install -y jq
-
 
     # Note: We disable global error handler because we want to print a more user-friendly error message
     set +e

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -121,7 +121,7 @@ function get_package_url() {
   PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)
 
   if [ -z "${PACKAGES_METADATA}" ]; then
-      echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts"
+      echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts" 1>&2
       exit 2
   fi
 
@@ -129,8 +129,8 @@ function get_package_url() {
   PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/${PACKAGE_NAME_REGEX}")
 
   if [ -z "${PACKAGE_URL}" ]; then
-      echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})"
-      echo "Circle CI response: ${PACKAGES_METADATA}"
+      echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})" 1>&2
+      echo "Circle CI response: ${PACKAGES_METADATA}" 1>&2
       exit 2
   fi
 
@@ -376,16 +376,7 @@ install_st2() {
   else
     sudo yum -y install jq
 
-    # Note: We disable global error handler because we want to print a more user-friendly error message
-    set +e
     PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "el6" "st2-.*.rpm")
-
-    if [ -z "${PACKAGE_URL}" ]; then
-        exit 2
-    fi
-    # Re-enable a global error handler
-    set -e
-
     sudo yum -y install ${PACKAGE_URL}
   fi
 
@@ -563,16 +554,7 @@ install_st2mistral() {
   else
     sudo yum -y install jq
 
-    # Note: We disable global error handler because we want to print a more user-friendly error message
-    set +e
     PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "el6" "st2mistral-.*.rpm")
-
-    if [ -z "${PACKAGE_URL}" ]; then
-        exit 2
-    fi
-    # Re-enable a global error handler
-    set -e
-
     sudo yum -y install ${PACKAGE_URL}
   fi
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -126,7 +126,7 @@ function get_package_url() {
   fi
 
   PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
-  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/.*${PACKAGE_NAME_REGEX}")
+  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/${PACKAGE_NAME_REGEX}")
 
   if [ -z "${PACKAGE_URL}" ]; then
       echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})"

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -122,7 +122,7 @@ function get_package_url() {
 
   if [ -z "${PACKAGES_METADATA}" ]; then
       echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts" 1>&2
-      exit 2
+      return 2
   fi
 
   PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
@@ -131,7 +131,7 @@ function get_package_url() {
   if [ -z "${PACKAGE_URL}" ]; then
       echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})" 1>&2
       echo "Circle CI response: ${PACKAGES_METADATA}" 1>&2
-      exit 2
+      return 2
   fi
 
   echo ${PACKAGE_URL}

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -125,7 +125,7 @@ function get_package_url() {
   fi
 
   PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
-  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/.*${PACKAGE_NAME_REGEX}")
+  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/${PACKAGE_NAME_REGEX}")
 
   if [ -z "${PACKAGE_URL}" ]; then
       echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})"

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -114,7 +114,7 @@ install_yum_utils() {
 function get_package_url() {
   # Retrieve direct package URL for the provided dev build, subtype and package name regex.
   DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
-  SUBTYPE=$2
+  DISTRO=$2  # Distro name (e.g. trusty,xenial,el6,el7)
   PACKAGE_NAME_REGEX=$3
 
   PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)
@@ -125,10 +125,10 @@ function get_package_url() {
   fi
 
   PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
-  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${SUBTYPE}/.*${PACKAGE_NAME_REGEX}")
+  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/.*${PACKAGE_NAME_REGEX}")
 
   if [ -z "${PACKAGE_URL}" ]; then
-      echo "Failed to find url for ${SUBTYPE} deb package (${PACKAGE_NAME_REGEX})"
+      echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})"
       echo "Circle CI response: ${PACKAGES_METADATA}"
       exit 2
   fi

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -111,6 +111,31 @@ install_yum_utils() {
   sudo yum install -y yum-utils
 }
 
+function get_package_url() {
+  # Retrieve direct package URL for the provided dev build, subtype and package name regex.
+  DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
+  SUBTYPE=$2
+  PACKAGE_NAME_REGEX=$3
+
+  PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)
+
+  if [ -z "${PACKAGES_METADATA}" ]; then
+      echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts"
+      exit 2
+  fi
+
+  PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
+  PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${SUBTYPE}/.*${PACKAGE_NAME_REGEX}")
+
+  if [ -z "${PACKAGE_URL}" ]; then
+      echo "Failed to find url for ${SUBTYPE} deb package (${PACKAGE_NAME_REGEX})"
+      echo "Circle CI response: ${PACKAGES_METADATA}"
+      exit 2
+  fi
+
+  echo ${PACKAGE_URL}
+}
+
 
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
@@ -335,7 +360,17 @@ install_st2() {
     sudo yum -y install ${ST2_PKG}
   else
     sudo yum -y install jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el7/st2-.*.rpm")"
+
+    # Note: We disable global error handler because we want to print a more user-friendly error message
+    set +e
+    PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "el7" "st2-.*.rpm")
+
+    if [ -z "${PACKAGE_URL}" ]; then
+        exit 2
+    fi
+    # Re-enable a global error handler
+    set -e
+
     sudo yum -y install ${PACKAGE_URL}
   fi
 
@@ -503,7 +538,17 @@ install_st2mistral() {
     sudo yum -y install ${ST2MISTRAL_PKG}
   else
     sudo yum -y install jq
-    PACKAGE_URL="$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts | jq -r '.[].url' | egrep "el7/st2mistral-.*.rpm")"
+
+    # Note: We disable global error handler because we want to print a more user-friendly error message
+    set +e
+    PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "el7" "st2mistral-.*.rpm")
+
+    if [ -z "${PACKAGE_URL}" ]; then
+        exit 2
+    fi
+    # Re-enable a global error handler
+    set -e
+
     sudo yum -y install ${PACKAGE_URL}
   fi
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -120,17 +120,17 @@ function get_package_url() {
   PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)
 
   if [ -z "${PACKAGES_METADATA}" ]; then
-      echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts"
-      exit 2
+      echo "Failed to retrieve packages metadata from https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts" 1>&2 
+      return 2
   fi
 
   PACKAGES_URLS="$(echo ${PACKAGES_METADATA}  | jq -r '.[].url')"
   PACKAGE_URL=$(echo "${PACKAGES_URLS}" | egrep "${DISTRO}/${PACKAGE_NAME_REGEX}")
 
   if [ -z "${PACKAGE_URL}" ]; then
-      echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})"
-      echo "Circle CI response: ${PACKAGES_METADATA}"
-      exit 2
+      echo "Failed to find url for ${DISTRO} package (${PACKAGE_NAME_REGEX})" 1>&2
+      echo "Circle CI response: ${PACKAGES_METADATA}" 1>&2
+      return 2
   fi
 
   echo ${PACKAGE_URL}
@@ -361,16 +361,7 @@ install_st2() {
   else
     sudo yum -y install jq
 
-    # Note: We disable global error handler because we want to print a more user-friendly error message
-    set +e
     PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "el7" "st2-.*.rpm")
-
-    if [ -z "${PACKAGE_URL}" ]; then
-        exit 2
-    fi
-    # Re-enable a global error handler
-    set -e
-
     sudo yum -y install ${PACKAGE_URL}
   fi
 
@@ -539,16 +530,7 @@ install_st2mistral() {
   else
     sudo yum -y install jq
 
-    # Note: We disable global error handler because we want to print a more user-friendly error message
-    set +e
     PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "el7" "st2mistral-.*.rpm")
-
-    if [ -z "${PACKAGE_URL}" ]; then
-        exit 2
-    fi
-    # Re-enable a global error handler
-    set -e
-
     sudo yum -y install ${PACKAGE_URL}
   fi
 


### PR DESCRIPTION
Right now we swallow curl error / output so we end up with a lovely totally un-friendly error message like that:

```bash
Get:2 http://us-west-2.ec2.archive.ubuntu.com/ubuntu xenial/universe amd64 jq amd64 1.5+dfsg-1 [144 kB]
Fetched 232 kB in 0s (21.4 MB/s)
Selecting previously unselected package libonig2:amd64.
(Reading database ... 53986 files and directories currently installed.)
Preparing to unpack .../libonig2_5.9.6-1_amd64.deb ...
Unpacking libonig2:amd64 (5.9.6-1) ...
Selecting previously unselected package jq.
Preparing to unpack .../jq_1.5+dfsg-1_amd64.deb ...
Unpacking jq (1.5+dfsg-1) ...
Processing triggers for man-db (2.7.5-1) ...
Setting up libonig2:amd64 (5.9.6-1) ...
Setting up jq (1.5+dfsg-1) ...
Processing triggers for libc-bin (2.23-0ubuntu9) ...
############### ERROR ###############
# Failed on step - Install st2 #
```

## TODO

- [ ] Backport to v2.4