### PR TITLE
Fix sharing st2 logs when CircleCI job failed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -87,11 +87,11 @@ jobs:
 #          working_directory: ~/st2-packages
       - run:
           name: Test the Packages
-          command: |
-            set -x
-            .circle/docker-compose2.sh test ${DISTRO}
-            # Once test container finishes we can copy logs directly from it
-            docker cp st2-packages-vol:/var/log/st2 ~/st2-packages/build/${DISTRO}/log/st2
+          command: .circle/docker-compose2.sh test ${DISTRO}
+      - run:
+          when: always
+          name: Grab the st2 logs
+          command: docker cp st2-packages-vol:/var/log/st2 ~/st2-packages/build/${DISTRO}/log/st2
       - store_artifacts:
           path: ~/st2-packages/build
           destination: packages


### PR DESCRIPTION
See https://github.com/StackStorm/st2/pull/4158 for more context

