### PR TITLE
Add entry for missing st2-track-result binary (v2.7)

### DIFF
--- a/packages/st2/debian/st2.links
+++ b/packages/st2/debian/st2.links
@@ -9,6 +9,7 @@ opt/stackstorm/st2/bin/st2-bootstrap-rmq usr/bin/st2-bootstrap-rmq
 opt/stackstorm/st2/bin/st2-submit-debug-info usr/bin/st2-submit-debug-info
 opt/stackstorm/st2/bin/st2-generate-symmetric-crypto-key usr/bin/st2-generate-symmetric-crypto-key
 opt/stackstorm/st2/bin/st2-self-check usr/bin/st2-self-check
+opt/stackstorm/st2/bin/st2-track-result usr/bin/st2-track-result
 opt/stackstorm/st2/bin/st2-validate-pack-config usr/bin/st2-validate-pack-config
 opt/stackstorm/st2/bin/st2-check-license usr/bin/st2-check-license
 opt/stackstorm/st2/bin/st2ctl usr/bin/st2ctl

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -63,12 +63,12 @@ class ST2Spec
     },
 
     package_has_binaries: {
-      st2common: %w(st2-bootstrap-rmq st2-register-content st2-self-check st2ctl st2-validate-pack-config st2-check-license st2-run-pack-tests),
+      st2common: %w(st2-bootstrap-rmq st2-register-content st2-self-check st2-track-result st2ctl st2-validate-pack-config st2-check-license st2-run-pack-tests),
       st2reactor: %w(st2-rule-tester st2-trigger-refire),
       st2client: %w(st2),
       st2debug: %w(st2-submit-debug-info),
       st2: %w(st2-bootstrap-rmq st2-register-content st2-rule-tester st2-run-pack-tests
-              st2-apply-rbac-definitions st2-trigger-refire st2 st2-self-check st2-validate-pack-config st2-check-license st2ctl
+              st2-apply-rbac-definitions st2-trigger-refire st2 st2-self-check st2-track-result st2-validate-pack-config st2-check-license st2ctl
               st2-generate-symmetric-crypto-key st2-submit-debug-info),
       mistral: %w(mistral)
     },


### PR DESCRIPTION
Corresponding change for https://github.com/StackStorm/st2/pull/4072.