### PR TITLE
Add back Circle CI 1.0 related files still used by mistral repo

### DIFF
--- a/.circle/configure-postgres.sh
+++ b/.circle/configure-postgres.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+CONFIG=$(cat <<EHD
+CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD 'StackStorm';
+CREATE DATABASE mistral OWNER mistral;
+EHD
+)
+
+echo -e "$CONFIG" | psql -U ubuntu

--- a/.circle/configure-rabbitmq.sh
+++ b/.circle/configure-rabbitmq.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Enable remote guest access
+CONFIG=$(cat <<EHD
+[{rabbit, [{disk_free_limit, 10}, {loopback_users, []}, {tcp_listeners, [{"0.0.0.0", 5672}]}]}].
+EHD
+)
+
+service rabbitmq-server stop
+echo "$CONFIG" > /etc/rabbitmq/rabbitmq.config
+service rabbitmq-server start

--- a/.circle/configure-services.sh
+++ b/.circle/configure-services.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# change into script directory
+cd $(dirname `readlink -f $0`)
+
+set -x
+sudo ./configure-rabbitmq.sh
+sudo ./configure-postgres.sh

--- a/.circle/fix-cache-permissions.sh
+++ b/.circle/fix-cache-permissions.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Script is run at dependencies:pre stage, thus
+# it's invoked after cache restore.
+set -e
+set -x
+
+# Make ubuntu's .cache/pip and wheelhouse owned by root
+mkdir -p ~/.cache/pip && sudo chown -R root:root ~/.cache/pip
+mkdir -p ~/wheelhouse && sudo chown -R root:root ~/wheelhouse


### PR DESCRIPTION
Those files are still used by the mistral repo (https://github.com/StackStorm/mistral/blob/master/circle.yml) which hasn't been ported to Circle CI 2.0 yet.

This is a temporary solution to try to get the build to pass and the packages out. Eventually we should also move that repo to Circle CI 2.0.