### PR TITLE
Fixed #594 where st2 package failed to uninstall

### DIFF
--- a/packages/st2/rpm/st2.spec
+++ b/packages/st2/rpm/st2.spec
@@ -58,12 +58,12 @@ Conflicts: st2common
 %preun
   %service_preun st2actionrunner %{worker_name} st2api st2stream st2auth st2notifier st2workflowengine
   %service_preun st2resultstracker st2rulesengine st2timersengine st2sensorcontainer st2garbagecollector
-  %service_prerun st2scheduler
+  %service_preun st2scheduler
 
 %postun
   %service_postun st2actionrunner %{worker_name} st2api st2stream st2auth st2notifier st2workflowengine
   %service_postun st2resultstracker st2rulesengine st2timersengine st2sensorcontainer st2garbagecollector
-  %service_postrun st2scheduler
+  %service_postun st2scheduler
   # Remove st2 logrotate config, since there's no analog of apt-get purge available
   if [ $1 -eq 0 ]; then
     [ ! -f /etc/logrotate.d/st2 ] || rm /etc/logrotate.d/st2


### PR DESCRIPTION
Closes #594 

Fixes mis-spelling from `service_prerun` -> `service_preun` and `service_postrun` -> `service_postun`