### PR TITLE
Add st2python dependency for st2mistral under EL6

### DIFF
--- a/packages/st2mistral/rpm/st2mistral.spec
+++ b/packages/st2mistral/rpm/st2mistral.spec
@@ -16,7 +16,11 @@ Group: System/Management
 License: Apache 2.0
 Url: https://github.com/StackStorm/mistral
 Source0: .
+%if 0%{?use_st2python}
+Requires: st2python, bash, procps
+%else
 Requires: bash, procps
+%endif
 Provides: openstack-mistral
 Summary: st2 Mistral workflow service
 


### PR DESCRIPTION
Fixes #407 when `st2mistral` package is missing `st2python` as a dependency.

This makes sense when st2mistral is installed on another machine and needs  st2python on EL6.