### PR TITLE
Temporarily pin postgres version to fix "initdb" problem

### DIFF
--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -616,7 +616,13 @@ install_st2mistral_dependencies() {
       sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-2.noarch.rpm
   fi
 
-  sudo yum -y install postgresql94-server postgresql94-contrib postgresql94-devel
+  # Temporarily removing this - see note below regarding initdb failure
+  # sudo yum -y install postgresql94-server postgresql94-contrib postgresql94-devel
+
+  # Installing a specific version of postgres for now, postgresql94-9.4.15-3 broke initdb
+  sudo yum remove -y postgresql94
+  sudo yum install -y postgresql94-9.4.15-2PGDG.rhel6 postgresql94-contrib-9.4.15-2PGDG.rhel6.x86_64 postgresql94-server-9.4.15-2PGDG.rhel6.x86_64 postgresql94-devel-9.4.15-2PGDG.rhel6.x86_64 postgresql94-libs-9.4.15-2PGDG.rhel6.x86_64
+  sudo rm -rf /var/lib/pgsql/9.4/data
 
   # Setup postgresql at a first time
   sudo service postgresql-9.4 initdb

--- a/scripts/st2bootstrap-el6.template.sh
+++ b/scripts/st2bootstrap-el6.template.sh
@@ -260,7 +260,13 @@ install_st2mistral_dependencies() {
       sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-2.noarch.rpm
   fi
 
-  sudo yum -y install postgresql94-server postgresql94-contrib postgresql94-devel
+  # Temporarily removing this - see note below regarding initdb failure
+  # sudo yum -y install postgresql94-server postgresql94-contrib postgresql94-devel
+
+  # Installing a specific version of postgres for now, postgresql94-9.4.15-3 broke initdb
+  sudo yum remove -y postgresql94
+  sudo yum install -y postgresql94-9.4.15-2PGDG.rhel6 postgresql94-contrib-9.4.15-2PGDG.rhel6.x86_64 postgresql94-server-9.4.15-2PGDG.rhel6.x86_64 postgresql94-devel-9.4.15-2PGDG.rhel6.x86_64 postgresql94-libs-9.4.15-2PGDG.rhel6.x86_64
+  sudo rm -rf /var/lib/pgsql/9.4/data
 
   # Setup postgresql at a first time
   sudo service postgresql-9.4 initdb


### PR DESCRIPTION
Yesterday, we started seeing installation failures of stackstorm on RHEL6. Upon perusing logs, we noticed that the `initdb` command was failing.

Since that failed, the corresponding `sed` statement also failed, since the file in question didn't exist.

```
0171208T071401+0000 Complete!
20171208T071402+0000 Initializing database: ^[[60G[^[[0;31mFAILED^[[0;39m]^M
20171208T071402+0000 sed: can't read /var/lib/pgsql/9.4/data/pg_hba.conf: No such file or directory
```

We also noticed that the postgres packages were updated to `9.4.15-3` on the same day we started seeing these failures (12/7/2017).

To get the install working again, we're temporarily pinning the previous version `9.4.15-2` which works. Hopefully the upstream packages are fixed in the meantime.

[Install is working again.](https://gist.github.com/Mierdin/c0c8a5e03e9f75429c4732d3ea55fcb6)