### PR TITLE
Logrotate mistral logs

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -35,6 +35,7 @@ post_install:
 pre_install:
 	install -D conf/policy.json $(DESTDIR)/etc/mistral/policy.json
 	install -D etc/logging.conf.sample $(DESTDIR)/etc/mistral/logging.conf
+	install -m644 conf/logrotate.conf $(DESTDIR)/etc/logrotate.d/mistral
 	install -D etc/wf_trace_logging.conf.sample $(DESTDIR)/etc/mistral/wf_trace_logging.conf
 	install -D -m644 conf/helpers-sysvinit $(DESTDIR)/opt/stackstorm/mistral/share/sysvinit/helpers
 	sed -i "s%/var/log/%/var/log/mistral/%" $(DESTDIR)/etc/mistral/*logging.conf

--- a/packages/st2mistral/conf/logrotate.conf
+++ b/packages/st2mistral/conf/logrotate.conf
@@ -13,7 +13,7 @@
 
 ## Mistral Server
 /var/log/mistral/mistral-server.log {
-  size 10M
+  size 50M
   rotate 10
   compress
   notifempty

--- a/packages/st2mistral/conf/logrotate.conf
+++ b/packages/st2mistral/conf/logrotate.conf
@@ -7,7 +7,7 @@
   missingok
   create 644 mistral mistral
   postrotate
-    pkill -USR1 -f mistral.api.wsgi
+    pkill -USR1 -f mistral.api.wsgi > /dev/null 2>&1 || true
   endscript
 }
 

--- a/packages/st2mistral/conf/logrotate.conf
+++ b/packages/st2mistral/conf/logrotate.conf
@@ -1,0 +1,25 @@
+## Mistral API
+/var/log/mistral/mistral-api.log {
+  size 1M
+  rotate 5
+  compress
+  notifempty
+  missingok
+  create 644 mistral mistral
+  postrotate
+    pkill -USR1 -f mistral.api.wsgi
+  endscript
+}
+
+## Mistral Server
+/var/log/mistral/mistral-server.log {
+  size 10M
+  rotate 10
+  compress
+  notifempty
+  missingok
+  # Mistral doesn't handle USR1 signal right to re-open log files,
+  # Sending HUP will re-open the logs, but will stop the running workflows
+  copytruncate
+  delaycompress
+}

--- a/packages/st2mistral/debian/conffiles
+++ b/packages/st2mistral/debian/conffiles
@@ -1,0 +1,1 @@
+/etc/logrotate.d/mistral

--- a/packages/st2mistral/debian/control
+++ b/packages/st2mistral/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/stackstorm/mistral
 Package: st2mistral
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.16), python2.7, adduser
-Depends: ${shlibs:Depends}, ${misc:Depends}, adduser
+Depends: ${shlibs:Depends}, ${misc:Depends}, adduser, procps
 Description: st2 Mistral workflow service.
  Task orchestration and workflow engine with powerful strategies like parallelism, loops, retries,
  nested tasks, execution order capabilities. Rules defined in YAML, extended with YAQL expressions.

--- a/packages/st2mistral/debian/st2mistral.dirs
+++ b/packages/st2mistral/debian/st2mistral.dirs
@@ -1,3 +1,4 @@
 /etc/mistral
 /var/log/mistral
 /var/run/mistral
+/etc/logrotate.d

--- a/packages/st2mistral/rpm/st2mistral.spec
+++ b/packages/st2mistral/rpm/st2mistral.spec
@@ -16,6 +16,7 @@ Group: System/Management
 License: Apache 2.0
 Url: https://github.com/StackStorm/mistral
 Source0: .
+Requires: bash, procps
 Provides: openstack-mistral
 Summary: st2 Mistral workflow service
 

--- a/packages/st2mistral/rpm/st2mistral.spec
+++ b/packages/st2mistral/rpm/st2mistral.spec
@@ -60,6 +60,7 @@ Summary: st2 Mistral workflow service
   %{_bindir}/mistral
   /opt/stackstorm/mistral
   %config(noreplace) %{_sysconfdir}/mistral/*
+  %config(noreplace) %{_sysconfdir}/logrotate.d/mistral
   %attr(755, %{svc_user}, root) %{_localstatedir}/log/mistral
   %attr(755, %{svc_user}, root) %{_localstatedir}/run/mistral
 %if 0%{?use_systemd}

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -84,13 +84,15 @@ class ST2Spec
                     /opt/stackstorm/packs),
       mistral: [
         '/etc/mistral',
+        '/etc/logrotate.d',
+        '/opt/stackstorm/mistral',
         [ '/var/log/mistral', example: Proc.new {|_| be_writable.by('owner')} ]
       ]
     },
 
     package_has_files: {
-      st2common: %w(/etc/st2/st2.conf),
-      mistral: %w(/etc/mistral/mistral.conf)
+      st2common: %w(/etc/st2/st2.conf /etc/logrotate.d/st2),
+      mistral: %w(/etc/mistral/mistral.conf /etc/logrotate.d/mistral)
     },
 
     package_has_users: {


### PR DESCRIPTION
Fixes #468 

Add logrotate configs for `st2mistral` deb/rpm package to prevent filling up the disk space by logs and overall to be a better packaging citizens.
