### PR TITLE
Revert "Make st2 RPM package depend on netcfg package."

### DIFF
--- a/packages/st2/rpm/st2.spec
+++ b/packages/st2/rpm/st2.spec
@@ -12,9 +12,9 @@ Epoch: %{epoch}
 %endif
 
 %if 0%{?use_st2python}
-Requires: st2python, python-devel, openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash, netcfg
+Requires: st2python, python-devel, openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash
 %else
-Requires: python-devel, openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash, netcfg
+Requires: python-devel, openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash
 %endif
 
 Summary: StackStorm all components bundle


### PR DESCRIPTION
Reverting the change for now since it causes st2 build failure.

Will dig into it tomorrow and re-enable then.