### PR TITLE
Update st2bootstrap-deb.sh

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -288,6 +288,7 @@ configure_st2_cli_config() {
   # Configure CLI config (write credentials for the root user and user which ran the script)
   ROOT_USER="root"
   CURRENT_USER=$(whoami)
+  CURRENT_USER_GROUP=$(id -gn)
 
   ROOT_HOME=$(eval echo ~${ROOT_USER})
   : "${HOME:=$(eval echo ~${CURRENT_USER})}"
@@ -325,7 +326,7 @@ password = ${PASSWORD}
 EOT"
 
   # Fix the permissions
-  sudo chown -R ${CURRENT_USER}:${CURRENT_USER} ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
+  sudo chown -R "${CURRENT_USER}":"${CURRENT_USER_GROUP}" ${CURRENT_USER_CLI_CONFIG_DIRECTORY}
 }
 
 


### PR DESCRIPTION
Allow for different usernames and group names, allow for spaces in both username and group name.

E.g.
20180620T110239-0500 chown: invalid group: ‘zpuls@kfn.local:zpuls@kfn.local’
20180620T110239-0500 ############### ERROR ###############
20180620T110239-0500 # Failed on Configure st2 CLI config #
20180620T110239-0500 #####################################

When the user is "zpuls@kfn.local" and group is "domain users@kfn.local".