### PR TITLE
Remove deprecated CloudSlang and Windows runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       # with real gitrevs during releases. Note that they are commented out, so that they do not interfere
       # with build parameters. st2cd prep tasks will uncomment these on a branch, and replace with proper
       # gitrefs.
-      ST2_GITREV: "remove_obsolete_runners_v310"
+      # ST2_GITREV: ""
       # ST2MISTRAL_GITREV: ""
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       # with real gitrevs during releases. Note that they are commented out, so that they do not interfere
       # with build parameters. st2cd prep tasks will uncomment these on a branch, and replace with proper
       # gitrefs.
-      # ST2_GITREV: ""
+      ST2_GITREV: "remove_windows_and_cloudslang_runner"
       # ST2MISTRAL_GITREV: ""
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       # with real gitrevs during releases. Note that they are commented out, so that they do not interfere
       # with build parameters. st2cd prep tasks will uncomment these on a branch, and replace with proper
       # gitrefs.
-      ST2_GITREV: "remove_windows_and_cloudslang_runner"
+      ST2_GITREV: "remove_obsolete_runners_v310"
       # ST2MISTRAL_GITREV: ""
     steps:
       - checkout

--- a/packages/st2/in-requirements.txt
+++ b/packages/st2/in-requirements.txt
@@ -10,7 +10,6 @@ st2tests
 git+https://github.com/StackStorm/st2-auth-backend-pam.git@master#egg=st2-auth-backend-pam
 stackstorm-runner-action-chain
 stackstorm-runner-announcement
-stackstorm-runner-cloudslang
 stackstorm-runner-http
 stackstorm-runner-inquirer
 stackstorm-runner-local
@@ -19,5 +18,4 @@ stackstorm-runner-noop
 stackstorm-runner-orquesta
 stackstorm-runner-python
 stackstorm-runner-remote
-stackstorm-runner-windows
 stackstorm-runner-winrm


### PR DESCRIPTION
Part of https://github.com/StackStorm/st2/pull/4465 change.