### PR TITLE
v2.2: Fix CentOS7 st2chatops installation failure

### DIFF
--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -550,6 +550,11 @@ EOT"
 }
 
 install_st2chatops() {
+  # Temporary hack until proper upstream fix https://bugs.centos.org/view.php?id=13669
+  if ! yum list http-parser 1>/dev/null 2>&1; then
+    sudo yum install -y https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm
+  fi
+
   # Add NodeJS 4 repo
   curl -sL https://rpm.nodesource.com/setup_4.x | sudo -E bash -
 


### PR DESCRIPTION
Same as #484, but for v2.2.

Temporary hack to install removed in EPEL 'http-parser' package until proper upstream fix https://bugs.centos.org/view.php?id=13669