### PR TITLE
Use master branch from st2 repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       # with real gitrevs during releases. Note that they are commented out, so that they do not interfere
       # with build parameters. st2cd prep tasks will uncomment these on a branch, and replace with proper
       # gitrefs.
-      ST2_GITREV: "stevedore-runners"
+      # ST2_GITREV: ""
       # ST2MISTRAL_GITREV: ""
     steps:
       - checkout


### PR DESCRIPTION
There was a cyclic dependency problem between those two changes (https://github.com/StackStorm/st2-packages/pull/585, https://github.com/StackStorm/st2/pull/4217) so I needed to first pin it to a specific st2 branch to get tests to pass.

Once StackStorm/st2 branch is merged, we can use master branch again.