### PR TITLE
Fix dh-virtualenv packages build, avoid updating pip to latest v10.0

### DIFF
--- a/.circle/docker-compose2.sh
+++ b/.circle/docker-compose2.sh
@@ -23,7 +23,7 @@ case "$1" in
   # Perform fake command invocation, technically provides images "pull" phase.
   pull)
     echo Pulling dependent Docker images for $2 ...
-    docker-compose -f docker-compose.circle2.yml -f docker-compose.override.yml run $2 /bin/true
+    docker-compose -f docker-compose.circle2.yml -f docker-compose.override.yml pull --include-deps $2
   ;;
   build)
     echo Starting Packages Build for $2 ...

--- a/packages/st2/debian/rules
+++ b/packages/st2/debian/rules
@@ -56,9 +56,13 @@ override_dh_installdeb:
 	dh_installdeb
 
 override_dh_virtualenv:
-	# NP! Wheels must be pre-populated by now, we use --no-index to skip
+	# NB! Wheels must be pre-populated by now, we use --no-index to skip
 	# querying pypi and rely only on --find-links.
-	dh_virtualenv --extra-pip-arg '--find-links=$(WHEELDIR)' \
+	#
+	# NB! Use '--no-download' arg for 'virtualenv' is required,
+	# otherwise it downloads latest PIP version instead of bundled/pinned one.
+	dh_virtualenv --extra-virtualenv-arg='--no-download' \
+								--extra-pip-arg '--find-links=$(WHEELDIR)' \
 								--extra-pip-arg '--no-index' --no-test
 
 override_dh_compress:

--- a/rpmspec/package_venv.spec
+++ b/rpmspec/package_venv.spec
@@ -16,7 +16,7 @@
   %if 0%{?use_st2python} \
     export PATH=/usr/share/python/st2python/bin:$PATH \
   %endif \
-  virtualenv %{venv_dir} \
+  virtualenv --no-download %{venv_dir} \
   %{venv_pip} -r requirements.txt \
   %{venv_pip} . \
   venvctrl-relocate --source=%{venv_dir} --destination=/%{venv_install_dir} \

--- a/scripts/install_os_packages.sh
+++ b/scripts/install_os_packages.sh
@@ -11,7 +11,6 @@ version_delemiter() {
 }
 
 install_rpm() {
-  sudo yum -y update
   sudo yum -y install $(lookup_fullnames $@);
 }
 

--- a/scripts/setup-vagrant.sh
+++ b/scripts/setup-vagrant.sh
@@ -31,7 +31,7 @@ sudo $INSTALL_CMD install -y git curl wget
 
 # Install docker-compose
 DC_BIN="/usr/local/bin/docker-compose"
-DC_URL="https://github.com/docker/compose/releases/download/1.9.0/docker-compose-`uname -s`-`uname -m`"
+DC_URL="https://github.com/docker/compose/releases/download/1.21.0/docker-compose-`uname -s`-`uname -m`"
 if [[ ! -x $DC_BIN ]]; then
   echo "[Install] docker-compose $ST2_TARGET"
   sudo sh -c "curl -sL $DC_URL > $DC_BIN"


### PR DESCRIPTION
> Related to: https://github.com/StackStorm/st2-dockerfiles/pull/58 https://github.com/StackStorm/st2-dockerfiles/pull/59 https://github.com/StackStorm/st2-dockerfiles/pull/60

pip recently released new `v10.0` which broke the `dh-virtualenv` packages build.

So here is the rabbit hole.
While we use & [pin `virtualenv 15.1.0`](https://github.com/StackStorm/st2/blob/e8f179c0023bd1a11b332126cfe493c197284486/fixed-requirements.txt#L34-L35) which advertizes to install `pip 9.0.1` (https://virtualenv.pypa.io/en/stable/changes/#id1) it doesn't happen in reality.

Obviously, at it happens in software world, it's not a bug but a feature, - `virtualenv` since `14.0.1` installs _latest available_ (!) pip version by default when user creates a new virtualenv (see https://github.com/pypa/virtualenv/issues/1044 and https://github.com/pypa/virtualenv/issues/1157).

To avoid this behavior in virtualenv and stick with expected associated pip version, `--no-download` flag was added (see https://virtualenv.pypa.io/en/stable/changes/#id12):
> Download new releases of the preinstalled software from PyPI when there are new releases available. This behavior can be disabled using --no-download.

Well, it means that once we updated to newer virtualenv version (14.0.1+) which installs latest pip by default, we opened a can of worms.

### TODO
- [x] Find the root cause
- [x] Provide `--no-download` flag to virtualenv in st2-packages
   - [x] Investigate new fails: we rely on [our outdated fork](https://github.com/StackStorm/dh-virtualenv/tree/fix/py-custom-shebang) of `dh-virtualenv` which doesn't have [`--extra-virtualenv-arg`](https://github.com/spotify/dh-virtualenv/pull/146)
     - [x] Update our `dh-virtualenv` fork, re-implement custom changes https://github.com/StackStorm/dh-virtualenv/commit/bf43b0ae436c8caa67f24d545df8cfca70d3cb9a (thanks @Kami https://github.com/StackStorm/st2-dockerfiles/pull/61)
       - [x] `trusty` build started to fail due to updated `dh-virtualenv` fork changes, fix: https://github.com/StackStorm/dh-virtualenv/commit/bab5d2ef8c9402c3d203bfb3bf757b39a22e1f1d
- [x] Check if `st2` repo needs `--no-download` as well for `st2 pack install` (thanks @Kami https://github.com/StackStorm/st2/pull/4085)

