### PR TITLE
Pin 'package_cloud' gem version to '0.2.45' to fix Build failure

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -53,7 +53,7 @@ dependencies:
     - sudo .circle/configure-services.sh
     - sudo .circle/fix-cache-permissions.sh
     - sudo apt-get -y install parallel jq
-    - gem install package_cloud
+    - gem install package_cloud -v 0.2.45
     - sudo pip install wheel "docker-compose==1.14.0"
     - docker-compose version
     - docker version


### PR DESCRIPTION
Similar to https://github.com/StackStorm/bwc-ui/pull/20

Fixes CircleCI build failure due to `package_cloud`'s gem Ruby 2.0 dependency, which is not available under the current "old" Circle env.

Original Error:
```
gem install package_cloud

Fetching: thor-0.20.0.gem (100%)
Successfully installed thor-0.20.0
Fetching: highline-1.6.20.gem (100%)
Successfully installed highline-1.6.20
Fetching: unf_ext-0.0.7.4.gem (100%)
Building native extensions.  This could take a while...
Successfully installed unf_ext-0.0.7.4
Fetching: unf-0.1.4.gem (100%)
Successfully installed unf-0.1.4
Fetching: domain_name-0.5.20170404.gem (100%)
Successfully installed domain_name-0.5.20170404
Fetching: http-cookie-1.0.3.gem (100%)
Successfully installed http-cookie-1.0.3
Fetching: mime-types-data-3.2016.0521.gem (100%)
ERROR:  Error installing package_cloud:
	mime-types-data requires Ruby version >= 2.0.

gem install package_cloud returned exit code 1

Action failed: gem install package_cloud
```