### PR TITLE
Use non-interactive mode when installing Debian packages (fix for Bionic build failures)

### DIFF
--- a/scripts/install_os_packages.sh
+++ b/scripts/install_os_packages.sh
@@ -15,6 +15,8 @@ install_rpm() {
 }
 
 install_deb() {
+  export DEBIAN_FRONTEND=noninteractive
+
   sudo apt-get -o Acquire::ForceIPv4=true update -y
 
   for fpath in $(lookup_fullnames $@); do


### PR DESCRIPTION
I noticed Bionic package builds started to fail today - https://circleci.com/gh/StackStorm/st2/10349#tests/containers/2, https://circleci.com/gh/StackStorm/st2/10354#tests/containers/2.

It looks like the issue is related to some st2 package dependency relying on services being restarted. 

This prompt for restarting the services is displayed during package installation. Because we don't run that process in non-interactive mode the build fails (times out waiting on user input).

I believe the fix is making sure we run install / update process non non-interactive mode.

And why did those failures start to appear only now?

I believe it's related to this change - https://github.com/StackStorm/st2packaging-dockerfiles/pull/70. 

That change triggered a new version of bionicbuild and bionictest container images to to be built. New version of Bionic image likely depends on some new version of system library / package which requires service restart which displays that prompt.