### PR TITLE
Allow installer to work with Proxy

### DIFF
--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -1,3 +1,11 @@
+function configure_proxy() {
+  # Allow bypassing 'proxy' env vars via sudo
+  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
+  if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
+    echo "${sudoers_proxy}" | sudo tee -a /etc/sudoers.d/st2
+  fi
+}
+
 function get_package_url() {
   # Retrieve direct package URL for the provided dev build, subtype and package name regex.
   DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -14,7 +14,7 @@ function configure_proxy() {
     sudo test -e ${service_config} || sudo touch ${service_config}
     for env_var in http_proxy https_proxy no_proxy proxy_ca_bundle_path; do
       # delete line from file if specific proxy env var is unset
-      if sudo test -z ${!env_var}; then
+      if sudo test -z "${!env_var:-}"; then
         sudo sed -i "/^${env_var}=/d" ${service_config}
       # add proxy env var if it doesn't exist yet
       elif ! sudo grep -s -q ^"${env_var}=" ${service_config}; then

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -2,7 +2,7 @@ function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
-    sudo sh -c "echo ${sudoers_proxy} >> /etc/sudoers.d/st2"
+    sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi
 }
 

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -4,6 +4,27 @@ function configure_proxy() {
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
     sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi
+
+  # Configure proxy env vars for 'st2api' and 'st2actionrunner' system configs
+  # See: https://docs.stackstorm.com/packs.html#installing-packs-from-behind-a-proxy
+  local service_config_path=$(hash apt-get >/dev/null 2>&1 && echo '/etc/default' || echo '/etc/sysconfig')
+  for service in st2api st2actionrunner; do
+    service_config="${service_config_path}/${service}"
+    # create file if doesn't exist yet
+    sudo test -e ${service_config} || sudo touch ${service_config}
+    for env_var in http_proxy https_proxy no_proxy proxy_ca_bundle_path; do
+      # delete line from file if specific proxy env var is unset
+      if sudo test -z ${!env_var}; then
+        sudo sed -i "/^${env_var}=/d" ${service_config}
+      # add proxy env var if it doesn't exist yet
+      elif ! sudo grep -s -q ^"${env_var}=" ${service_config}; then
+        sudo sh -c "echo '${env_var}=${!env_var}' >> ${service_config}"
+      # modify existing proxy env var value
+      elif ! sudo grep -s -q ^"${env_var}=${!env_var}$" ${service_config}; then
+        sudo sed -i "s#^${env_var}=.*#${env_var}=${!env_var}#" ${service_config}
+      fi
+    done
+  done
 }
 
 function get_package_url() {

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -2,7 +2,7 @@ function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
-    echo "${sudoers_proxy}" | sudo tee -a /etc/sudoers.d/st2
+    sudo sh -c "echo ${sudoers_proxy} >> /etc/sudoers.d/st2"
   fi
 }
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -131,7 +131,7 @@ function configure_proxy() {
     sudo test -e ${service_config} || sudo touch ${service_config}
     for env_var in http_proxy https_proxy no_proxy proxy_ca_bundle_path; do
       # delete line from file if specific proxy env var is unset
-      if sudo test -z ${!env_var}; then
+      if sudo test -z "${!env_var:-}"; then
         sudo sed -i "/^${env_var}=/d" ${service_config}
       # add proxy env var if it doesn't exist yet
       elif ! sudo grep -s -q ^"${env_var}=" ${service_config}; then

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -115,6 +115,14 @@ setup_args() {
 }
 
 
+function configure_proxy() {
+  # Allow bypassing 'proxy' env vars via sudo
+  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
+  if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
+    echo "${sudoers_proxy}" | sudo tee -a /etc/sudoers.d/st2
+  fi
+}
+
 function get_package_url() {
   # Retrieve direct package URL for the provided dev build, subtype and package name regex.
   DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
@@ -671,6 +679,7 @@ trap 'fail' EXIT
 STEP="Setup args" && setup_args $@
 STEP="Check TCP ports and MongoDB storage requirements" && check_st2_host_dependencies
 STEP="Generate random password" && generate_random_passwords
+STEP="Configure Proxy" && configure_proxy
 STEP="Install st2 dependencies" && install_st2_dependencies
 STEP="Install st2 dependencies (MongoDB)" && install_mongodb
 STEP="Install st2" && install_st2

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -119,7 +119,7 @@ function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
-    sudo sh -c "echo ${sudoers_proxy} >> /etc/sudoers.d/st2"
+    sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi
 }
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -119,7 +119,7 @@ function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
-    echo "${sudoers_proxy}" | sudo tee -a /etc/sudoers.d/st2
+    sudo sh -c "echo ${sudoers_proxy} >> /etc/sudoers.d/st2"
   fi
 }
 

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -396,6 +396,7 @@ trap 'fail' EXIT
 STEP="Setup args" && setup_args $@
 STEP="Check TCP ports and MongoDB storage requirements" && check_st2_host_dependencies
 STEP="Generate random password" && generate_random_passwords
+STEP="Configure Proxy" && configure_proxy
 STEP="Install st2 dependencies" && install_st2_dependencies
 STEP="Install st2 dependencies (MongoDB)" && install_mongodb
 STEP="Install st2" && install_st2

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -126,7 +126,7 @@ function configure_proxy() {
     sudo test -e ${service_config} || sudo touch ${service_config}
     for env_var in http_proxy https_proxy no_proxy proxy_ca_bundle_path; do
       # delete line from file if specific proxy env var is unset
-      if sudo test -z ${!env_var}; then
+      if sudo test -z "${!env_var:-}"; then
         sudo sed -i "/^${env_var}=/d" ${service_config}
       # add proxy env var if it doesn't exist yet
       elif ! sudo grep -s -q ^"${env_var}=" ${service_config}; then

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -114,7 +114,7 @@ function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
-    sudo sh -c "echo ${sudoers_proxy} >> /etc/sudoers.d/st2"
+    sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi
 }
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -114,7 +114,7 @@ function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
-    echo "${sudoers_proxy}" | sudo tee -a /etc/sudoers.d/st2
+    sudo sh -c "echo ${sudoers_proxy} >> /etc/sudoers.d/st2"
   fi
 }
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -116,6 +116,27 @@ function configure_proxy() {
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
     sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi
+
+  # Configure proxy env vars for 'st2api' and 'st2actionrunner' system configs
+  # See: https://docs.stackstorm.com/packs.html#installing-packs-from-behind-a-proxy
+  local service_config_path=$(hash apt-get >/dev/null 2>&1 && echo '/etc/default' || echo '/etc/sysconfig')
+  for service in st2api st2actionrunner; do
+    service_config="${service_config_path}/${service}"
+    # create file if doesn't exist yet
+    sudo test -e ${service_config} || sudo touch ${service_config}
+    for env_var in http_proxy https_proxy no_proxy proxy_ca_bundle_path; do
+      # delete line from file if specific proxy env var is unset
+      if sudo test -z ${!env_var}; then
+        sudo sed -i "/^${env_var}=/d" ${service_config}
+      # add proxy env var if it doesn't exist yet
+      elif ! sudo grep -s -q ^"${env_var}=" ${service_config}; then
+        sudo sh -c "echo '${env_var}=${!env_var}' >> ${service_config}"
+      # modify existing proxy env var value
+      elif ! sudo grep -s -q ^"${env_var}=${!env_var}$" ${service_config}; then
+        sudo sed -i "s#^${env_var}=.*#${env_var}=${!env_var}#" ${service_config}
+      fi
+    done
+  done
 }
 
 function get_package_url() {

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -110,6 +110,14 @@ setup_args() {
 }
 
 
+function configure_proxy() {
+  # Allow bypassing 'proxy' env vars via sudo
+  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
+  if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
+    echo "${sudoers_proxy}" | sudo tee -a /etc/sudoers.d/st2
+  fi
+}
+
 function get_package_url() {
   # Retrieve direct package URL for the provided dev build, subtype and package name regex.
   DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
@@ -711,6 +719,7 @@ configure_st2chatops() {
 
 trap 'fail' EXIT
 STEP='Parse arguments' && setup_args $@
+STEP="Configure Proxy" && configure_proxy
 STEP="Check TCP ports and MongoDB storage requirements" && check_st2_host_dependencies
 STEP='Check libffi-devel availability' && check_libffi_devel
 STEP='Adjust SELinux policies' && adjust_selinux_policies

--- a/scripts/st2bootstrap-el6.template.sh
+++ b/scripts/st2bootstrap-el6.template.sh
@@ -384,6 +384,7 @@ configure_st2chatops() {
 
 trap 'fail' EXIT
 STEP='Parse arguments' && setup_args $@
+STEP="Configure Proxy" && configure_proxy
 STEP="Check TCP ports and MongoDB storage requirements" && check_st2_host_dependencies
 STEP='Check libffi-devel availability' && check_libffi_devel
 STEP='Adjust SELinux policies' && adjust_selinux_policies

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -126,7 +126,7 @@ function configure_proxy() {
     sudo test -e ${service_config} || sudo touch ${service_config}
     for env_var in http_proxy https_proxy no_proxy proxy_ca_bundle_path; do
       # delete line from file if specific proxy env var is unset
-      if sudo test -z ${!env_var}; then
+      if sudo test -z "${!env_var:-}"; then
         sudo sed -i "/^${env_var}=/d" ${service_config}
       # add proxy env var if it doesn't exist yet
       elif ! sudo grep -s -q ^"${env_var}=" ${service_config}; then

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -114,7 +114,7 @@ function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
-    sudo sh -c "echo ${sudoers_proxy} >> /etc/sudoers.d/st2"
+    sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi
 }
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -114,7 +114,7 @@ function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
-    echo "${sudoers_proxy}" | sudo tee -a /etc/sudoers.d/st2
+    sudo sh -c "echo ${sudoers_proxy} >> /etc/sudoers.d/st2"
   fi
 }
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -116,6 +116,27 @@ function configure_proxy() {
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
     sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi
+
+  # Configure proxy env vars for 'st2api' and 'st2actionrunner' system configs
+  # See: https://docs.stackstorm.com/packs.html#installing-packs-from-behind-a-proxy
+  local service_config_path=$(hash apt-get >/dev/null 2>&1 && echo '/etc/default' || echo '/etc/sysconfig')
+  for service in st2api st2actionrunner; do
+    service_config="${service_config_path}/${service}"
+    # create file if doesn't exist yet
+    sudo test -e ${service_config} || sudo touch ${service_config}
+    for env_var in http_proxy https_proxy no_proxy proxy_ca_bundle_path; do
+      # delete line from file if specific proxy env var is unset
+      if sudo test -z ${!env_var}; then
+        sudo sed -i "/^${env_var}=/d" ${service_config}
+      # add proxy env var if it doesn't exist yet
+      elif ! sudo grep -s -q ^"${env_var}=" ${service_config}; then
+        sudo sh -c "echo '${env_var}=${!env_var}' >> ${service_config}"
+      # modify existing proxy env var value
+      elif ! sudo grep -s -q ^"${env_var}=${!env_var}$" ${service_config}; then
+        sudo sed -i "s#^${env_var}=.*#${env_var}=${!env_var}#" ${service_config}
+      fi
+    done
+  done
 }
 
 function get_package_url() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -110,6 +110,14 @@ setup_args() {
 }
 
 
+function configure_proxy() {
+  # Allow bypassing 'proxy' env vars via sudo
+  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
+  if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
+    echo "${sudoers_proxy}" | sudo tee -a /etc/sudoers.d/st2
+  fi
+}
+
 function get_package_url() {
   # Retrieve direct package URL for the provided dev build, subtype and package name regex.
   DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
@@ -695,6 +703,7 @@ configure_st2chatops() {
 
 trap 'fail' EXIT
 STEP='Parse arguments' && setup_args $@
+STEP="Configure Proxy" && configure_proxy
 STEP='Install net-tools' && install_net_tools
 STEP="Check TCP ports and MongoDB storage requirements" && check_st2_host_dependencies
 STEP='Adjust SELinux policies' && adjust_selinux_policies

--- a/scripts/st2bootstrap-el7.template.sh
+++ b/scripts/st2bootstrap-el7.template.sh
@@ -368,6 +368,7 @@ configure_st2chatops() {
 
 trap 'fail' EXIT
 STEP='Parse arguments' && setup_args $@
+STEP="Configure Proxy" && configure_proxy
 STEP='Install net-tools' && install_net_tools
 STEP="Check TCP ports and MongoDB storage requirements" && check_st2_host_dependencies
 STEP='Adjust SELinux policies' && adjust_selinux_policies


### PR DESCRIPTION
Closes #500 as part of the https://github.com/StackStorm/discussions/issues/262 story

The expected interface to install st2 via proxy and then configure it is by passing `env` variables. An example: 
```sh
export http_proxy=http://192.168.10.123:3128
export https_proxy=http://192.168.10.123:3128
export no_proxy=127.0.0.1,localhost

# which is similar to passing the optional Hubot token
export HUBOT_SLACK_TOKEN=xoxb-abc-123

curl -sSL https://stackstorm.com/packages/install.sh |  bash -s -- --user=st2admin --password=st2admin --unstable
```

## Behavior
Keeping in mind that we're targeting idempotence (https://github.com/StackStorm/discussions/issues/262) in `curl|bash` scripts, the implemented logic honors the fact that installer could be re-ran many times.

- If proxy env vars are set - add them them in `st2api` and `st2actionrunner` service configs
- If passed proxy env vars are changed, - next `curl|bash` run will update the existing var values in service cofnigs
- If proxy env var(s) are unset/removed - `curl|bash` installer with remove the unset vars from service configs


## TODO
- [x] proxy support for community installer
  - [x] fix blocker: https://github.com/StackStorm/st2-packages/pull/511
- [x] st2docs https://github.com/StackStorm/st2docs/pull/633 https://github.com/StackStorm/st2docs/pull/635
- [x] test under the 4 platforms
  - [x] EL6
  - [x] EL7
  - [x] U14
  - [x] U16
- [ ] post-merge
  - [ ] manual tests
  - [ ] verify enterprise installer
  - [ ] verify suites installer