### PR TITLE
Added st2-cleanup-db references

### DIFF
--- a/packages/st2/debian/st2.links
+++ b/packages/st2/debian/st2.links
@@ -11,4 +11,5 @@ opt/stackstorm/st2/bin/st2-generate-symmetric-crypto-key usr/bin/st2-generate-sy
 opt/stackstorm/st2/bin/st2-self-check usr/bin/st2-self-check
 opt/stackstorm/st2/bin/st2-validate-pack-config usr/bin/st2-validate-pack-config
 opt/stackstorm/st2/bin/st2-check-license usr/bin/st2-check-license
+opt/stackstorm/st2/bin/st2-cleanup-db usr/bin/st2-cleanup-db
 opt/stackstorm/st2/bin/st2ctl usr/bin/st2ctl

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -63,13 +63,13 @@ class ST2Spec
     },
 
     package_has_binaries: {
-      st2common: %w(st2-bootstrap-rmq st2-register-content st2-self-check st2ctl st2-validate-pack-config st2-check-license st2-run-pack-tests),
+      st2common: %w(st2-bootstrap-rmq st2-register-content st2-self-check st2ctl st2-validate-pack-config st2-check-license st2-run-pack-tests st2-cleanup-db),
       st2reactor: %w(st2-rule-tester st2-trigger-refire),
       st2client: %w(st2),
       st2debug: %w(st2-submit-debug-info),
       st2: %w(st2-bootstrap-rmq st2-register-content st2-rule-tester st2-run-pack-tests
               st2-apply-rbac-definitions st2-trigger-refire st2 st2-self-check st2-validate-pack-config st2-check-license st2ctl
-              st2-generate-symmetric-crypto-key st2-submit-debug-info),
+              st2-generate-symmetric-crypto-key st2-submit-debug-info st2-cleanup-db),
       mistral: %w(mistral)
     },
 


### PR DESCRIPTION
The PR in the main StackStorm repo https://github.com/StackStorm/st2/pull/3669 adds a new command `st2-cleanup-db`. This new command needs to be added to packaging.

DO NOT MERGE UNTIL  https://github.com/StackStorm/st2/pull/3669 IS MERGED