### PR TITLE
Remove stackstorm-runner-orchestra from st2

### DIFF
--- a/packages/st2/in-requirements.txt
+++ b/packages/st2/in-requirements.txt
@@ -7,5 +7,4 @@ st2reactor
 st2exporter
 st2debug
 st2tests
-stackstorm-runner-orchestra
 git+https://github.com/StackStorm/st2-auth-backend-pam.git@master#egg=st2-auth-backend-pam


### PR DESCRIPTION
The orchestra runner has been renamed to orquesta. The reference to it in requirements is causing build failures.