### PR TITLE
Add python-memcached to deps

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -76,6 +76,7 @@ inject-deps: .stamp-inject-deps
 	grep -q 'gunicorn' requirements.txt || echo "gunicorn" >> requirements.txt
 	grep -q 'psycopg2' requirements.txt || echo "psycopg2>=2.6.2,<2.7.0" >> requirements.txt
 	grep -q 'pika' requirements.txt || echo "pika<0.11,>=0.9" >> requirements.txt
+	grep -q 'python-memcached' requirements.txt || echo "python-memcached" >> requirements.txt
 	sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
 	sed -i "s/^Babel.*/Babel>=2.3.4,!=2.4.0 # BSD/g" requirements.txt
 


### PR DESCRIPTION
One of our upstreams seems to have removed `python-memcached` from their dependencies, despite the fact that oslo.cache still seems to need it. So we started seeing mistral failures:

```
[2017-12-08 22:51:26 +0000] [23258] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 578, in spawn_worker
    worker.init_process()
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 126, in init_process
    self.load_wsgi()
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 135, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 65, in load
    return self.load_wsgiapp()
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/gunicorn/util.py", line 352, in import_app
    __import__(module)
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/mistral/api/wsgi.py", line 15, in <module>
    from mistral.api import app
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/mistral/api/app.py", line 21, in <module>
    from mistral.api import access_control
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/mistral/api/access_control.py", line 17, in <module>
    from keystonemiddleware import auth_token
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/keystonemiddleware/auth_token/__init__.py", line 237, in <module>
    from keystonemiddleware.auth_token import _cache
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/keystonemiddleware/auth_token/_cache.py", line 16, in <module>
    from oslo_cache import _memcache_pool as memcache_pool
  File "/opt/stackstorm/mistral/local/lib/python2.7/site-packages/oslo_cache/_memcache_pool.py", line 27, in <module>
    import memcache
ImportError: No module named memcache
```

So we're adding it ourselves to get Mistral happy again.
