### PR TITLE
Add support for Ubuntu Bionic for StackStorm using Python 3

### DIFF
--- a/.circle/buildenv_common.sh
+++ b/.circle/buildenv_common.sh
@@ -6,3 +6,17 @@ write_env() {
   done
   echo ". ~/.buildenv" >> ~/.circlerc
 }
+
+distros=($DISTROS)
+DISTRO=${distros[$CIRCLE_NODE_INDEX]}
+
+# NOTE: We don't build Mistral package on Ubuntu Bionic
+if [ "${DISTRO}" = "bionic"} ]; then
+    ST2_PACKAGES="st2"
+else
+    ST2_PACKAGES=${ST2_PACKAGES:-st2 mistral}
+fi
+
+write_env ST2_PACKAGES
+
+cat ~/.buildenv

--- a/.circle/buildenv_mistral.sh
+++ b/.circle/buildenv_mistral.sh
@@ -11,11 +11,11 @@ fetch_version() {
   if [ -f ../version_st2.py ]; then
     # Get st2 version based on hardcoded string in st2common
     # build takes place in `st2` repo
-    python -c 'execfile("../version_st2.py"); print __version__'
+    python -c 'exec(open("../version_st2.py").read()); print(__version__)'
   else
     # build takes place in `st2-packages` repo
     curl -sSL -o /tmp/mistral_version.py ${ST2MISTRAL_GITURL}/raw/${ST2MISTRAL_GITREV}/version_st2.py
-    python -c 'execfile("/tmp/mistral_version.py"); print __version__'
+    python -c 'exec(open("/tmp/mistral_version.py").read()); print(__version__)'
   fi
 }
 

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -x
 
 my_dir="$(dirname "$0")"
 source "$my_dir/buildenv_common.sh"

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -40,6 +40,7 @@ st2_giturl() {
 # ST2_GITREV - st2 branch name (ex: master, v1.2.1). This will be used to determine correct Docker Tag: `latest`, `1.2.1`
 # ST2PKG_VERSION - st2 version, will be reused in Docker image metadata (ex: 1.2dev)
 # ST2PKG_RELEASE - Release number aka revision number for `st2` package, will be reused in Docker metadata (ex: 4)
+# ST2_PACKAGES - Which packages to build (defautls to st2 mistral).
 
 ST2_GITURL=${ST2_GITURL:-https://github.com/StackStorm/st2}
 ST2_GITREV=${ST2_GITREV:-master}
@@ -57,6 +58,13 @@ re="\\b$DISTRO\\b"
 
 ST2_CIRCLE_URL=${CIRCLE_BUILD_URL}
 
-write_env ST2_GITURL ST2_GITREV ST2PKG_VERSION ST2PKG_RELEASE DISTRO TESTING ST2_CIRCLE_URL
+# NOTE: We don't build Mistral package on Ubuntu Bionic
+if [ "${DISTRO}" = "bionic"} ]; then
+    ST2_PACKAGES="st2"
+else
+    ST2_PACKAGES=${ST2_PACKAGES:-st2 mistral}
+fi
+
+write_env ST2_GITURL ST2_GITREV ST2PKG_VERSION ST2PKG_RELEASE DISTRO TESTING ST2_CIRCLE_URL ST2_PACKAGES
 
 cat ~/.buildenv

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -58,13 +58,6 @@ re="\\b$DISTRO\\b"
 
 ST2_CIRCLE_URL=${CIRCLE_BUILD_URL}
 
-# NOTE: We don't build Mistral package on Ubuntu Bionic
-if [ "${DISTRO}" = "bionic"} ]; then
-    ST2_PACKAGES="st2"
-else
-    ST2_PACKAGES=${ST2_PACKAGES:-st2 mistral}
-fi
-
-write_env ST2_GITURL ST2_GITREV ST2PKG_VERSION ST2PKG_RELEASE DISTRO TESTING ST2_CIRCLE_URL ST2_PACKAGES
+write_env ST2_GITURL ST2_GITREV ST2PKG_VERSION ST2PKG_RELEASE DISTRO TESTING ST2_CIRCLE_URL
 
 cat ~/.buildenv

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -37,11 +37,11 @@ st2_giturl() {
 # ST2_GITREV - st2 branch name (ex: master, v1.2.1). This will be used to determine correct Docker Tag: `latest`, `1.2.1`
 # ST2PKG_VERSION - st2 version, will be reused in Docker image metadata (ex: 1.2dev)
 # ST2PKG_RELEASE - Release number aka revision number for `st2` package, will be reused in Docker metadata (ex: 4)
-# ST2_PACKAGES - Which packages to build (defautls to st2 mistral).
 
 ST2_GITURL=${ST2_GITURL:-https://github.com/StackStorm/st2}
 ST2_GITREV=${ST2_GITREV:-master}
 ST2PKG_VERSION=$(fetch_version)
+
 # for PackageCloud
 if [ -n "$PACKAGECLOUD_TOKEN" ]; then
   ST2PKG_RELEASE=$(.circle/packagecloud.sh next-revision ${DISTRO} ${ST2PKG_VERSION} st2)
@@ -55,13 +55,6 @@ re="\\b$DISTRO\\b"
 
 ST2_CIRCLE_URL=${CIRCLE_BUILD_URL}
 
-# NOTE: We don't build Mistral package on Ubuntu Bionic
-if [ "${DISTRO}" = "bionic"} ]; then
-    ST2_PACKAGES="st2"
-else
-    ST2_PACKAGES=${ST2_PACKAGES:-st2 mistral}
-fi
-
-write_env ST2_GITURL ST2_GITREV ST2PKG_VERSION ST2PKG_RELEASE DISTRO TESTING ST2_CIRCLE_URL ST2_PACKAGES
+write_env ST2_GITURL ST2_GITREV ST2PKG_VERSION ST2PKG_RELEASE DISTRO TESTING ST2_CIRCLE_URL
 
 cat ~/.buildenv

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -7,17 +7,20 @@ source "$my_dir/buildenv_common.sh"
 distros=($DISTROS)
 DISTRO=${distros[$CIRCLE_NODE_INDEX]}
 
-echo "Using distros: ${DISTRO}"
+echo "Using distro: ${DISTRO}"
+echo "Using Python: $(python --version 2>&1)"
+echo "ST2_GITURL: ${ST2_GITURL}"
+echo "ST2_GITREV: ${ST2_GITREV}"
 
 fetch_version() {
   if [ -f ../st2/st2common/st2common/__init__.py ]; then
     # Get st2 version based on hardcoded string in st2common
     # build takes place in `st2` repo
-    python -c 'execfile("../st2/st2common/st2common/__init__.py"); print __version__'
+    python -c 'execfile("../st2/st2common/st2common/__init__.py"); print(__version__)'
   else
     # build takes place in `st2-packages` repo
     curl -sSL -o /tmp/st2_version.py ${ST2_GITURL}/raw/${ST2_GITREV}/st2common/st2common/__init__.py
-    python -c 'execfile("/tmp/st2_version.py"); print __version__'
+    python -c 'execfile("/tmp/st2_version.py"); print(__version__)'
   fi
 }
 

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -58,6 +58,13 @@ re="\\b$DISTRO\\b"
 
 ST2_CIRCLE_URL=${CIRCLE_BUILD_URL}
 
-write_env ST2_GITURL ST2_GITREV ST2PKG_VERSION ST2PKG_RELEASE DISTRO TESTING ST2_CIRCLE_URL
+# NOTE: We don't build Mistral package on Ubuntu Bionic
+if [ "${DISTRO}" = "bionic"} ]; then
+    ST2_PACKAGES="st2"
+else
+    ST2_PACKAGES=${ST2_PACKAGES:-st2 mistral}
+fi
+
+write_env ST2_GITURL ST2_GITREV ST2PKG_VERSION ST2PKG_RELEASE DISTRO TESTING ST2_CIRCLE_URL ST2_PACKAGES
 
 cat ~/.buildenv

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -x
 
 my_dir="$(dirname "$0")"
 source "$my_dir/buildenv_common.sh"

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -7,6 +7,8 @@ source "$my_dir/buildenv_common.sh"
 distros=($DISTROS)
 DISTRO=${distros[$CIRCLE_NODE_INDEX]}
 
+echo "Using distros: ${DISTRO}"
+
 fetch_version() {
   if [ -f ../st2/st2common/st2common/__init__.py ]; then
     # Get st2 version based on hardcoded string in st2common

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -16,11 +16,11 @@ fetch_version() {
   if [ -f ../st2/st2common/st2common/__init__.py ]; then
     # Get st2 version based on hardcoded string in st2common
     # build takes place in `st2` repo
-    python -c 'execfile("../st2/st2common/st2common/__init__.py"); print(__version__)'
+    python -c 'exec(open("../st2/st2common/st2common/__init__.py").read()); print(__version__)'
   else
     # build takes place in `st2-packages` repo
     curl -sSL -o /tmp/st2_version.py ${ST2_GITURL}/raw/${ST2_GITREV}/st2common/st2common/__init__.py
-    python -c 'execfile("/tmp/st2_version.py"); print(__version__)'
+    python -c 'exec(open("/tmp/st2_version.py").read()); print(__version__)'
   fi
 }
 

--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -9,8 +9,6 @@ DISTRO=${distros[$CIRCLE_NODE_INDEX]}
 
 echo "Using distro: ${DISTRO}"
 echo "Using Python: $(python --version 2>&1)"
-echo "ST2_GITURL: ${ST2_GITURL}"
-echo "ST2_GITREV: ${ST2_GITREV}"
 
 fetch_version() {
   if [ -f ../st2/st2common/st2common/__init__.py ]; then

--- a/.circle/packagecloud.sh
+++ b/.circle/packagecloud.sh
@@ -120,6 +120,14 @@ function deploy() {
      continue
     fi
 
+    # NOTE: At the moment we only support staging unstable Bionic packages
+    if [ "${PKG_OS}" = "bionic" ]; then
+      if [ "${PACKAGECLOUD_REPO}" != "staging-unstable"]; then
+        echo "Skipping upload for ${PKG_OS} packages, right now it's only enabled for staging unstable."
+        continue
+      fi
+    fi
+
     debug "PACKAGECLOUD_ORGANIZATION:  ${PACKAGECLOUD_ORGANIZATION}"
     debug "PACKAGECLOUD_REPO:          ${PACKAGECLOUD_REPO}"
     debug "PKG_PATH:                   ${PKG_PATH}"

--- a/.circle/packagecloud.sh
+++ b/.circle/packagecloud.sh
@@ -37,8 +37,8 @@ function main() {
       fi
       ;;
     *)
-      echo $"Usage: deploy {trusty|xenial|el6|el7} /tmp/st2-packages"
-      echo $"Usage: next-revision {trusty|xenial|el6|el7} 0.14dev st2"
+      echo $"Usage: deploy {trusty|xenial|bionic|el6|el7} /tmp/st2-packages"
+      echo $"Usage: next-revision {trusty|xenial|bionic|el6|el7} 0.14dev st2"
       exit 1
   esac
 }
@@ -230,7 +230,7 @@ function get_pkg_os() {
       PKG_OS_VERSION=$PKG_OS
       PKG_TYPE="deb"
       ;;
-    warty|hoary|breezy|dapper|edgy|feisty|gutsy|hardy|intrepid|jaunty|karmic|lucid|maverick|natty|oneiric|precise|quantal|raring|saucy|trusty|utopic|vivid|wily|xenial)
+    warty|hoary|breezy|dapper|edgy|feisty|gutsy|hardy|intrepid|jaunty|karmic|lucid|maverick|natty|oneiric|precise|quantal|raring|saucy|trusty|utopic|vivid|wily|xenial|bionic)
       PKG_OS_NAME=ubuntu
       PKG_OS_VERSION=$PKG_OS
       PKG_TYPE="deb"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - image: circleci/python:2.7
     working_directory: ~/st2-packages
     environment:
-      DISTROS: "trusty xenial el6 el7"
+      DISTROS: "trusty xenial bionic el6 el7"
       ST2_PACKAGES: "st2 st2mistral"
       BASH_ENV: ~/.buildenv
       # These should be set to an empty string, so that st2cd prep tasks are able to replace these

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,7 @@ jobs:
       - image: circleci/ruby:2.4
     working_directory: /tmp/deploy
     environment:
+      # TODO: Add support for deploying Bionic to Staging Unstable
       - DISTROS: "trusty xenial el6 el7"
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,7 @@ jobs:
       - image: circleci/ruby:2.4
     working_directory: /tmp/deploy
     environment:
-      # TODO: Add support for deploying Bionic to Staging Unstable
-      - DISTROS: "trusty xenial el6 el7"
+      - DISTROS: "trusty xenial bionic el6 el7"
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ jobs:
     working_directory: ~/st2-packages
     environment:
       DISTROS: "trusty xenial bionic el6 el7"
-      ST2_PACKAGES: "st2 st2mistral"
       BASH_ENV: ~/.buildenv
       # These should be set to an empty string, so that st2cd prep tasks are able to replace these
       # with real gitrevs during releases. Note that they are commented out, so that they do not interfere

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 jobs:
   # Build & Test st2 & st2mistral packages
   packages:
-    parallelism: 4
+    parallelism: 5
     # 4CPUs & 8GB RAM CircleCI machine
     # sadly, it doesn't work with 'setup_remote_docker'
     resource_class: large

--- a/README.md
+++ b/README.md
@@ -117,40 +117,22 @@ For example:
 ...
 
 bionic:
+  ...
   image: quay.io/stackstorm/packagingrunner
-  extends:
-    file: docker-compose.override.yml
-    service: suite-compose
-  environment:
-    - BUILDNODE=bionicbuild
-    - TESTNODE=bionictest
-  links:
-    - bionicbuild
-    - bionictest
-    - rabbitmq
-    - mongodb
-    - postgres
-
+  ...
 ...
 
 bionicbuild:
+  ...
   image: bionicbuild
-  extends:
-    file: docker-compose.override.yml
-    service: volumes-compose
+  ...
 
 ...
 
 bionictest:
+  ...
   image: bionictest
-  privileged: true
-  extends:
-    file: docker-compose.override.yml
-    service: volumes-compose
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-
-...
+  ...
 ```
 
 NOTE: Main ``distro`` definition (e.g. ``bionic``, ``xenial``, etc.) needs to use packaging runner image.
@@ -163,8 +145,11 @@ Before that will work, you of course also need to build those images locally.
 For example:
 
 ```bash
-cd ~/st2packaging-dockerfiles/packagingbuild
+cd ~/st2packaging-dockerfiles/packagingbuild/bionic
 docker build -t bionicbuild .
+
+cd ~/st2packaging-dockerfiles/packagingtest/bionic/systemd
+docker build -t bionictest .
 ```
 
 # License and Authors

--- a/README.md
+++ b/README.md
@@ -114,13 +114,43 @@ need to update ``docker-compose.yml`` file to use locally built Docker images.
 For example:
 
 ```yaml
-image: stackstorm/packagingbuild:centos7
+...
+
+bionic:
+  image: quay.io/stackstorm/packagingrunner
+  extends:
+    file: docker-compose.override.yml
+    service: suite-compose
+  environment:
+    - BUILDNODE=bionicbuild
+    - TESTNODE=bionictest
+  links:
+    - bionicbuild
+    - bionictest
+    - rabbitmq
+    - mongodb
+    - postgres
+
+...
 
 bionicbuild:
   image: bionicbuild
   extends:
     file: docker-compose.override.yml
     service: volumes-compose
+
+...
+
+bionictest:
+  image: bionictest
+  privileged: true
+  extends:
+    file: docker-compose.override.yml
+    service: volumes-compose
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+...
 ```
 
 NOTE: Main ``distro`` definition (e.g. ``bionic``, ``xenial``, etc.) needs to use packaging runner image.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ bionicbuild:
     service: volumes-compose
 ```
 
+NOTE: Main ``distro`` definition (e.g. ``bionic``, ``xenial``, etc.) needs to use packaging runner image.
+
 As you can see, ``image`` attribute references local image tagged ``bionicbuild`` instead of a
 remote image (e.g. ``stackstorm/packagingbuild:bionic`` or similar).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Go to Docker Hub](https://img.shields.io/badge/Docker%20Hub-%E2%86%92-blue.svg)](https://hub.docker.com/r/stackstorm/)
 [![Download deb/rpm](https://img.shields.io/badge/Download-deb/rpm-blue.svg)](https://packagecloud.io/StackStorm/)
 
-
 ## Highlights
 
  - **Docker based**. Leveraging docker it's possible to deliver packages for any OS distro in a fast and reliable way.
@@ -23,7 +22,6 @@ Packages build environment is a *multi-container docker* application defined and
 `Dockerfiles` sources are available at [StackStorm/st2-dockerfiles](https://github.com/stackstorm/st2-dockerfiles).
 
 The Packages build environment compose application brings a self-sufficient pipeline to deliver ready to use packages.
-
 
 # Usage
 
@@ -107,6 +105,35 @@ Current community packages are hosted on https://packagecloud.io/StackStorm. For
 - [RHEL7/CentOS7](https://docs.stackstorm.com/install/rhel7.html)
 - [RHEL6/CentOS6](https://docs.stackstorm.com/install/rhel6.html)
 
+## Adding Support For a New Distribution
+
+If you are adding support for a new distribution for which ``packagingbuild`` and ``packagingtest``
+images are not yet published to Docker Hub and you want to test the build pipeline locally, you
+need to update ``docker-compose.yml`` file to use locally built Docker images.
+
+For example:
+
+```yaml
+image: stackstorm/packagingbuild:centos7
+
+bionicbuild:
+  image: bionicbuild
+  extends:
+    file: docker-compose.override.yml
+    service: volumes-compose
+```
+
+As you can see, ``image`` attribute references local image tagged ``bionicbuild`` instead of a
+remote image (e.g. ``stackstorm/packagingbuild:bionic`` or similar).
+
+Before that will work, you of course also need to build those images locally.
+
+For example:
+
+```bash
+cd ~/st2packaging-dockerfiles/packagingbuild
+docker build -t bionicbuild .
+```
 
 # License and Authors
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,11 @@ VIRTUAL_MACHINES = {
     :box => 'ubuntu/xenial64',
     :ip => '192.168.16.21',
   },
+  :bionic=> {
+    :hostname => 'st2-packages-bionic',
+    :box => 'ubuntu/bionic64',
+    :ip => '192.168.16.23',
+  },
   :el7 => {
     :hostname => 'st2-packages-el7',
     :box => 'centos/7',

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -33,7 +33,6 @@ bionic:
     # NOTE: We don't build st2mistral package so we don't mix Python 3
     # (StackStorm components) and Python 2 (Mistral)
     # Bionic will be first release without a Mistral
-    - ST2_GITREV=fix_py3_issues
     - ST2_PACKAGES=st2
   links:
     - bionicbuild

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -22,6 +22,26 @@ xenial:
     - xenialbuild
     - xenialtest
 
+bionic:
+  image: quay.io/stackstorm/packagingrunner
+  extends:
+    file: docker-compose.override.yml
+    service: suite-compose
+  environment:
+    - BUILDNODE=bionicbuild
+    - TESTNODE=bionictest
+    # NOTE: We don't build st2mistral package so we don't mix Python 3
+    # (StackStorm components) and Python 2 (Mistral)
+    # Bionic will be first release without a Mistral
+    - ST2_GITREV=fix_py3_issues
+    - ST2_PACKAGES=st2
+  links:
+    - bionicbuild
+    - bionictest
+    - rabbitmq
+    - mongodb
+    - postgres
+
 el7:
   image: quay.io/stackstorm/packagingrunner
   extends:
@@ -61,6 +81,11 @@ xenialbuild:
     file: docker-compose.override.yml
     service: volumes-circle
 
+bionicbuild:
+  image: stackstorm/packagingbuild:bionic
+  volumes_from:
+    - st2-packages-vol
+
 centos6build:
   image: stackstorm/packagingbuild:centos6
   extends:
@@ -87,6 +112,14 @@ xenialtest:
   extends:
     file: docker-compose.override.yml
     service: volumes-circle
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+bionictest:
+  image: stackstorm/packagingtest:bionic-systemd
+  privileged: true
+  volumes_from:
+    - st2-packages-vol
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
 

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -40,6 +40,7 @@ bionic:
     # (StackStorm components) and Python 2 (Mistral)
     # Bionic will be first release without a Mistral
     - ST2_PACKAGES=st2
+    - ST2_GITREV=more_py3_fixes
   links:
     - bionicbuild
     - bionictest

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -93,8 +93,8 @@ xenialbuild:
 bionicbuild:
   image: stackstorm/packagingbuild:bionic
   volumes_from:
-  environment:
     - st2-packages-vol
+  environment:
     # NOTE: We don't build st2mistral package so we don't mix Python 3
     # (StackStorm components) and Python 2 (Mistral)
     # Bionic will be first release without a Mistral

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -39,7 +39,6 @@ bionic:
     # NOTE: We don't build st2mistral package so we don't mix Python 3
     # (StackStorm components) and Python 2 (Mistral)
     # Bionic will be first release without a Mistral
-    - ST2_GITREV=fix_py3_issues
     - ST2_PACKAGES=st2
   links:
     - bionicbuild

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -93,7 +93,12 @@ xenialbuild:
 bionicbuild:
   image: stackstorm/packagingbuild:bionic
   volumes_from:
+  environment:
     - st2-packages-vol
+    # NOTE: We don't build st2mistral package so we don't mix Python 3
+    # (StackStorm components) and Python 2 (Mistral)
+    # Bionic will be first release without a Mistral
+    - ST2_PACKAGES=st2
 
 centos6build:
   image: stackstorm/packagingbuild:centos6
@@ -127,6 +132,12 @@ bionictest:
     - st2-packages-vol
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  environment:
+    - st2-packages-vol
+    # NOTE: We don't build st2mistral package so we don't mix Python 3
+    # (StackStorm components) and Python 2 (Mistral)
+    # Bionic will be first release without a Mistral
+    - ST2_PACKAGES=st2
 
 centos6test:
   image: stackstorm/packagingtest:centos6-sshd

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -94,11 +94,6 @@ bionicbuild:
   image: stackstorm/packagingbuild:bionic
   volumes_from:
     - st2-packages-vol
-  environment:
-    # NOTE: We don't build st2mistral package so we don't mix Python 3
-    # (StackStorm components) and Python 2 (Mistral)
-    # Bionic will be first release without a Mistral
-    - ST2_PACKAGES=st2
 
 centos6build:
   image: stackstorm/packagingbuild:centos6
@@ -132,12 +127,6 @@ bionictest:
     - st2-packages-vol
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  environment:
-    - st2-packages-vol
-    # NOTE: We don't build st2mistral package so we don't mix Python 3
-    # (StackStorm components) and Python 2 (Mistral)
-    # Bionic will be first release without a Mistral
-    - ST2_PACKAGES=st2
 
 centos6test:
   image: stackstorm/packagingtest:centos6-sshd

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -28,6 +28,21 @@ xenial:
     - mongodb
     - postgres
 
+bionic:
+  image: quay.io/stackstorm/packagingrunner
+  extends:
+    file: docker-compose.override.yml
+    service: suite-compose
+  environment:
+    - BUILDNODE=bionicbuild
+    - TESTNODE=bionictest
+  links:
+    - bionicbuild
+    - bionictest
+    - rabbitmq
+    - mongodb
+    - postgres
+
 el7:
   image: quay.io/stackstorm/packagingrunner
   working_dir: /root/st2-packages
@@ -71,6 +86,11 @@ xenialbuild:
   volumes_from:
     - st2-packages-vol
 
+bionicbuild:
+  image: stackstorm/packagingbuild:bionic
+  volumes_from:
+    - st2-packages-vol
+
 centos6build:
   image: stackstorm/packagingbuild:centos6
   volumes_from:
@@ -90,6 +110,14 @@ trustytest:
 
 xenialtest:
   image: stackstorm/packagingtest:xenial-systemd
+  privileged: true
+  volumes_from:
+    - st2-packages-vol
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+bionictest:
+  image: stackstorm/packagingtest:bionic-systemd
   privileged: true
   volumes_from:
     - st2-packages-vol

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -30,9 +30,9 @@ xenial:
 
 bionic:
   image: quay.io/stackstorm/packagingrunner
-  extends:
-    file: docker-compose.override.yml
-    service: suite-compose
+  working_dir: /root/st2-packages
+  volumes_from:
+    - st2-packages-vol
   environment:
     - BUILDNODE=bionicbuild
     - TESTNODE=bionictest

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -36,6 +36,11 @@ bionic:
   environment:
     - BUILDNODE=bionicbuild
     - TESTNODE=bionictest
+    # NOTE: We don't build st2mistral package so we don't mix Python 3
+    # (StackStorm components) and Python 2 (Mistral)
+    # Bionic will be first release without a Mistral
+    - ST2_GITREV=fix_py3_issues
+    - ST2_PACKAGES=st2
   links:
     - bionicbuild
     - bionictest

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -40,7 +40,6 @@ bionic:
     # (StackStorm components) and Python 2 (Mistral)
     # Bionic will be first release without a Mistral
     - ST2_PACKAGES=st2
-    - ST2_GITREV=more_py3_fixes
   links:
     - bionicbuild
     - bionictest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,10 +97,6 @@ bionicbuild:
   extends:
     file: docker-compose.override.yml
     service: volumes-compose
-  environment:
-    # (StackStorm components) and Python 2 (Mistral)
-    # Bionic will be first release without a Mistral
-    - ST2_PACKAGES=st2
 
 centos6build:
   image: stackstorm/packagingbuild:centos6
@@ -139,10 +135,6 @@ bionictest:
     service: volumes-compose
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  environment:
-    # (StackStorm components) and Python 2 (Mistral)
-    # Bionic will be first release without a Mistral
-    - ST2_PACKAGES=st2
 
 centos6test:
   image: stackstorm/packagingtest:centos6-sshd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,10 @@ bionic:
   environment:
     - BUILDNODE=bionicbuild
     - TESTNODE=bionictest
+    # NOTE: We don't build st2mistral package so we don't mix Python 3
+    # (StackStorm components) and Python 2 (Mistral)
+    # Bionic will be first release without a Mistral
+    - ST2_PACKAGES=st2
   links:
     - bionicbuild
     - bionictest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ bionic:
     # NOTE: We don't build st2mistral package so we don't mix Python 3
     # (StackStorm components) and Python 2 (Mistral)
     # Bionic will be first release without a Mistral
-    - ST2_GITREV=fix_py3_issues
     - ST2_PACKAGES=st2
   links:
     - bionicbuild

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,21 @@ xenial:
     - mongodb
     - postgres
 
+bionic:
+  image: quay.io/stackstorm/packagingrunner
+  extends:
+    file: docker-compose.override.yml
+    service: suite-compose
+  environment:
+    - BUILDNODE=bionicbuild
+    - TESTNODE=bionictest
+  links:
+    - bionicbuild
+    - bionictest
+    - rabbitmq
+    - mongodb
+    - postgres
+
 el7:
   image: quay.io/stackstorm/packagingrunner
   extends:
@@ -73,6 +88,12 @@ xenialbuild:
     file: docker-compose.override.yml
     service: volumes-compose
 
+bionicbuild:
+  image: stackstorm/packagingbuild:bionic
+  extends:
+    file: docker-compose.override.yml
+    service: volumes-compose
+
 centos6build:
   image: stackstorm/packagingbuild:centos6
   extends:
@@ -95,6 +116,15 @@ trustytest:
 
 xenialtest:
   image: stackstorm/packagingtest:xenial-systemd
+  privileged: true
+  extends:
+    file: docker-compose.override.yml
+    service: volumes-compose
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+bionictest:
+  image: stackstorm/packagingtest:bionic-systemd
   privileged: true
   extends:
     file: docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,10 @@ bionicbuild:
   extends:
     file: docker-compose.override.yml
     service: volumes-compose
+  environment:
+    # (StackStorm components) and Python 2 (Mistral)
+    # Bionic will be first release without a Mistral
+    - ST2_PACKAGES=st2
 
 centos6build:
   image: stackstorm/packagingbuild:centos6
@@ -135,6 +139,10 @@ bionictest:
     service: volumes-compose
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  environment:
+    # (StackStorm components) and Python 2 (Mistral)
+    # Bionic will be first release without a Mistral
+    - ST2_PACKAGES=st2
 
 centos6test:
   image: stackstorm/packagingtest:centos6-sshd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ bionic:
     # NOTE: We don't build st2mistral package so we don't mix Python 3
     # (StackStorm components) and Python 2 (Mistral)
     # Bionic will be first release without a Mistral
+    - ST2_GITREV=fix_py3_issues
     - ST2_PACKAGES=st2
   links:
     - bionicbuild

--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -7,16 +7,11 @@ RUNNERS := $(shell ls ../contrib/runners)
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1
-	#DEB_EPOCH := $(shell echo $(ST2PKG_VERSION) | grep -q dev || echo '1')
+	DEB_EPOCH := $(shell echo $(ST2PKG_VERSION) | grep -q dev || echo '1')
+	DEB_DISTRO := $(shell lsb_release -cs)
 else
 	REDHAT := 1
-endif
-
-# Only useful for debian builds
-ifeq ($(DEB_EPOCH),)
 	DEB_DISTRO := unstable
-else
-	DEB_DISTRO := $(shell lsb_release -cs)
 endif
 
 ifneq (,$(wildcard /usr/share/python/st2python/bin/python))
@@ -39,7 +34,7 @@ ST2PKG_NORMALIZED_VERSION ?= $(shell $(PYTHON_BINARY) setup.py --version || echo
 retry = $(2) $(foreach t,$(shell seq 1 ${1}),|| (echo -e "\033[33m Failed ($$?): '$(2)'\n Retrying $t ... \033[0m"; $(2)))
 
 .PHONY: all install wheelhouse
-all: install
+all: info install
 
 .PHONY: info
 info:

--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -4,10 +4,13 @@ ST2PKG_RELEASE ?= 1
 ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
 CHANGELOG_COMMENT ?= "automated build, version: $(ST2PKG_VERSION)"
 RUNNERS := $(shell ls ../contrib/runners)
+DEB_DISTRO := $(shell lsb_release -cs)
 
 ifneq (,$(wildcard /usr/share/python/st2python/bin/python))
 	PATH := /usr/share/python/st2python/bin:$(PATH)
 	PYTHON_BINARY := /usr/share/python/st2python/bin/python
+else ifeq ($(DEB_DISTRO),bionic)
+	PYTHON_BINARY := /usr/bin/python3
 else
 	PYTHON_BINARY := python
 endif
@@ -38,6 +41,13 @@ retry = $(2) $(foreach t,$(shell seq 1 ${1}),|| (echo -e "\033[33m Failed ($$?):
 
 .PHONY: all install wheelhouse
 all: install
+
+.PHONY: info
+info:
+	@echo "DEBIAN=$(DEBIAN)"
+	@echo "REDHAT=$(REDHAT)"
+	@echo "DEB_DISTRO=$(DEB_DISTRO)"
+	@echo "PYTHON_BINARY=$(PYTHON_BINARY)"
 
 install: wheelhouse changelog
 

--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -100,7 +100,7 @@ populate_version: .stamp-populate_version
 	touch $@
 
 requirements:
-	python ../scripts/fixate-requirements.py -s ../st2*/in-requirements.txt ../contrib/runners/*/in-requirements.txt -f ../fixed-requirements.txt
+	$(PYTHON_BINARY) ../scripts/fixate-requirements.py -s ../st2*/in-requirements.txt ../contrib/runners/*/in-requirements.txt -f ../fixed-requirements.txt
 	cat requirements.txt
 
 changelog: populate_version

--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -4,21 +4,6 @@ ST2PKG_RELEASE ?= 1
 ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
 CHANGELOG_COMMENT ?= "automated build, version: $(ST2PKG_VERSION)"
 RUNNERS := $(shell ls ../contrib/runners)
-DEB_DISTRO := $(shell lsb_release -cs)
-
-ifneq (,$(wildcard /usr/share/python/st2python/bin/python))
-	PATH := /usr/share/python/st2python/bin:$(PATH)
-	PYTHON_BINARY := /usr/share/python/st2python/bin/python
-else ifeq ($(DEB_DISTRO),bionic)
-	PYTHON_BINARY := /usr/bin/python3
-else
-	PYTHON_BINARY := python
-endif
-
-# Note: We dynamically obtain the version, this is required because dev
-# build versions don't store correct version identifier in __init__.py
-# and we need setup.py to normalize it (e.g. 1.4dev -> 1.4.dev0)
-ST2PKG_NORMALIZED_VERSION ?= $(shell $(PYTHON_BINARY) setup.py --version || echo "failed_to_retrieve_version")
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1
@@ -33,6 +18,20 @@ ifeq ($(DEB_EPOCH),)
 else
 	DEB_DISTRO := $(shell lsb_release -cs)
 endif
+
+ifneq (,$(wildcard /usr/share/python/st2python/bin/python))
+	PATH := /usr/share/python/st2python/bin:$(PATH)
+	PYTHON_BINARY := /usr/share/python/st2python/bin/python
+else ifeq ($(DEB_DISTRO),bionic)
+	PYTHON_BINARY := /usr/bin/python3
+else
+	PYTHON_BINARY := python
+endif
+
+# Note: We dynamically obtain the version, this is required because dev
+# build versions don't store correct version identifier in __init__.py
+# and we need setup.py to normalize it (e.g. 1.4dev -> 1.4.dev0)
+ST2PKG_NORMALIZED_VERSION ?= $(shell $(PYTHON_BINARY) setup.py --version || echo "failed_to_retrieve_version")
 
 # Makefile function to retry the failed command 'N' times
 # Make sure you use it for nothing but networking stuff (think about race conditons)

--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -7,7 +7,7 @@ RUNNERS := $(shell ls ../contrib/runners)
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1
-	DEB_EPOCH := $(shell echo $(ST2PKG_VERSION) | grep -q dev || echo '1')
+	#DEB_EPOCH := $(shell echo $(ST2PKG_VERSION) | grep -q dev || echo '1')
 	DEB_DISTRO := $(shell lsb_release -cs)
 else
 	REDHAT := 1

--- a/packages/st2/component.makefile
+++ b/packages/st2/component.makefile
@@ -35,6 +35,7 @@ info:
 	@echo "REDHAT=$(REDHAT)"
 	@echo "DEB_DISTRO=$(DEB_DISTRO)"
 	@echo "PYTHON_BINARY=$(PYTHON_BINARY)"
+	@echo "PIP_BINARY=$(PIP_BINARY)"
 
 .PHONY: populate_version requirements wheelhouse bdist_wheel
 all: info populate_version requirements bdist_wheel

--- a/packages/st2/debian/control
+++ b/packages/st2/debian/control
@@ -3,7 +3,7 @@ Section: Python
 Priority: optional
 Maintainer: StackStorm Engineering <opsadmin@stackstorm.com>
 Build-Depends: debhelper (>= 9),
-               ${build:Depends}
+               python,
                dh-virtualenv (>= 0.8),
 Standards-Version: 3.9.5
 Homepage: http://stackstorm.com/

--- a/packages/st2/debian/control
+++ b/packages/st2/debian/control
@@ -3,8 +3,8 @@ Section: Python
 Priority: optional
 Maintainer: StackStorm Engineering <opsadmin@stackstorm.com>
 Build-Depends: debhelper (>= 9),
-               python,
-               dh-virtualenv (>= 0.8)
+               ${build:Depends}
+               dh-virtualenv (>= 0.8),
 Standards-Version: 3.9.5
 Homepage: http://stackstorm.com/
 Vcs-Git: git://github.com/stackstorm/st2.git
@@ -12,8 +12,8 @@ Vcs-Browser: https://github.com/stackstorm/st2
 
 Package: st2
 Architecture: any
-Pre-Depends: dpkg (>= 1.16.16), python2.7, ${misc:Pre-Depends}, adduser
-Depends: ${shlibs:Depends}, ${misc:Depends}, sudo, adduser, libpython-dev | python-dev, libssl-dev, libffi-dev, git, libpam0g, openssh-server, openssh-client, bash, netbase
+Pre-Depends: dpkg (>= 1.16.16), ${pre:Depends}, adduser
+Depends: ${shlibs:Depends}, ${misc:Depends}, sudo, adduser, ${Depends}, libssl-dev, libffi-dev, git, libpam0g, openssh-server, openssh-client, bash, netbase
 Conflicts: st2common
 Description: StackStorm Event-driven automation
  Package is full standalone st2 installation including

--- a/packages/st2/debian/control
+++ b/packages/st2/debian/control
@@ -12,7 +12,7 @@ Vcs-Browser: https://github.com/stackstorm/st2
 
 Package: st2
 Architecture: any
-Pre-Depends: dpkg (>= 1.16.16), ${pre:Depends}, adduser
+Pre-Depends: dpkg (>= 1.16.16), ${pre:Depends}, ${misc:Pre-Depends}, adduser
 Depends: ${shlibs:Depends}, ${misc:Depends}, sudo, adduser, ${Depends}, libssl-dev, libffi-dev, git, libpam0g, openssh-server, openssh-client, bash, netbase
 Conflicts: st2common
 Description: StackStorm Event-driven automation

--- a/packages/st2/debian/rules
+++ b/packages/st2/debian/rules
@@ -16,19 +16,13 @@ IS_SYSTEMD = $(shell command -v dh_systemd_enable > /dev/null 2>&1 && echo true)
 DEB_DISTRO := $(shell lsb_release -cs)
 
 # Trusty, Xenial and Bionic depend on different libraries.
-# Most important, Bionic uses Python 3 and others use Python 2.7
-BIONIC_PRE_DEPENDS := python3 (>= 3.6)
-BIONIC_DEPENDS := python3-distutils, python3-dev
-
-OTHER_PRE_DEPENDS := python2.7
-OTHER_DEPENDS = libpython-dev | python-dev
-
+# Most important, Bionic uses Python 3 and others use Python 2.7.
 ifeq ($(DEB_DISTRO),bionic)
-	BUILD_PRE_DEPENDS := $(BIONIC_PRE_DEPENDS)
-	BUILD_DEPENDS := $(BIONIC_DEPENDS)
+	BUILD_PRE_DEPENDS := python3 (>= 3.6)
+	BUILD_DEPENDS := python3-distutils, python3-dev
 else
-	BUILD_PRE_DEPENDS := $(OTHER_PRE_DEPENDS)
-	BUILD_DEPENDS := $(OTHER_DEPENDS)
+	BUILD_PRE_DEPENDS := python2.7
+	BUILD_DEPENDS := libpython-dev | python-dev
 endif
 
 %:

--- a/packages/st2/debian/rules
+++ b/packages/st2/debian/rules
@@ -16,8 +16,7 @@ IS_SYSTEMD = $(shell command -v dh_systemd_enable > /dev/null 2>&1 && echo true)
 DEB_DISTRO := $(shell lsb_release -cs)
 
 %:
-%:
-	# Use Python 3 binary on Ubuntu Bionic
+# Use Python 3 binary on Ubuntu Bionic
 ifeq ($(DEB_DISTRO),bionic)
 	dh $@ --with python-virtualenv --python /usr/bin/python3
 else

--- a/packages/st2/debian/rules
+++ b/packages/st2/debian/rules
@@ -13,9 +13,16 @@ DH_VIRTUALENV_INSTALL_ROOT := /opt/stackstorm
 export DH_VIRTUALENV_INSTALL_ROOT
 
 IS_SYSTEMD = $(shell command -v dh_systemd_enable > /dev/null 2>&1 && echo true)
+DEB_DISTRO := $(shell lsb_release -cs)
 
 %:
+%:
+	# Use Python 3 binary on Ubuntu Bionic
+ifeq ($(DEB_DISTRO),bionic)
+	dh $@ --with python-virtualenv --python /usr/bin/python3
+else
 	dh $@ --with python-virtualenv
+endif
 
 override_dh_installdirs:
 	dh_installdirs

--- a/packages/st2/debian/rules
+++ b/packages/st2/debian/rules
@@ -29,6 +29,19 @@ override_dh_installdirs:
 	# dh_auto_install same with:
 	$(MAKE) install
 
+ifeq ($(DEB_DISTRO),bionic)
+	SUBSTVARS = -Vpre:Depends="python3 (>= 3.6)"
+	SUBSTVARS = -Vbuild:Depends="python3 (>= 3.6)"
+	SUBSTVARS = -VDepends="python3-distutils python3-dev"
+else
+	SUBSTVARS = -Vpre:Depends="python2.7"
+	SUBSTVARS = -Vbuild:VDepends="python2.7"
+	SUBSTVARS = -VDepends="libpython-dev | python-dev"
+endif
+
+override_dh_gencontrol:
+	dh_gencontrol -- $(SUBSTVARS)
+
 # Packaging recognizes only 1 {package_name} service file (http://manpages.ubuntu.com/manpages/trusty/man1/dh_installinit.1.html)
 # We have many, and so force it to install multiple service files
 override_dh_installinit:

--- a/packages/st2/debian/rules
+++ b/packages/st2/debian/rules
@@ -15,6 +15,22 @@ export DH_VIRTUALENV_INSTALL_ROOT
 IS_SYSTEMD = $(shell command -v dh_systemd_enable > /dev/null 2>&1 && echo true)
 DEB_DISTRO := $(shell lsb_release -cs)
 
+# Trusty, Xenial and Bionic depend on different libraries.
+# Most important, Bionic uses Python 3 and others use Python 2.7
+BIONIC_PRE_DEPENDS := python3 (>= 3.6)
+BIONIC_DEPENDS := python3-distutils, python3-dev
+
+OTHER_PRE_DEPENDS := python2.7
+OTHER_DEPENDS = libpython-dev | python-dev
+
+ifeq ($(DEB_DISTRO),bionic)
+	BUILD_PRE_DEPENDS := $(BIONIC_PRE_DEPENDS)
+	BUILD_DEPENDS := $(BIONIC_DEPENDS)
+else
+	BUILD_PRE_DEPENDS := $(OTHER_PRE_DEPENDS)
+	BUILD_DEPENDS := $(OTHER_DEPENDS)
+endif
+
 %:
 # Use Python 3 binary on Ubuntu Bionic
 ifeq ($(DEB_DISTRO),bionic)
@@ -29,16 +45,8 @@ override_dh_installdirs:
 	# dh_auto_install same with:
 	$(MAKE) install
 
-ifeq ($(DEB_DISTRO),bionic)
-	SUBSTVARS = -Vpre:Depends="python3 (>= 3.6)"
-	SUBSTVARS = -VDepends="python3-distutils python3-dev"
-else
-	SUBSTVARS = -Vpre:Depends="python2.7"
-	SUBSTVARS = -VDepends="libpython-dev | python-dev"
-endif
-
 override_dh_gencontrol:
-	dh_gencontrol -- $(SUBSTVARS)
+	dh_gencontrol -- -Vpre:Depends="$(BUILD_PRE_DEPENDS)" -VDepends="$(BUILD_DEPENDS)"
 
 # Packaging recognizes only 1 {package_name} service file (http://manpages.ubuntu.com/manpages/trusty/man1/dh_installinit.1.html)
 # We have many, and so force it to install multiple service files

--- a/packages/st2/debian/rules
+++ b/packages/st2/debian/rules
@@ -31,11 +31,9 @@ override_dh_installdirs:
 
 ifeq ($(DEB_DISTRO),bionic)
 	SUBSTVARS = -Vpre:Depends="python3 (>= 3.6)"
-	SUBSTVARS = -Vbuild:Depends="python3 (>= 3.6)"
 	SUBSTVARS = -VDepends="python3-distutils python3-dev"
 else
 	SUBSTVARS = -Vpre:Depends="python2.7"
-	SUBSTVARS = -Vbuild:VDepends="python2.7"
 	SUBSTVARS = -VDepends="libpython-dev | python-dev"
 endif
 

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -30,7 +30,7 @@ function configure_proxy() {
 function get_package_url() {
   # Retrieve direct package URL for the provided dev build, subtype and package name regex.
   DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
-  DISTRO=$2  # Distro name (e.g. trusty,xenial,el6,el7)
+  DISTRO=$2  # Distro name (e.g. trusty,xenial,bionic,el6,el7)
   PACKAGE_NAME_REGEX=$3
 
   PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)

--- a/scripts/setup-vagrant.sh
+++ b/scripts/setup-vagrant.sh
@@ -12,7 +12,7 @@ case $ST2_TARGET in
   "el7")
     DC_TARGET=centos7
     INSTALL_CMD="yum";;
-  "trusty"|"xenial")
+  "trusty"|"xenial"|"bionic")
     DC_TARGET=$ST2_TARGET
     INSTALL_CMD="apt-get";;
   *)

--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -163,8 +163,8 @@ elif [[ -n "$DEBTEST" ]]; then
   echo "*** Detected Distro is ${DEBTEST} ***"
   SUBTYPE=`lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}'`
   echo "*** Detected flavor ${SUBTYPE} ***"
-  if [[ "$SUBTYPE" != 'trusty' && "$SUBTYPE" != 'xenial' ]]; then
-    echo "Unsupported ubuntu flavor ${SUBTYPE}. Please use 14.04 (trusty) or 16.04 (xenial) as base system!"
+  if [[ "$SUBTYPE" != 'trusty' && "$SUBTYPE" != 'xenial' && "$SUBTYPE" != 'bionic' ]]; then
+    echo "Unsupported ubuntu flavor ${SUBTYPE}. Please use 14.04 (trusty), 16.04 (xenial) or 18.04 (bionic) as base system!"
     exit 2
   fi
   ST2BOOTSTRAP="${BASE_PATH}/${BRANCH}/scripts/st2bootstrap-deb.sh"

--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -186,7 +186,7 @@ else
     chmod +x ${BOOTSTRAP_FILE}
 
     echo "Running deployment script for st2 ${VERSION}..."
-    echo "OS specific script cmd: bash ${BOOTSTRAP_FILE} ${VERSION} ${RELEASE} ${REPO_TYPE} ${USERNAME} --password=****"
+    echo "OS specific script cmd: bash ${BOOTSTRAP_FILE} ${VERSION} ${RELEASE} ${REPO_TYPE} ${DEV_BUILD} ${USERNAME} --password=****"
     TS=$(date +%Y%m%dT%H%M%S)
     sudo mkdir -p /var/log/st2
     bash ${BOOTSTRAP_FILE} ${VERSION} ${RELEASE} ${REPO_TYPE} ${DEV_BUILD} ${USERNAME} ${PASSWORD} 2>&1 | adddate | sudo tee /var/log/st2/st2-install.${TS}.log

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -84,7 +84,7 @@ setup_args() {
   fi
 
   # Right now Bionic is not officially supported yet so we only support using staging unstable packages
-  if [[ "$SUBTYPE" == 'bionic' && "${REPO_TYPE}" != "staging"]]; then
+  if [[ "$SUBTYPE" == 'bionic' ]] && [[ "${REPO_TYPE}" != "staging" ]]; then
     if [[ "${RELEASE}" != "unstable" ]]; then
       echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
       exit 2

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -83,8 +83,13 @@ setup_args() {
     fi
   fi
 
-  # Right now Bionic is not officially supported yet so we only support using staging unstable packages
-  if [[ "$SUBTYPE" == 'bionic' ]] && [[ "${REPO_TYPE}" != "staging" ]]; then
+   # Right now Bionic is not officially supported yet so we only support using staging unstable packages
+  if [[ "$SUBTYPE" == 'bionic' ]] && [[ "${DEV_BUILD}" = "" ]]; then
+    if [[ "${REPO_TYPE}" != "staging" ]]; then
+      echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
+      exit 2
+    fi
+
     if [[ "${RELEASE}" != "unstable" ]]; then
       echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
       exit 2
@@ -431,7 +436,10 @@ install_st2_dependencies() {
   sudo apt-get update
 
   # Note: gnupg-curl is needed to be able to use https transport when fetching keys
-  sudo apt-get install -y gnupg-curl
+  if [[ "$SUBTYPE" != 'bionic' ]]; then
+    sudo apt-get install -y gnupg-curl
+  fi
+
   sudo apt-get install -y curl
   sudo apt-get install -y rabbitmq-server
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -440,6 +440,11 @@ install_st2_dependencies() {
     sudo apt-get install -y gnupg-curl
   fi
 
+  # python3-distutils is needed on Bionic
+  if [[ "$SUBTYPE" == 'bionic' ]]; then
+    sudo apt-get install -y python3-distutils
+  fi
+
   sudo apt-get install -y curl
   sudo apt-get install -y rabbitmq-server
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -440,11 +440,6 @@ install_st2_dependencies() {
     sudo apt-get install -y gnupg-curl
   fi
 
-  # python3-distutils is needed on Bionic
-  if [[ "$SUBTYPE" == 'bionic' ]]; then
-    sudo apt-get install -y python3-distutils
-  fi
-
   sudo apt-get install -y curl
   sudo apt-get install -y rabbitmq-server
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -22,8 +22,9 @@ DEV_BUILD=''
 USERNAME=''
 PASSWORD=''
 SUBTYPE=`lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}'`
-if [[ "$SUBTYPE" != 'trusty' && "$SUBTYPE" != 'xenial' ]]; then
-  echo "Unsupported ubuntu flavor ${SUBTYPE}. Please use 14.04 (trusty) or 16.04 (xenial) as base system!"
+
+if [[ "$SUBTYPE" != 'trusty' && "$SUBTYPE" != 'xenial' && "$SUBTYPE" != 'bionic' ]]; then
+  echo "Unsupported ubuntu flavor ${SUBTYPE}. Please use 14.04 (trusty), 16.04 (xenial) or Ubuntu 18.04 (bionic) as base system!"
   exit 2
 fi
 
@@ -79,6 +80,14 @@ setup_args() {
     if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+dev$ ]]; then
      echo "You're requesting a dev version! Switching to unstable!"
      RELEASE='unstable'
+    fi
+  fi
+
+  # Right now Bionic is not officially supported yet so we only support using staging unstable packages
+  if [[ "$SUBTYPE" == 'bionic' && "${REPO_TYPE}" != "staging"]]; then
+    if [[ "${RELEASE}" != "unstable" ]]; then
+      echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
+      exit 2
     fi
   fi
 
@@ -147,7 +156,7 @@ function configure_proxy() {
 function get_package_url() {
   # Retrieve direct package URL for the provided dev build, subtype and package name regex.
   DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
-  DISTRO=$2  # Distro name (e.g. trusty,xenial,el6,el7)
+  DISTRO=$2  # Distro name (e.g. trusty,xenial,bionic,el6,el7)
   PACKAGE_NAME_REGEX=$3
 
   PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)
@@ -429,7 +438,7 @@ install_st2_dependencies() {
   # Configure RabbitMQ to listen on localhost only
   sudo sh -c 'echo "RABBITMQ_NODE_IP_ADDRESS=127.0.0.1" >> /etc/rabbitmq/rabbitmq-env.conf'
 
-  if [[ "$SUBTYPE" == 'xenial' ]]; then
+  if [[ "$SUBTYPE" == 'xenial' || "${SUBTYPE}" == "bionic" ]]; then
     sudo systemctl restart rabbitmq-server
   else
     sudo service rabbitmq-server restart
@@ -441,8 +450,14 @@ install_st2_dependencies() {
 
 install_mongodb() {
   # Add key and repo for the latest stable MongoDB (3.4)
-  wget -qO - https://www.mongodb.org/static/pgp/server-3.4.asc | sudo apt-key add -
-  echo "deb http://repo.mongodb.org/apt/ubuntu ${SUBTYPE}/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+  # TODO: Install MongoDB 4.0 on Bionic
+  if [[ "$SUBTYPE" == 'bionic' ]]; then
+    wget -qO - https://www.mongodb.org/static/pgp/server-4.0.asc | sudo apt-key add -
+    echo "deb http://repo.mongodb.org/apt/ubuntu ${SUBTYPE}/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
+  else
+    wget -qO - https://www.mongodb.org/static/pgp/server-3.4.asc | sudo apt-key add -
+    echo "deb http://repo.mongodb.org/apt/ubuntu ${SUBTYPE}/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+  fi
 
   sudo apt-get update
   sudo apt-get install -y mongodb-org
@@ -450,7 +465,7 @@ install_mongodb() {
   # Configure MongoDB to listen on localhost only
   sudo sed -i -e "s#bindIp:.*#bindIp: 127.0.0.1#g" /etc/mongod.conf
 
-  if [[ "$SUBTYPE" == 'xenial' ]]; then
+  if [[ "$SUBTYPE" == 'xenial' || "${SUBTYPE}" == "bionic" ]]; then
     sudo systemctl enable mongod
     sudo systemctl start mongod
   else
@@ -488,7 +503,7 @@ EOF
   sudo sh -c 'echo "security:\n  authorization: enabled" >> /etc/mongod.conf'
 
   # MongoDB needs to be restarted after enabling auth
-  if [[ "$SUBTYPE" == 'xenial' ]]; then
+  if [[ "$SUBTYPE" == 'xenial'  || "${SUBTYPE}" == "bionic" ]]; then
     sudo systemctl restart mongod
   else
     sudo service mongod restart
@@ -711,8 +726,10 @@ STEP="Configure st2 CLI config" && configure_st2_cli_config
 STEP="Generate symmetric crypto key for datastore" && generate_symmetric_crypto_key_for_datastore
 STEP="Verify st2" && verify_st2
 
-STEP="Install mistral dependencies" && install_st2mistral_dependencies
-STEP="Install mistral" && install_st2mistral
+if [[ "${SUBTYPE}" != "bionic" ]]; then
+    STEP="Install mistral dependencies" && install_st2mistral_dependencies
+    STEP="Install mistral" && install_st2mistral
+fi
 
 STEP="Install st2web" && install_st2web
 

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -418,8 +418,10 @@ STEP="Configure st2 CLI config" && configure_st2_cli_config
 STEP="Generate symmetric crypto key for datastore" && generate_symmetric_crypto_key_for_datastore
 STEP="Verify st2" && verify_st2
 
-STEP="Install mistral dependencies" && install_st2mistral_dependencies
-STEP="Install mistral" && install_st2mistral
+if [[ "${SUBTYPE}" != "bionic" ]]; then
+    STEP="Install mistral dependencies" && install_st2mistral_dependencies
+    STEP="Install mistral" && install_st2mistral
+fi
 
 STEP="Install st2web" && install_st2web
 

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -75,8 +75,13 @@ setup_args() {
     fi
   fi
 
-  # Right now Bionic is not officially supported yet so we only support using staging unstable packages
-  if [[ "$SUBTYPE" == 'bionic' ]] && [[ "${REPO_TYPE}" != "staging" ]]; then
+   # Right now Bionic is not officially supported yet so we only support using staging unstable packages
+  if [[ "$SUBTYPE" == 'bionic' ]] && [[ "${DEV_BUILD}" = "" ]]; then
+    if [[ "${REPO_TYPE}" != "staging" ]]; then
+      echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
+      exit 2
+    fi
+
     if [[ "${RELEASE}" != "unstable" ]]; then
       echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
       exit 2

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -76,7 +76,7 @@ setup_args() {
   fi
 
   # Right now Bionic is not officially supported yet so we only support using staging unstable packages
-  if [[ "$SUBTYPE" == 'bionic' && "${REPO_TYPE}" != "staging"]]; then
+  if [[ "$SUBTYPE" == 'bionic' ]] && [[ "${REPO_TYPE}" != "staging" ]]; then
     if [[ "${RELEASE}" != "unstable" ]]; then
       echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
       exit 2

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -132,11 +132,6 @@ install_st2_dependencies() {
     sudo apt-get install -y gnupg-curl
   fi
 
-  # python3-distutils is needed on Bionic
-  if [[ "$SUBTYPE" == 'bionic' ]]; then
-    sudo apt-get install -y python3-distutils
-  fi
-
   sudo apt-get install -y curl
   sudo apt-get install -y rabbitmq-server
 

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -128,7 +128,10 @@ install_st2_dependencies() {
   sudo apt-get update
 
   # Note: gnupg-curl is needed to be able to use https transport when fetching keys
-  sudo apt-get install -y gnupg-curl
+  if [[ "$SUBTYPE" != 'bionic' ]]; then
+    sudo apt-get install -y gnupg-curl
+  fi
+
   sudo apt-get install -y curl
   sudo apt-get install -y rabbitmq-server
 

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -132,6 +132,11 @@ install_st2_dependencies() {
     sudo apt-get install -y gnupg-curl
   fi
 
+  # python3-distutils is needed on Bionic
+  if [[ "$SUBTYPE" == 'bionic' ]]; then
+    sudo apt-get install -y python3-distutils
+  fi
+
   sudo apt-get install -y curl
   sudo apt-get install -y rabbitmq-server
 

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -143,8 +143,13 @@ install_st2_dependencies() {
 install_mongodb() {
   # Add key and repo for the latest stable MongoDB (3.4)
   # TODO: Install MongoDB 4.0 on Bionic
-  wget -qO - https://www.mongodb.org/static/pgp/server-3.4.asc | sudo apt-key add -
-  echo "deb http://repo.mongodb.org/apt/ubuntu ${SUBTYPE}/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+  if [[ "$SUBTYPE" == 'bionic' ]]; then
+    wget -qO - https://www.mongodb.org/static/pgp/server-4.0.asc | sudo apt-key add -
+    echo "deb http://repo.mongodb.org/apt/ubuntu ${SUBTYPE}/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
+  else
+    wget -qO - https://www.mongodb.org/static/pgp/server-3.4.asc | sudo apt-key add -
+    echo "deb http://repo.mongodb.org/apt/ubuntu ${SUBTYPE}/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+  fi
 
   sudo apt-get update
   sudo apt-get install -y mongodb-org

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -142,7 +142,7 @@ function configure_proxy() {
 function get_package_url() {
   # Retrieve direct package URL for the provided dev build, subtype and package name regex.
   DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
-  DISTRO=$2  # Distro name (e.g. trusty,xenial,el6,el7)
+  DISTRO=$2  # Distro name (e.g. trusty,xenial,bionic,el6,el7)
   PACKAGE_NAME_REGEX=$3
 
   PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -142,7 +142,7 @@ function configure_proxy() {
 function get_package_url() {
   # Retrieve direct package URL for the provided dev build, subtype and package name regex.
   DEV_BUILD=$1 # Repo name and build number - <repo name>/<build_num> (e.g. st2/5646)
-  DISTRO=$2  # Distro name (e.g. trusty,xenial,el6,el7)
+  DISTRO=$2  # Distro name (e.g. trusty,xenial,bionic,el6,el7)
   PACKAGE_NAME_REGEX=$3
 
   PACKAGES_METADATA=$(curl -Ss -q https://circleci.com/api/v1.1/project/github/StackStorm/${DEV_BUILD}/artifacts)


### PR DESCRIPTION
This pull request add support for building StackStorm packages for Ubuntu Bionic using Python 3.

## Depends on

* https://github.com/StackStorm/st2packaging-dockerfiles/pull/69

## Related PRs

* https://github.com/StackStorm/st2web/pull/624
* https://github.com/StackStorm/st2chatops/pull/117
* https://github.com/StackStorm/bwc-enterprise-packages/pull/26

## TODO

- [x] New dh virtualenv debian rule for Bionic which uses python 3 binary
- [x] Support for Bionic in installer script (only for staging unstable until it's officially supported)