### PR TITLE
Make sure we also set DEBIAN_FRONTEND environment variable when installing dev version of packages

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -584,8 +584,8 @@ install_st2() {
     PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "${SUBTYPE}" "st2_.*.deb")
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
-    sudo dpkg -i --force-depends ${PACKAGE_FILENAME}
-    sudo apt-get install -yf
+    sudo DEBIAN_FRONTEND=noninteractive dpkg -i --force-depends ${PACKAGE_FILENAME}
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -yf
     rm ${PACKAGE_FILENAME}
   fi
 

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -276,8 +276,8 @@ install_st2() {
     PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "${SUBTYPE}" "st2_.*.deb")
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
-    sudo dpkg -i --force-depends ${PACKAGE_FILENAME}
-    sudo apt-get install -yf
+    sudo DEBIAN_FRONTEND=noninteractive dpkg -i --force-depends ${PACKAGE_FILENAME}
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -yf
     rm ${PACKAGE_FILENAME}
   fi
 


### PR DESCRIPTION
#616 fixed Bionic Build for stable packages (afaik) and I believe this should fix it for dev versions (scenario where we directly wget the package).