### PR TITLE
Point to v2.7 branch until v2.8 release is out.

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -15,7 +15,7 @@ USERNAME=''
 PASSWORD=''
 
 # Note: This variable needs to default to a branch of the latest stable release
-BRANCH='v2.8'
+BRANCH='v2.7'
 FORCE_BRANCH=""
 
 adddate() {


### PR DESCRIPTION
We should point to v2.7 branch of st2-packages otherwise things will break because v2.8.0 is not out yet.

Should resolve https://github.com/StackStorm/st2-packages/issues/576.