### PR TITLE
Pin python-senlinclient to workaround openstacksdk conflict

### DIFF
--- a/packages/st2mistral/Makefile
+++ b/packages/st2mistral/Makefile
@@ -81,6 +81,7 @@ inject-deps: .stamp-inject-deps
 	grep -q 'python-memcached' requirements.txt || echo "python-memcached" >> requirements.txt
 	sed -i "s/^oslo.messaging.*/oslo.messaging==5.24.2/g" requirements.txt
 	sed -i "s/^Babel.*/Babel>=2.3.4,!=2.4.0 # BSD/g" requirements.txt
+	sed -i "s/^python-senlinclient.*/python-senlinclient<1.10.0 # Apache-2.0/g" requirements.txt
 
 ifeq (,$(findstring dev,$(MISTRAL_VERSION)))
 	sed -i "s/^python-mistralclient.*/git+https:\/\/github.com\/StackStorm\/python-mistralclient.git@st2-$(MISTRAL_VERSION)\#egg=python-mistralclient/g" requirements.txt


### PR DESCRIPTION
The latest python-senlinclient version 1.10.0 requires openstacksdk 0.24.0. This is in conflict to the openstacksdk 0.21.0 that is currently specified. Updating openstacksdk will lead to other dependency conflicts.