### PR TITLE
Make sure we restart st2auth service after configuring auth in st2.conf

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -610,6 +610,7 @@ configure_st2_authentication() {
   sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
   sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
 
+  sudo st2ctl restart-component st2auth
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2stream
 }

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -302,6 +302,7 @@ configure_st2_authentication() {
   sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
   sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
 
+  sudo st2ctl restart-component st2auth
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2stream
 }

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -606,6 +606,7 @@ configure_st2_authentication() {
   sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
   sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
 
+  sudo st2ctl restart-component st2auth
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2stream
 }

--- a/scripts/st2bootstrap-el6.template.sh
+++ b/scripts/st2bootstrap-el6.template.sh
@@ -246,6 +246,7 @@ configure_st2_authentication() {
   sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
   sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
 
+  sudo st2ctl restart-component st2auth
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2stream
 }

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -593,6 +593,7 @@ configure_st2_authentication() {
   sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
   sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
 
+  sudo st2ctl restart-component st2auth
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2stream
 }

--- a/scripts/st2bootstrap-el7.template.sh
+++ b/scripts/st2bootstrap-el7.template.sh
@@ -233,6 +233,7 @@ configure_st2_authentication() {
   sudo crudini --set /etc/st2/st2.conf auth backend 'flat_file'
   sudo crudini --set /etc/st2/st2.conf auth backend_kwargs '{"file_path": "/etc/st2/htpasswd"}'
 
+  sudo st2ctl restart-component st2auth
   sudo st2ctl restart-component st2api
   sudo st2ctl restart-component st2stream
 }


### PR DESCRIPTION
I noticed that Ubuntu Bionic tests fail every now and then on run bootstrap script task.

It turns out it fails because ``st2auth`` service is not started.

After digging in, it turns out there is a race between the time when we configure authentication in st2.conf and staring / restarting st2 services.

If st2auth is started before auth is configured in st2.conf, it won't work correctly.