### PR TITLE
Increasing timeout for service startup on CentOS 6

### DIFF
--- a/packages/st2/conf/rhel-functions-sysvinit
+++ b/packages/st2/conf/rhel-functions-sysvinit
@@ -124,7 +124,7 @@ daemon() {
 # By default wait for the pid up to 3 seconds.
 pgrep_waitforpid() {
   local pid= pid_file= base= trailer=
-  local pgrep_opts="-n" timeout="3.0"
+  local pgrep_opts="-n" timeout="5.0"
 
   while [ "$1" != "${1##--}" ]; do
     case $1 in

--- a/packages/st2/conf/rhel-functions-sysvinit
+++ b/packages/st2/conf/rhel-functions-sysvinit
@@ -121,7 +121,7 @@ daemon() {
 
 
 # Write pid of a starting daemon into the pidfile.
-# By default wait for the pid up to 3 seconds.
+# By default wait for the pid up to 5 seconds.
 pgrep_waitforpid() {
   local pid= pid_file= base= trailer=
   local pgrep_opts="-n" timeout="5.0"


### PR DESCRIPTION
Closes StackStorm/st2/issues/4100

On CentOS/RHEL 6 in `2.7.0` we experienced the `st2auth` service failing to start due to a timeout waiting for the process to initialize. 

This change increases the process startup timeout on CentOS/RHEL 6 to allow for longer startup times from the `st2auth` service.