### PR TITLE
Add netbase as a dependency for st2 deb package

### DIFF
--- a/packages/st2/debian/control
+++ b/packages/st2/debian/control
@@ -13,7 +13,7 @@ Vcs-Browser: https://github.com/stackstorm/st2
 Package: st2
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.16), python2.7, ${misc:Pre-Depends}, adduser
-Depends: ${shlibs:Depends}, ${misc:Depends}, sudo, adduser, libpython-dev | python-dev, libssl-dev, libffi-dev, git, libpam0g, openssh-server, openssh-client, bash
+Depends: ${shlibs:Depends}, ${misc:Depends}, sudo, adduser, libpython-dev | python-dev, libssl-dev, libffi-dev, git, libpam0g, openssh-server, openssh-client, bash, netbase
 Conflicts: st2common
 Description: StackStorm Event-driven automation
  Package is full standalone st2 installation including

--- a/packages/st2/rpm/st2.spec
+++ b/packages/st2/rpm/st2.spec
@@ -12,9 +12,9 @@ Epoch: %{epoch}
 %endif
 
 %if 0%{?use_st2python}
-Requires: st2python, python-devel, openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash
+Requires: st2python, python-devel, openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash, netcfg
 %else
-Requires: python-devel, openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash
+Requires: python-devel, openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash, netcfg
 %endif
 
 Summary: StackStorm all components bundle


### PR DESCRIPTION
Some minimal container images (notably our xenial packagingtest image) don't contain this package and because of that, our tests fail.

We decided best way to ensure this package is present is to have netbase as a dependency of st2 package.

The issue only affects our xenial packagingtest build and image, but it's still a good idea to define it there.

For context and details, see https://github.com/StackStorm/st2/pull/4007#issuecomment-366909531.