### PR TITLE
Fix st2web self-signed SSL certificate validity

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -637,7 +637,7 @@ EOT"
   # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
   sudo mkdir -p /etc/ssl/st2
   sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
-  -days XXX -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information \
+  -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information \
   Technology/CN=$(hostname)"
 
   # Remove default site, if present

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -333,7 +333,7 @@ EOT"
   # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
   sudo mkdir -p /etc/ssl/st2
   sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
-  -days XXX -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information \
+  -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information \
   Technology/CN=$(hostname)"
 
   # Remove default site, if present


### PR DESCRIPTION
Found during the Inspec tests work (https://github.com/StackStorm/ova/pull/35/commits/843fcbcb3827edf31ef34777c8664fa488311e32) that we generate st2web self-signed SSL certificate for just `30 days`, because `days XXX` is incorrect.

Fixing that, so we produce `1yr` self-signed cert.

It's interesting that `EL` scripts already have `365` days.