### PR TITLE
Fix --version installer script argument on Ubuntu Bionic

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -529,11 +529,17 @@ get_full_pkg_versions() {
       exit 3
     fi
 
-    local ST2MISTRAL_VER=$(apt-cache show st2mistral | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2MISTRAL_VER" ]; then
-      echo "Could not find requested version of st2mistral!!!"
-      sudo apt-cache policy st2mistral
-      exit 3
+    if [[ "$SUBTYPE" != 'bionic' ]]; then
+        # Bionic doesn't support Mistral
+        local ST2MISTRAL_VER=$(apt-cache show st2mistral | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)
+
+        if [ -z "$ST2MISTRAL_VER" ]; then
+          echo "Could not find requested version of st2mistral!!!"
+          sudo apt-cache policy st2mistral
+          exit 3
+        fi
+     else
+        local ST2MISTRAL_VER="none"
     fi
 
     local ST2WEB_VER=$(apt-cache show st2web | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -221,11 +221,17 @@ get_full_pkg_versions() {
       exit 3
     fi
 
-    local ST2MISTRAL_VER=$(apt-cache show st2mistral | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2MISTRAL_VER" ]; then
-      echo "Could not find requested version of st2mistral!!!"
-      sudo apt-cache policy st2mistral
-      exit 3
+    if [[ "$SUBTYPE" != 'bionic' ]]; then
+        # Bionic doesn't support Mistral
+        local ST2MISTRAL_VER=$(apt-cache show st2mistral | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)
+
+        if [ -z "$ST2MISTRAL_VER" ]; then
+          echo "Could not find requested version of st2mistral!!!"
+          sudo apt-cache policy st2mistral
+          exit 3
+        fi
+     else
+        local ST2MISTRAL_VER="none"
     fi
 
     local ST2WEB_VER=$(apt-cache show st2web | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)


### PR DESCRIPTION
Ubuntu Bionic packages don't include and support Mistral so we should skip st2mistral package check when using ``--version`` installer script argument on Bionic (e.g. ``bash install.sh --user=st2admin --password=Ch@ngeMe --staging --unstable --version=2.10dev ``).