### PR TITLE
Removed default site on RHEL/CentOS hosts

### DIFF
--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -688,11 +688,11 @@ EOT"
   sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
   -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information Technology/CN=$(hostname)"
 
+  # Remove default site, if present
+  sudo rm -f /etc/nginx/conf.d/default.conf
+
   # Copy and enable StackStorm's supplied config file
   sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/
-
-  # Disable default_server configuration in existing /etc/nginx/conf.d/default.conf
-  sudo sed -i 's/default_server//g' /etc/nginx/conf.d/default.conf
 
   sudo service nginx start
   sudo chkconfig nginx on

--- a/scripts/st2bootstrap-el6.template.sh
+++ b/scripts/st2bootstrap-el6.template.sh
@@ -328,11 +328,11 @@ EOT"
   sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
   -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information Technology/CN=$(hostname)"
 
+  # Remove default site, if present
+  sudo rm -f /etc/nginx/conf.d/default.conf
+
   # Copy and enable StackStorm's supplied config file
   sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/
-
-  # Disable default_server configuration in existing /etc/nginx/conf.d/default.conf
-  sudo sed -i 's/default_server//g' /etc/nginx/conf.d/default.conf
 
   sudo service nginx start
   sudo chkconfig nginx on

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -667,11 +667,11 @@ EOT"
   sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
   -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information Technology/CN=$(hostname)"
 
+  # Remove default site, if present
+  sudo rm -f /etc/nginx/conf.d/default.conf
+
   # Copy and enable StackStorm's supplied config file
   sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/
-
-  # Disable default_server configuration in existing /etc/nginx/nginx.conf
-  sudo sed -i 's/default_server//g' /etc/nginx/nginx.conf
 
   sudo systemctl restart nginx
   sudo systemctl enable nginx

--- a/scripts/st2bootstrap-el7.template.sh
+++ b/scripts/st2bootstrap-el7.template.sh
@@ -307,11 +307,11 @@ EOT"
   sudo openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt \
   -days 365 -nodes -subj "/C=US/ST=California/L=Palo Alto/O=StackStorm/OU=Information Technology/CN=$(hostname)"
 
+  # Remove default site, if present
+  sudo rm -f /etc/nginx/conf.d/default.conf
+
   # Copy and enable StackStorm's supplied config file
   sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/
-
-  # Disable default_server configuration in existing /etc/nginx/nginx.conf
-  sudo sed -i 's/default_server//g' /etc/nginx/nginx.conf
 
   sudo systemctl restart nginx
   sudo systemctl enable nginx


### PR DESCRIPTION
Fixes https://github.com/StackStorm/st2/issues/4358

In order to prevent the default splash screen from showing, we need to remove the default config on RHEL/CentOS hosts.