### PR TITLE
Revert "Prevent reading st2web logs by others"

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -646,9 +646,6 @@ EOT"
   sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/
 
   sudo service nginx restart
-
-  # st2web logs shouldn't be read by others
-  sudo chmod o-r /var/log/nginx/st2webui.* /var/log/nginx/ssl-st2webui.*
 }
 
 install_st2chatops() {

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -342,9 +342,6 @@ EOT"
   sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/
 
   sudo service nginx restart
-
-  # st2web logs shouldn't be read by others
-  sudo chmod o-r /var/log/nginx/st2webui.* /var/log/nginx/ssl-st2webui.*
 }
 
 install_st2chatops() {

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -692,9 +692,6 @@ EOT"
 
   sudo service nginx start
   sudo chkconfig nginx on
-
-  # st2web logs shouldn't be read by others
-  sudo chmod o-r /var/log/nginx/st2webui.* /var/log/nginx/ssl-st2webui.*
 }
 
 install_st2chatops() {

--- a/scripts/st2bootstrap-el6.template.sh
+++ b/scripts/st2bootstrap-el6.template.sh
@@ -336,9 +336,6 @@ EOT"
 
   sudo service nginx start
   sudo chkconfig nginx on
-
-  # st2web logs shouldn't be read by others
-  sudo chmod o-r /var/log/nginx/st2webui.* /var/log/nginx/ssl-st2webui.*
 }
 
 install_st2chatops() {

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -671,9 +671,6 @@ EOT"
 
   sudo systemctl restart nginx
   sudo systemctl enable nginx
-
-  # st2web logs shouldn't be read by others
-  sudo chmod o-r /var/log/nginx/st2webui.* /var/log/nginx/ssl-st2webui.*
 }
 
 install_st2chatops() {

--- a/scripts/st2bootstrap-el7.template.sh
+++ b/scripts/st2bootstrap-el7.template.sh
@@ -315,9 +315,6 @@ EOT"
 
   sudo systemctl restart nginx
   sudo systemctl enable nginx
-
-  # st2web logs shouldn't be read by others
-  sudo chmod o-r /var/log/nginx/st2webui.* /var/log/nginx/ssl-st2webui.*
 }
 
 install_st2chatops() {


### PR DESCRIPTION
Reverts StackStorm/st2-packages#460

Log files permissions is not an issue anymore, being fixed in st2web `2.8` and so we can remove previous workarounds.

See https://github.com/StackStorm/discussions/issues/242 for context.

---

related https://github.com/StackStorm/ansible-st2/pull/197 https://github.com/StackStorm/st2web/pull/580 https://github.com/StackStorm/bwc-ui/pull/43