### PR TITLE
Make sure we restart st2sensorcontainer and st2workflowengine service after generating encryption key (v2.8)

### DIFF
--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -234,10 +234,10 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # NOTE: We need to restart all the affected services so they pick the key and load it in memory
-  sudo st2ctl restart-component st2api
-  sudo st2ctl restart-component st2sensorcontainer
-  sudo st2ctl restart-component st2workflowengine
-  sudo st2ctl restart-component st2actionrunner
+  # NOTE: Only st2api, st2sensorcontainer, st2workflowengine and st2actionrunner work with
+  # encrypted datastore values, but we restart all the services to be on the safe side and for
+  # future proofing reasons.
+  sudo st2ctl restart
 }
 
 

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -234,10 +234,10 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # NOTE: We need to restart all the affected services so they pick the key and load it in memory
-  # NOTE: Only st2api, st2sensorcontainer, st2workflowengine and st2actionrunner work with
-  # encrypted datastore values, but we restart all the services to be on the safe side and for
-  # future proofing reasons.
-  sudo st2ctl restart
+  sudo st2ctl restart-component st2api
+  sudo st2ctl restart-component st2sensorcontainer
+  sudo st2ctl restart-component st2workflowengine
+  sudo st2ctl restart-component st2actionrunner
 }
 
 

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -234,6 +234,8 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   sudo st2ctl restart-component st2api
+  sudo st2ctl restart-component st2sensorcontainer
+  sudo st2ctl restart-component st2workflowengine
 }
 
 

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -233,7 +233,7 @@ generate_symmetric_crypto_key_for_datastore() {
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
-  # NOTE: We need to restart all the affected services so they pick the key nad load it in memory
+  # NOTE: We need to restart all the affected services so they pick the key and load it in memory
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2sensorcontainer
   sudo st2ctl restart-component st2workflowengine

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -233,9 +233,11 @@ generate_symmetric_crypto_key_for_datastore() {
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
+  # NOTE: We need to restart all the affected services so they pick the key nad load it in memory
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2sensorcontainer
   sudo st2ctl restart-component st2workflowengine
+  sudo st2ctl restart-component st2actionrunner
 }
 
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -350,7 +350,7 @@ generate_symmetric_crypto_key_for_datastore() {
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
-  # NOTE: We need to restart all the affected services so they pick the key nad load it in memory
+  # NOTE: We need to restart all the affected services so they pick the key and load it in memory
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2sensorcontainer
   sudo st2ctl restart-component st2workflowengine

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -351,6 +351,8 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   sudo st2ctl restart-component st2api
+  sudo st2ctl restart-component st2sensorcontainer
+  sudo st2ctl restart-component st2workflowengine
 }
 
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -350,9 +350,11 @@ generate_symmetric_crypto_key_for_datastore() {
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
+  # NOTE: We need to restart all the affected services so they pick the key nad load it in memory
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2sensorcontainer
   sudo st2ctl restart-component st2workflowengine
+  sudo st2ctl restart-component st2actionrunner
 }
 
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -351,10 +351,10 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # NOTE: We need to restart all the affected services so they pick the key and load it in memory
-  sudo st2ctl restart-component st2api
-  sudo st2ctl restart-component st2sensorcontainer
-  sudo st2ctl restart-component st2workflowengine
-  sudo st2ctl restart-component st2actionrunner
+  # NOTE: Only st2api, st2sensorcontainer, st2workflowengine and st2actionrunner work with
+  # encrypted datastore values, but we restart all the services to be on the safe side and for
+  # future proofing reasons.
+  sudo st2ctl restart
 }
 
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -351,10 +351,10 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # NOTE: We need to restart all the affected services so they pick the key and load it in memory
-  # NOTE: Only st2api, st2sensorcontainer, st2workflowengine and st2actionrunner work with
-  # encrypted datastore values, but we restart all the services to be on the safe side and for
-  # future proofing reasons.
-  sudo st2ctl restart
+  sudo st2ctl restart-component st2api
+  sudo st2ctl restart-component st2sensorcontainer
+  sudo st2ctl restart-component st2workflowengine
+  sudo st2ctl restart-component st2actionrunner
 }
 
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -345,7 +345,7 @@ generate_symmetric_crypto_key_for_datastore() {
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
-  # NOTE: We need to restart all the affected services so they pick the key nad load it in memory
+  # NOTE: We need to restart all the affected services so they pick the key and load it in memory
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2sensorcontainer
   sudo st2ctl restart-component st2workflowengine

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -346,10 +346,10 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # NOTE: We need to restart all the affected services so they pick the key and load it in memory
-  # NOTE: Only st2api, st2sensorcontainer, st2workflowengine and st2actionrunner work with
-  # encrypted datastore values, but we restart all the services to be on the safe side and for
-  # future proofing reasons.
-  sudo st2ctl restart
+  sudo st2ctl restart-component st2api
+  sudo st2ctl restart-component st2sensorcontainer
+  sudo st2ctl restart-component st2workflowengine
+  sudo st2ctl restart-component st2actionrunner
 }
 
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -346,6 +346,8 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   sudo st2ctl restart-component st2api
+  sudo st2ctl restart-component st2sensorcontainer
+  sudo st2ctl restart-component st2workflowengine
 }
 
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -346,10 +346,10 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # NOTE: We need to restart all the affected services so they pick the key and load it in memory
-  sudo st2ctl restart-component st2api
-  sudo st2ctl restart-component st2sensorcontainer
-  sudo st2ctl restart-component st2workflowengine
-  sudo st2ctl restart-component st2actionrunner
+  # NOTE: Only st2api, st2sensorcontainer, st2workflowengine and st2actionrunner work with
+  # encrypted datastore values, but we restart all the services to be on the safe side and for
+  # future proofing reasons.
+  sudo st2ctl restart
 }
 
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -345,9 +345,11 @@ generate_symmetric_crypto_key_for_datastore() {
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
+  # NOTE: We need to restart all the affected services so they pick the key nad load it in memory
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2sensorcontainer
   sudo st2ctl restart-component st2workflowengine
+  sudo st2ctl restart-component st2actionrunner
 }
 
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -345,7 +345,7 @@ generate_symmetric_crypto_key_for_datastore() {
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
-  # NOTE: We need to restart all the affected services so they pick the key nad load it in memory
+  # NOTE: We need to restart all the affected services so they pick the key and load it in memory
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2sensorcontainer
   sudo st2ctl restart-component st2workflowengine

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -346,10 +346,10 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # NOTE: We need to restart all the affected services so they pick the key and load it in memory
-  # NOTE: Only st2api, st2sensorcontainer, st2workflowengine and st2actionrunner work with
-  # encrypted datastore values, but we restart all the services to be on the safe side and for
-  # future proofing reasons.
-  sudo st2ctl restart
+  sudo st2ctl restart-component st2api
+  sudo st2ctl restart-component st2sensorcontainer
+  sudo st2ctl restart-component st2workflowengine
+  sudo st2ctl restart-component st2actionrunner
 }
 
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -346,6 +346,8 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   sudo st2ctl restart-component st2api
+  sudo st2ctl restart-component st2sensorcontainer
+  sudo st2ctl restart-component st2workflowengine
 }
 
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -346,10 +346,10 @@ generate_symmetric_crypto_key_for_datastore() {
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
   # NOTE: We need to restart all the affected services so they pick the key and load it in memory
-  sudo st2ctl restart-component st2api
-  sudo st2ctl restart-component st2sensorcontainer
-  sudo st2ctl restart-component st2workflowengine
-  sudo st2ctl restart-component st2actionrunner
+  # NOTE: Only st2api, st2sensorcontainer, st2workflowengine and st2actionrunner work with
+  # encrypted datastore values, but we restart all the services to be on the safe side and for
+  # future proofing reasons.
+  sudo st2ctl restart
 }
 
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -345,9 +345,11 @@ generate_symmetric_crypto_key_for_datastore() {
   # set path to the key file in the config
   sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
 
+  # NOTE: We need to restart all the affected services so they pick the key nad load it in memory
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2sensorcontainer
   sudo st2ctl restart-component st2workflowengine
+  sudo st2ctl restart-component st2actionrunner
 }
 
 


### PR DESCRIPTION
I noticed this bug / issue while testing v2.8.0 packages.

We generate symmetric encryption key for encrypted datastore values after StackStorm has been installed and all the services started.

This means that if we don't restart all the affected services (st2api, st2workflowengine, st2sensorcontainer), those services won't be aware that the key exists until they have been restarted. As such, encryption / decryption will fail.

For example (from `st2workflowengine` log file):

```bash
2018-07-06 11:08:17,633 140130336387472 INFO keyvalue [-] Checking if encryption is enabled for key-value store.
2018-07-06 11:08:17,633 140130336387472 INFO keyvalue [-] Encryption enabled. Looking for key in path 
2018-07-06 11:08:17,633 140130336387472 ERROR keyvalue [-] Encryption key file does not exist in path .
```

I originally noticed this issue in `st2workflowengine`, but the same issue exists with `st2sensorcontainer` which spawns long running sensor processes on start up.

Keep in mind that the same issue doesn't affect `st2actionrunner`, because decrypting / encrypting values is only supported by Python runner actions and those actions run as subprocesses which are spawned when action execution is requested.

Having said that, I would still recommend to restart it as well - mostly for consistency reasons and to avoid simialr issues in the future if we ever change how st2actionrunner works or add support for encrypting / decrypting to other runner actions.
