### PR TITLE
Fix ENV vars export consistency in service configs (different platforms)

### DIFF
--- a/packages/st2/debian/st2.st2actionrunner-worker.upstart
+++ b/packages/st2/debian/st2.st2actionrunner-worker.upstart
@@ -21,7 +21,9 @@ script
   DAEMON_ARGS="--config-file /etc/st2/st2.conf"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   # Load global locale settings
   test -f /etc/default/locale && . /etc/default/locale || true

--- a/packages/st2/debian/st2.st2actionrunner.upstart
+++ b/packages/st2/debian/st2.st2actionrunner.upstart
@@ -34,7 +34,9 @@ post-stop script
   WORKERS=${WORKERS:-10}
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
   for i in `seq 1 $WORKERS`; do
     stop st2actionrunner-worker WORKERID=$i || :
   done

--- a/packages/st2/debian/st2.st2actionrunner.upstart
+++ b/packages/st2/debian/st2.st2actionrunner.upstart
@@ -19,7 +19,9 @@ pre-start script
   WORKERS=${WORKERS:-2}
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
   for i in `seq 1 $WORKERS`; do
     start st2actionrunner-worker WORKERID=$i || :
   done

--- a/packages/st2/debian/st2.st2api.upstart
+++ b/packages/st2/debian/st2.st2api.upstart
@@ -20,7 +20,9 @@ script
   DAEMON_ARGS="-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   exec /opt/stackstorm/st2/bin/gunicorn st2api.wsgi:application $DAEMON_ARGS
 end script

--- a/packages/st2/debian/st2.st2auth.upstart
+++ b/packages/st2/debian/st2.st2auth.upstart
@@ -20,7 +20,9 @@ script
   DAEMON_ARGS="-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   exec /opt/stackstorm/st2/bin/gunicorn st2auth.wsgi:application $DAEMON_ARGS
 end script

--- a/packages/st2/debian/st2.st2exporter.upstart
+++ b/packages/st2/debian/st2.st2exporter.upstart
@@ -20,7 +20,9 @@ script
   DAEMON_ARGS="--config-file /etc/st2/st2.conf"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   exec /opt/stackstorm/st2/bin/$NAME ${DAEMON_ARGS}
 end script

--- a/packages/st2/debian/st2.st2garbagecollector.upstart
+++ b/packages/st2/debian/st2.st2garbagecollector.upstart
@@ -20,7 +20,9 @@ script
   DAEMON_ARGS="--config-file /etc/st2/st2.conf"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   exec /opt/stackstorm/st2/bin/$NAME ${DAEMON_ARGS}
 end script

--- a/packages/st2/debian/st2.st2notifier.upstart
+++ b/packages/st2/debian/st2.st2notifier.upstart
@@ -20,7 +20,9 @@ script
   DAEMON_ARGS="--config-file /etc/st2/st2.conf"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   exec /opt/stackstorm/st2/bin/$NAME ${DAEMON_ARGS}
 end script

--- a/packages/st2/debian/st2.st2resultstracker.upstart
+++ b/packages/st2/debian/st2.st2resultstracker.upstart
@@ -20,7 +20,9 @@ script
   DAEMON_ARGS="--config-file /etc/st2/st2.conf"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   exec /opt/stackstorm/st2/bin/$NAME ${DAEMON_ARGS}
 end script

--- a/packages/st2/debian/st2.st2rulesengine.upstart
+++ b/packages/st2/debian/st2.st2rulesengine.upstart
@@ -20,7 +20,9 @@ script
   DAEMON_ARGS="--config-file /etc/st2/st2.conf"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   exec /opt/stackstorm/st2/bin/$NAME ${DAEMON_ARGS}
 end script

--- a/packages/st2/debian/st2.st2sensorcontainer.upstart
+++ b/packages/st2/debian/st2.st2sensorcontainer.upstart
@@ -20,7 +20,9 @@ script
   DAEMON_ARGS="--config-file /etc/st2/st2.conf"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   exec /opt/stackstorm/st2/bin/$NAME ${DAEMON_ARGS}
 end script

--- a/packages/st2/debian/st2.st2stream.upstart
+++ b/packages/st2/debian/st2.st2stream.upstart
@@ -20,7 +20,9 @@ script
   DAEMON_ARGS="-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   exec /opt/stackstorm/st2/bin/gunicorn st2stream.wsgi:application $DAEMON_ARGS
 end script

--- a/packages/st2/rpm/st2actionrunner-worker.init
+++ b/packages/st2/rpm/st2actionrunner-worker.init
@@ -39,7 +39,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 
 # Check if invoked worker service directly
 if [ -z $WORKERID ]; then

--- a/packages/st2/rpm/st2actionrunner.init
+++ b/packages/st2/rpm/st2actionrunner.init
@@ -25,7 +25,9 @@ export WORKERS
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 
 
 start() {

--- a/packages/st2/rpm/st2api.init
+++ b/packages/st2/rpm/st2api.init
@@ -36,7 +36,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 DAEMON_ARGS="st2api.wsgi:application ${DAEMON_ARGS}"
 
 

--- a/packages/st2/rpm/st2auth.init
+++ b/packages/st2/rpm/st2auth.init
@@ -36,7 +36,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 DAEMON_ARGS="st2auth.wsgi:application ${DAEMON_ARGS}"
 
 

--- a/packages/st2/rpm/st2exporter.init
+++ b/packages/st2/rpm/st2exporter.init
@@ -36,7 +36,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 
 
 start() {

--- a/packages/st2/rpm/st2garbagecollector.init
+++ b/packages/st2/rpm/st2garbagecollector.init
@@ -36,7 +36,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 
 
 start() {

--- a/packages/st2/rpm/st2notifier.init
+++ b/packages/st2/rpm/st2notifier.init
@@ -36,7 +36,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 
 
 start() {

--- a/packages/st2/rpm/st2resultstracker.init
+++ b/packages/st2/rpm/st2resultstracker.init
@@ -36,7 +36,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 
 
 start() {

--- a/packages/st2/rpm/st2rulesengine.init
+++ b/packages/st2/rpm/st2rulesengine.init
@@ -36,7 +36,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 
 
 start() {

--- a/packages/st2/rpm/st2sensorcontainer.init
+++ b/packages/st2/rpm/st2sensorcontainer.init
@@ -36,7 +36,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 
 
 start() {

--- a/packages/st2/rpm/st2stream.init
+++ b/packages/st2/rpm/st2stream.init
@@ -36,7 +36,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 DAEMON_ARGS="st2stream.wsgi:application ${DAEMON_ARGS}"
 
 

--- a/packages/st2mistral/debian/mistral-api.init
+++ b/packages/st2mistral/debian/mistral-api.init
@@ -33,7 +33,9 @@ UMASK=022
 [ -x "$DAEMON" ] || exit 0
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/default/mistral ] && . /etc/default/mistral
+set +o allexport
 DAEMON_ARGS="${API_ARGS}"
 
 # Load the VERBOSE setting and other rcS variables

--- a/packages/st2mistral/debian/mistral-api.upstart
+++ b/packages/st2mistral/debian/mistral-api.upstart
@@ -23,7 +23,9 @@ script
   API_ARGS="--log-file /var/log/mistral/mistral-api.log -b 127.0.0.1:8989 -w 2 mistral.api.wsgi --graceful-timeout 10"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   # NB! Exit if mistral-api is disabled
   . /opt/stackstorm/mistral/share/sysvinit/helpers

--- a/packages/st2mistral/debian/mistral-server.init
+++ b/packages/st2mistral/debian/mistral-server.init
@@ -32,7 +32,9 @@ UMASK=022
 [ -x "$DAEMON" ] || exit 0
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/default/mistral ] && . /etc/default/mistral
+set +o allexport
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh

--- a/packages/st2mistral/debian/mistral-server.upstart
+++ b/packages/st2mistral/debian/mistral-server.upstart
@@ -23,7 +23,9 @@ script
   SERVER_ARGS="--config-file /etc/mistral/mistral.conf --log-file /var/log/mistral/mistral-server.log"
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   # Exit if server components are disabled, otherwise inject them into args.
   . /opt/stackstorm/mistral/share/sysvinit/helpers

--- a/packages/st2mistral/debian/mistral.init
+++ b/packages/st2mistral/debian/mistral.init
@@ -21,7 +21,9 @@ NAME=mistral
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+set +o allexport
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh

--- a/packages/st2mistral/rpm/mistral-api.init
+++ b/packages/st2mistral/rpm/mistral-api.init
@@ -39,7 +39,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/mistral ] && . /etc/sysconfig/mistral
+set +o allexport
 DAEMON_ARGS="${API_ARGS}"
 
 # NB! Exit if mistral-api is disabled

--- a/packages/st2mistral/rpm/mistral-server.init
+++ b/packages/st2mistral/rpm/mistral-server.init
@@ -38,7 +38,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/mistral ] && . /etc/sysconfig/mistral
+set +o allexport
 
 
 # NB! Exit if mistral-server is disabled

--- a/packages/st2mistral/rpm/mistral.init
+++ b/packages/st2mistral/rpm/mistral.init
@@ -20,7 +20,9 @@ DESC="mistral"
 NAME=mistral
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 
 
 # Mistral wrapper passes execution to mistral-api and mistral-server


### PR DESCRIPTION
> Found during the work on #510 Proxy support

Here is the problem:

Placing env variables in service configs (ex: `/etc/default/st2api`, `/etc/sysconfig/st2api`) for `CentOS7` & `Ubuntu16` works this way:
```
http_proxy=http://host/
```

While for `EL6` and `Ubuntu14` explicit `export` is needed:
```
export http_proxy=http://host/
```

This brings all the confusion and inconsistency, especially when working with configuration management systems. We have that covered even in docs, see: https://docs.stackstorm.com/packs.html#ubuntu-14-04-or-rhel-6, but it doesn't make life any easier.

----

This PR is going to fix the behavior so it'll be consistent across the different platforms and packages we build.

### TODO
- [x] st2
- [x] st2mistral
- [x] st2chatops https://github.com/StackStorm/st2chatops/pull/91
- [x] adjust `st2docs` https://github.com/StackStorm/st2docs/pull/629
- [ ] Test
  - [ ] `EL6`
  - [ ] `Ubuntu14`