### PR TITLE
Fix nginx to install from 'nginx' repo on EL7, instead of 'EPEL'

### DIFF
--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -673,8 +673,10 @@ gpgcheck=1
 enabled=1
 EOT"
 
-  # Install st2web and nginx
-  sudo yum install -y ${ST2WEB_PKG} nginx
+  # Install nginx
+  sudo yum --disablerepo='epel' install -y nginx
+  # Install st2web
+  sudo yum install -y ${ST2WEB_PKG}
 
   # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
   sudo mkdir -p /etc/ssl/st2

--- a/scripts/st2bootstrap-el6.template.sh
+++ b/scripts/st2bootstrap-el6.template.sh
@@ -317,8 +317,10 @@ gpgcheck=1
 enabled=1
 EOT"
 
-  # Install st2web and nginx
-  sudo yum install -y ${ST2WEB_PKG} nginx
+  # Install nginx
+  sudo yum --disablerepo='epel' install -y nginx
+  # Install st2web
+  sudo yum install -y ${ST2WEB_PKG}
 
   # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
   sudo mkdir -p /etc/ssl/st2

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -652,8 +652,10 @@ gpgcheck=1
 enabled=1
 EOT"
 
-  # Install st2web and nginx
-  sudo yum install -y ${ST2WEB_PKG} nginx
+  # Install nginx
+  sudo yum --disablerepo='epel' install -y nginx
+  # Install st2web
+  sudo yum install -y ${ST2WEB_PKG}
 
   # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
   sudo mkdir -p /etc/ssl/st2

--- a/scripts/st2bootstrap-el7.template.sh
+++ b/scripts/st2bootstrap-el7.template.sh
@@ -296,8 +296,10 @@ gpgcheck=1
 enabled=1
 EOT"
 
-  # Install st2web and nginx
-  sudo yum install -y ${ST2WEB_PKG} nginx
+  # Install nginx
+  sudo yum --disablerepo='epel' install -y nginx
+  # Install st2web
+  sudo yum install -y ${ST2WEB_PKG}
 
   # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2
   sudo mkdir -p /etc/ssl/st2


### PR DESCRIPTION

Originally we install `nginx` from the `nxing.org` official repo which has `1:1.12.2-1` version.
A few days ago EPEL released new version of nginx `1:1.12.2-2.el7` which now takes precedence over the nginx.org version and gets installed instead.

EPEL version of nginx comes with other dependencies, different directory structure, nginx config which resulted in a broken EL7 installation.

```
20180328T173450+0000 ############### ERROR ###############
20180328T173450+0000 # Failed on Install st2web #
20180328T173450+0000 #####################################
```

> Related Ansible-st2 fix: https://github.com/StackStorm/ansible-st2/pull/191
