### PR TITLE
Add missing dh-virtualenv fix for st2mistral

### DIFF
--- a/packages/st2mistral/debian/rules
+++ b/packages/st2mistral/debian/rules
@@ -33,5 +33,8 @@ override_dh_installdeb:
 	dh_installdeb
 
 override_dh_virtualenv:
-	dh_virtualenv --extra-pip-arg '--find-links=$(WHEELDIR)' \
+	# NB! Use '--no-download' arg for 'virtualenv' is required,
+	# otherwise it downloads latest PIP version instead of bundled/pinned one.
+	dh_virtualenv --extra-virtualenv-arg='--no-download' \
+								--extra-pip-arg '--find-links=$(WHEELDIR)' \
 								--extra-pip-arg '--no-index' --install-suffix mistral --no-test


### PR DESCRIPTION
Missing dh-virtualenv fix for `st2mistral`, part of https://github.com/StackStorm/st2-packages/pull/549