### PR TITLE
Bumping postgres version to latest avaliable

### DIFF
--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -613,11 +613,11 @@ configure_st2_authentication() {
 
 install_st2mistral_dependencies() {
   if grep -q "CentOS" /etc/redhat-release; then
-      sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-2.noarch.rpm
+      sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-3.noarch.rpm
   fi
 
   if grep -q "Red Hat" /etc/redhat-release; then
-      sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-2.noarch.rpm
+      sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-3.noarch.rpm
   fi
 
   sudo yum -y install postgresql94-server postgresql94-contrib postgresql94-devel

--- a/scripts/st2bootstrap-el6.template.sh
+++ b/scripts/st2bootstrap-el6.template.sh
@@ -253,11 +253,11 @@ configure_st2_authentication() {
 
 install_st2mistral_dependencies() {
   if grep -q "CentOS" /etc/redhat-release; then
-      sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-2.noarch.rpm
+      sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-3.noarch.rpm
   fi
 
   if grep -q "Red Hat" /etc/redhat-release; then
-      sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-2.noarch.rpm
+      sudo yum -y localinstall http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-3.noarch.rpm
   fi
 
   sudo yum -y install postgresql94-server postgresql94-contrib postgresql94-devel


### PR DESCRIPTION
Previous EL version is no longer available. This PR bumps to latest patch available for our major.minor PG version.