### PR TITLE
Fix Ubuntu Bionic install failure caused by updated 'libssl' required user prompt

### DIFF
--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -1,6 +1,6 @@
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
-  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
+  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
     sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -118,7 +118,7 @@ setup_args() {
 
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
-  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
+  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
     sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi
@@ -420,6 +420,8 @@ fail() {
 
 
 install_st2_dependencies() {
+  # Silence debconf prompt, raised during some dep installations. This will be passed to sudo via 'env_keep'.
+  export DEBIAN_FRONTEND=noninteractive
   sudo apt-get update
 
   # Note: gnupg-curl is needed to be able to use https transport when fetching keys
@@ -564,15 +566,15 @@ install_st2() {
   # 'mistral' repo builds single 'st2mistral' package and so we have to install 'st2' from repo
   if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^mistral/.* ]]; then
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y st2${ST2_PKG_VERSION}
+    sudo apt-get install -y st2${ST2_PKG_VERSION}
   else
     sudo apt-get install -y jq
 
     PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "${SUBTYPE}" "st2_.*.deb")
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
-    sudo DEBIAN_FRONTEND=noninteractive dpkg -i --force-depends ${PACKAGE_FILENAME}
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -yf
+    sudo dpkg -i --force-depends ${PACKAGE_FILENAME}
+    sudo apt-get install -yf
     rm ${PACKAGE_FILENAME}
   fi
 

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -112,6 +112,8 @@ setup_args() {
 
 
 install_st2_dependencies() {
+  # Silence debconf prompt, raised during some dep installations. This will be passed to sudo via 'env_keep'.
+  export DEBIAN_FRONTEND=noninteractive
   sudo apt-get update
 
   # Note: gnupg-curl is needed to be able to use https transport when fetching keys
@@ -256,15 +258,15 @@ install_st2() {
   # 'mistral' repo builds single 'st2mistral' package and so we have to install 'st2' from repo
   if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^mistral/.* ]]; then
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y st2${ST2_PKG_VERSION}
+    sudo apt-get install -y st2${ST2_PKG_VERSION}
   else
     sudo apt-get install -y jq
 
     PACKAGE_URL=$(get_package_url "${DEV_BUILD}" "${SUBTYPE}" "st2_.*.deb")
     PACKAGE_FILENAME="$(basename ${PACKAGE_URL})"
     curl -Ss -k -o ${PACKAGE_FILENAME} ${PACKAGE_URL}
-    sudo DEBIAN_FRONTEND=noninteractive dpkg -i --force-depends ${PACKAGE_FILENAME}
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -yf
+    sudo dpkg -i --force-depends ${PACKAGE_FILENAME}
+    sudo apt-get install -yf
     rm ${PACKAGE_FILENAME}
   fi
 

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -112,7 +112,7 @@ setup_args() {
 
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
-  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
+  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
     sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -112,7 +112,7 @@ setup_args() {
 
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
-  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path"'
+  local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
   if ! sudo grep -s -q ^"${sudoers_proxy}" /etc/sudoers.d/st2; then
     sudo sh -c "echo '${sudoers_proxy}' >> /etc/sudoers.d/st2"
   fi


### PR DESCRIPTION
Continuation of a https://github.com/StackStorm/st2-packages/pull/617 story when installer starting failing in other places.

Set `DEBIAN_FRONTEND=noninteractive` for the whole deb installer.