### PR TITLE
Install and use special gunicorn logging config file for all gunicorn API services

### DIFF
--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -51,10 +51,13 @@ post_install:
 	install -m644 ../st2actions/conf/logging.workflowengine.conf $(DESTDIR)/etc/st2/logging.workflowengine.conf
 	install -m644 ../st2actions/conf/syslog.workflowengine.conf $(DESTDIR)/etc/st2/syslog.workflowengine.conf
 	install -m644 ../st2api/conf/logging.conf $(DESTDIR)/etc/st2/logging.api.conf
+	install -m644 ../st2api/conf/logging.gunicorn.conf $(DESTDIR)/etc/st2/logging.api.gunicorn.conf
 	install -m644 ../st2api/conf/syslog.conf $(DESTDIR)/etc/st2/syslog.api.conf
 	install -m644 ../st2stream/conf/logging.conf $(DESTDIR)/etc/st2/logging.stream.conf
+	install -m644 ../st2stream/conf/logging.gunicorn.conf $(DESTDIR)/etc/st2/logging.stream.gunicorn.conf
 	install -m644 ../st2stream/conf/syslog.conf $(DESTDIR)/etc/st2/syslog.stream.conf
 	install -m644 ../st2auth/conf/logging.conf $(DESTDIR)/etc/st2/logging.auth.conf
+	install -m644 ../st2auth/conf/logging.gunicorn.conf $(DESTDIR)/etc/st2/logging.auth.gunicorn.conf
 	install -m644 ../st2auth/conf/syslog.conf $(DESTDIR)/etc/st2/syslog.auth.conf
 	install -m755 ../st2client/conf/st2.complete.sh $(DESTDIR)/etc/bash_completion.d/st2
 	install -m755 bin/runners.sh $(DESTDIR)/opt/stackstorm/st2/bin/runners.sh

--- a/packages/st2/debian/st2.st2api.upstart
+++ b/packages/st2/debian/st2.st2api.upstart
@@ -17,7 +17,7 @@ kill timeout 60
 
 script
   NAME=st2api
-  DAEMON_ARGS="-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
+  DAEMON_ARGS="-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.api.gunicorn.conf"
 
   # Read configuration variable file if it is present
   set -o allexport

--- a/packages/st2/debian/st2.st2auth.upstart
+++ b/packages/st2/debian/st2.st2auth.upstart
@@ -17,7 +17,7 @@ kill timeout 60
 
 script
   NAME=st2auth
-  DAEMON_ARGS="-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
+  DAEMON_ARGS="-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.auth.gunicorn.conf"
 
   # Read configuration variable file if it is present
   set -o allexport

--- a/packages/st2/debian/st2.st2stream.upstart
+++ b/packages/st2/debian/st2.st2stream.upstart
@@ -17,7 +17,7 @@ kill timeout 60
 
 script
   NAME=st2stream
-  DAEMON_ARGS="-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30"
+  DAEMON_ARGS="-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.stream.gunicorn.conf"
 
   # Read configuration variable file if it is present
   set -o allexport

--- a/packages/st2/debian/st2api.service
+++ b/packages/st2/debian/st2api.service
@@ -7,7 +7,7 @@ Requires=st2api.socket
 Type=simple
 User=st2
 Group=st2
-Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
+Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.api.gunicorn.conf"
 EnvironmentFile=-/etc/default/st2api
 ExecStart=/opt/stackstorm/st2/bin/gunicorn st2api.wsgi:application $DAEMON_ARGS
 TimeoutSec=60

--- a/packages/st2/debian/st2auth.service
+++ b/packages/st2/debian/st2auth.service
@@ -7,7 +7,7 @@ Requires=st2auth.socket
 Type=simple
 User=st2
 Group=st2
-Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
+Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.auth.gunicorn.conf"
 EnvironmentFile=-/etc/default/st2auth
 ExecStart=/opt/stackstorm/st2/bin/gunicorn st2auth.wsgi:application $DAEMON_ARGS
 TimeoutSec=60

--- a/packages/st2/debian/st2stream.service
+++ b/packages/st2/debian/st2stream.service
@@ -7,7 +7,7 @@ Requires=st2stream.socket
 Type=simple
 User=st2
 Group=st2
-Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30"
+Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.stream.gunicorn.conf"
 EnvironmentFile=-/etc/default/st2stream
 ExecStart=/opt/stackstorm/st2/bin/gunicorn st2stream.wsgi:application $DAEMON_ARGS
 TimeoutSec=60

--- a/packages/st2/rpm/st2api.init
+++ b/packages/st2/rpm/st2api.init
@@ -27,7 +27,7 @@ DESC="st2api"
 NAME=st2api
 DAEMON=/opt/stackstorm/st2/bin/gunicorn
 PIDFILE=/var/run/st2/$NAME.pid
-DAEMON_ARGS="-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --pid ${PIDFILE}"
+DAEMON_ARGS="-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.api.gunicorn.conf --pid ${PIDFILE}"
 RUNAS_USER="st2"
 
 lockfile=/var/lock/subsys/$NAME

--- a/packages/st2/rpm/st2api.service
+++ b/packages/st2/rpm/st2api.service
@@ -7,7 +7,7 @@ Requires=st2api.socket
 Type=simple
 User=st2
 Group=st2
-Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
+Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9101 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.api.gunicorn.conf"
 EnvironmentFile=-/etc/sysconfig/st2api
 ExecStart=/opt/stackstorm/st2/bin/gunicorn st2api.wsgi:application $DAEMON_ARGS
 TimeoutSec=60

--- a/packages/st2/rpm/st2auth.init
+++ b/packages/st2/rpm/st2auth.init
@@ -27,7 +27,7 @@ DESC="st2auth"
 NAME=st2auth
 DAEMON=/opt/stackstorm/st2/bin/gunicorn
 PIDFILE=/var/run/st2/$NAME.pid
-DAEMON_ARGS="-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --pid ${PIDFILE}"
+DAEMON_ARGS="-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.auth.gunicorn.conf --pid ${PIDFILE}"
 RUNAS_USER="st2"
 
 lockfile=/var/lock/subsys/$NAME

--- a/packages/st2/rpm/st2auth.service
+++ b/packages/st2/rpm/st2auth.service
@@ -7,7 +7,7 @@ Requires=st2auth.socket
 Type=simple
 User=st2
 Group=st2
-Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30"
+Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9100 --workers 1 --threads 1 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.auth.gunicorn.conf"
 EnvironmentFile=-/etc/sysconfig/st2auth
 ExecStart=/opt/stackstorm/st2/bin/gunicorn st2auth.wsgi:application $DAEMON_ARGS
 TimeoutSec=60

--- a/packages/st2/rpm/st2stream.init
+++ b/packages/st2/rpm/st2stream.init
@@ -27,7 +27,7 @@ DESC="st2stream"
 NAME=st2stream
 DAEMON=/opt/stackstorm/st2/bin/gunicorn
 PIDFILE=/var/run/st2/$NAME.pid
-DAEMON_ARGS="-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30 --pid ${PIDFILE}"
+DAEMON_ARGS="-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.stream.gunicorn.conf --pid ${PIDFILE}"
 RUNAS_USER="st2"
 
 lockfile=/var/lock/subsys/$NAME

--- a/packages/st2/rpm/st2stream.service
+++ b/packages/st2/rpm/st2stream.service
@@ -7,7 +7,7 @@ Requires=st2stream.socket
 Type=simple
 User=st2
 Group=st2
-Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30"
+Environment="DAEMON_ARGS=-k eventlet -b 127.0.0.1:9102 --workers 1 --threads 10 --graceful-timeout 10 --timeout 30 --log-config /etc/st2/logging.stream.gunicorn.conf"
 EnvironmentFile=-/etc/sysconfig/st2stream
 ExecStart=/opt/stackstorm/st2/bin/gunicorn st2stream.wsgi:application $DAEMON_ARGS
 TimeoutSec=60


### PR DESCRIPTION
This pull request installs gunicorn worker logging config files and updates service manager files to pass ``--logging-config`` argument to the gunicorn process.

For context and details, see https://github.com/StackStorm/st2/pull/4206.