### PR TITLE
Add support for bionic to production release

### DIFF
--- a/.circle/packagecloud.sh
+++ b/.circle/packagecloud.sh
@@ -120,14 +120,6 @@ function deploy() {
      continue
     fi
 
-    # NOTE: At the moment we only support staging unstable Bionic packages
-    if [ "${PKG_OS}" = "bionic" ]; then
-      if [[ "${PACKAGECLOUD_REPO}" != "staging-unstable" ]] && [[ "${PACKAGECLOUD_REPO}" != "staging-enterprise-unstable" ]]; then
-        echo "Skipping upload for ${PKG_OS} packages, right now it's only enabled for staging unstable."
-        continue
-      fi
-    fi
-
     debug "PACKAGECLOUD_ORGANIZATION:  ${PACKAGECLOUD_ORGANIZATION}"
     debug "PACKAGECLOUD_REPO:          ${PACKAGECLOUD_REPO}"
     debug "PKG_PATH:                   ${PKG_PATH}"

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -83,19 +83,6 @@ setup_args() {
     fi
   fi
 
-   # Right now Bionic is not officially supported yet so we only support using staging unstable packages
-  if [[ "$SUBTYPE" == 'bionic' ]] && [[ "${DEV_BUILD}" = "" ]]; then
-    if [[ "${REPO_TYPE}" != "staging" ]]; then
-      echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
-      exit 2
-    fi
-
-    if [[ "${RELEASE}" != "unstable" ]]; then
-      echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
-      exit 2
-    fi
-  fi
-
   echo "########################################################"
   echo "          Installing StackStorm $RELEASE $VERSION              "
   echo "########################################################"

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -75,19 +75,6 @@ setup_args() {
     fi
   fi
 
-   # Right now Bionic is not officially supported yet so we only support using staging unstable packages
-  if [[ "$SUBTYPE" == 'bionic' ]] && [[ "${DEV_BUILD}" = "" ]]; then
-    if [[ "${REPO_TYPE}" != "staging" ]]; then
-      echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
-      exit 2
-    fi
-
-    if [[ "${RELEASE}" != "unstable" ]]; then
-      echo "Ubuntu 18.04 (Bionic) is not officially supported yet and only staging unstable (--staging --unstable) packages can be used on Bionic"
-      exit 2
-    fi
-  fi
-
   echo "########################################################"
   echo "          Installing StackStorm $RELEASE $VERSION              "
   echo "########################################################"


### PR DESCRIPTION
Add support for ubuntu 18 (bionic) to production release. Remove the temporary if statement in packagecloud.sh that prevents bionic packages from being pushed to staging-stable and staging-enterprise for production release. Update the bootstrap scripts to allow installation of bionic packages from production stable.