### PR TITLE
Add support for Ubuntu Bionic to packagecloud.sh

### DIFF
--- a/.circle/packagecloud.sh
+++ b/.circle/packagecloud.sh
@@ -122,7 +122,7 @@ function deploy() {
 
     # NOTE: At the moment we only support staging unstable Bionic packages
     if [ "${PKG_OS}" = "bionic" ]; then
-      if [ "${PACKAGECLOUD_REPO}" != "staging-unstable"]; then
+      if [ "${PACKAGECLOUD_REPO}" != "staging-unstable" ]; then
         echo "Skipping upload for ${PKG_OS} packages, right now it's only enabled for staging unstable."
         continue
       fi

--- a/.circle/packagecloud.sh
+++ b/.circle/packagecloud.sh
@@ -37,8 +37,8 @@ function main() {
       fi
       ;;
     *)
-      echo $"Usage: deploy {trusty|xenial|el6|el7} /tmp/st2-packages"
-      echo $"Usage: next-revision {trusty|xenial|el6|el7} 0.14dev st2"
+      echo $"Usage: deploy {trusty|xenial|bionic|el6|el7} /tmp/st2-packages"
+      echo $"Usage: next-revision {trusty|xenial|bionic|el6|el7} 0.14dev st2"
       exit 1
   esac
 }
@@ -118,6 +118,14 @@ function deploy() {
     if [ -z "$PKG_NAME" ] || [ -z "$PKG_VERSION" ] || [ -z "$PKG_RELEASE" ]; then
      echo "$PKG_PATH doesn't look like package, skipping..."
      continue
+    fi
+
+    # NOTE: At the moment we only support staging unstable Bionic packages
+    if [ "${PKG_OS}" = "bionic" ]; then
+      if [ "${PACKAGECLOUD_REPO}" != "staging-unstable"]; then
+        echo "Skipping upload for ${PKG_OS} packages, right now it's only enabled for staging unstable."
+        continue
+      fi
     fi
 
     debug "PACKAGECLOUD_ORGANIZATION:  ${PACKAGECLOUD_ORGANIZATION}"
@@ -230,7 +238,7 @@ function get_pkg_os() {
       PKG_OS_VERSION=$PKG_OS
       PKG_TYPE="deb"
       ;;
-    warty|hoary|breezy|dapper|edgy|feisty|gutsy|hardy|intrepid|jaunty|karmic|lucid|maverick|natty|oneiric|precise|quantal|raring|saucy|trusty|utopic|vivid|wily|xenial)
+    warty|hoary|breezy|dapper|edgy|feisty|gutsy|hardy|intrepid|jaunty|karmic|lucid|maverick|natty|oneiric|precise|quantal|raring|saucy|trusty|utopic|vivid|wily|xenial|bionic)
       PKG_OS_NAME=ubuntu
       PKG_OS_VERSION=$PKG_OS
       PKG_TYPE="deb"


### PR DESCRIPTION
This pull request adds support for Ubuntu Bionic to packagecloud.sh script.

We need to merge that PR before we can merge other PRs in st2web, st2chatops, etc. to avoid chicken and the egg problem.

Cherry picked from https://github.com/StackStorm/st2-packages/pull/590.