### PR TITLE
Only call set_permissions at upgrade action

### DIFF
--- a/packages/st2/rpm/preinst_script.spec
+++ b/packages/st2/rpm/preinst_script.spec
@@ -54,6 +54,6 @@ set_permissions() {
 create_users
 
 # We perform upgrade (when install count > 1)
-if [ "$1" -ge 1 ]; then
+if [ "$1" -gt 1 ]; then
   set_permissions "$RESET_PERMS"
 fi


### PR DESCRIPTION
With "-ge" option will call set permission even on rpm install. Need to test if $1 is greater than 1 and call only on upgrade.