### PR TITLE
Fix Ubuntu Bionic install failure caused by updated 'libssl' that requires user prompt

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -577,7 +577,7 @@ install_st2() {
   # 'mistral' repo builds single 'st2mistral' package and so we have to install 'st2' from repo
   if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^mistral/.* ]]; then
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
-    sudo apt-get install -y st2${ST2_PKG_VERSION}
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y st2${ST2_PKG_VERSION}
   else
     sudo apt-get install -y jq
 

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -269,7 +269,7 @@ install_st2() {
   # 'mistral' repo builds single 'st2mistral' package and so we have to install 'st2' from repo
   if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^mistral/.* ]]; then
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
-    sudo apt-get install -y st2${ST2_PKG_VERSION}
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y st2${ST2_PKG_VERSION}
   else
     sudo apt-get install -y jq
 


### PR DESCRIPTION
See related https://github.com/StackStorm/st2-packages/pull/615 and https://github.com/StackStorm/st2packaging-dockerfiles/pull/71

New `libssl` version which is a dependency for `st2` package now asks for user prompt asking if it should restart affected services or not.
Answering default option, otherwise scripted Ubuntu Bionic installation is waiting for user input and no `apt-get install -y` flag can help.