### PR TITLE
WIP: EL8 installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ In order to build, package, install and test ST2 in an isolated Vagrant VM, run 
 vagrant up $TARGET
 ```
 
-Where `$TARGET` is one of `trusty`, `xenial` or `el7`. Note that `el6` does not reliably support docker,
-so it is not an available option.
+Where `$TARGET` is one of `trusty`, `xenial`, `el7`, or `el8`. Note that `el6` does not reliably
+ support docker, so it is not an available option. If you are using `el8`, comment out the 
+ `vm_config.vm.provision :docker` line in the Vagrantfile. There is logic in `setup-vagrant.sh` to 
+ install docker in `el8`.
 
 The following steps are run while provisioning the Vagrant VM:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,11 @@ VIRTUAL_MACHINES = {
     :box => 'centos/7',
     :ip => '192.168.16.22',
   },
+  :el8 => {
+    :hostname => 'st2-packages-el8',
+    :box => 'centos/8',
+    :ip => '192.168.16.24',
+  },
 }
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ bionic:
     - postgres
 
 el8:
-  image: packagingrunner:trusty
+  image: quay.io/stackstorm/packagingrunner
   extends:
     file: docker-compose.override.yml
     service: suite-compose

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -140,7 +140,6 @@ configure_st2_user () {
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
-  ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
     PEM="-m PEM"

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -142,10 +142,8 @@ configure_st2_user () {
   # to be generated again.
   ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
-    if [[ "$ELMAJVER" == 8 ]]; then
-        # EL8 added -m PEM to force RSA PEM format
-        PEM="-m PEM"
-    fi
+    # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
+    PEM="-m PEM"
     sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
   fi
 

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -140,8 +140,13 @@ configure_st2_user () {
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
+  ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
-    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P ""
+    if [[ "$ELMAJVER" == 8 ]]; then
+        # EL8 added -m PEM to force RSA PEM format
+        PEM="-m PEM"
+    fi
+    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
   fi
 
   if ! sudo grep -s -q -f ${SYSTEM_HOME}/.ssh/stanley_rsa.pub ${SYSTEM_HOME}/.ssh/authorized_keys;

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -258,7 +258,6 @@ configure_st2_user () {
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
-  ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
     PEM="-m PEM"

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -260,10 +260,8 @@ configure_st2_user () {
   # to be generated again.
   ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
-    if [[ "$ELMAJVER" == 8 ]]; then
-        # EL8 added -m PEM to force RSA PEM format
-        PEM="-m PEM"
-    fi
+    # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
+    PEM="-m PEM"
     sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
   fi
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -258,8 +258,13 @@ configure_st2_user () {
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
+  ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
-    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P ""
+    if [[ "$ELMAJVER" == 8 ]]; then
+        # EL8 added -m PEM to force RSA PEM format
+        PEM="-m PEM"
+    fi
+    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
   fi
 
   if ! sudo grep -s -q -f ${SYSTEM_HOME}/.ssh/stanley_rsa.pub ${SYSTEM_HOME}/.ssh/authorized_keys;

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -252,7 +252,6 @@ configure_st2_user () {
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
-  ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
     PEM="-m PEM"

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -252,8 +252,13 @@ configure_st2_user () {
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
+  ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
-    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P ""
+    if [[ "$ELMAJVER" == 8 ]]; then
+        # EL8 added -m PEM to force RSA PEM format
+        PEM="-m PEM"
+    fi
+    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
   fi
 
   if ! sudo grep -s -q -f ${SYSTEM_HOME}/.ssh/stanley_rsa.pub ${SYSTEM_HOME}/.ssh/authorized_keys;

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -254,10 +254,8 @@ configure_st2_user () {
   # to be generated again.
   ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
-    if [[ "$ELMAJVER" == 8 ]]; then
-        # EL8 added -m PEM to force RSA PEM format
-        PEM="-m PEM"
-    fi
+    # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
+    PEM="-m PEM"
     sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
   fi
 

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -252,7 +252,6 @@ configure_st2_user () {
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
-  ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
     PEM="-m PEM"

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -252,8 +252,13 @@ configure_st2_user () {
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
+  ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
-    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P ""
+    if [[ "$ELMAJVER" == 8 ]]; then
+        # EL8 added -m PEM to force RSA PEM format
+        PEM="-m PEM"
+    fi
+    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
   fi
 
   if ! sudo grep -s -q -f ${SYSTEM_HOME}/.ssh/stanley_rsa.pub ${SYSTEM_HOME}/.ssh/authorized_keys;

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -254,10 +254,8 @@ configure_st2_user () {
   # to be generated again.
   ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
-    if [[ "$ELMAJVER" == 8 ]]; then
-        # EL8 added -m PEM to force RSA PEM format
-        PEM="-m PEM"
-    fi
+    # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
+    PEM="-m PEM"
     sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
   fi
 

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -517,7 +517,7 @@ install_mongodb() {
 
   # Need yum perl module enabled on RHEL 8
   if [[ "$RHEL" == "1" ]]; then
-    yum module enable perl:5.26
+    sudo yum -y module enable perl:5.26
   fi
 
   # Add key and repo for the latest stable MongoDB (4.0)

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -666,7 +666,7 @@ EOT"
 
   # RHEL 8 runs firewalld so we need to open http/https
   # Don't run this on ec2
-  if [[ "$RHEL" == "1" ]] && [[ $(grep -q "ec2" /sys/hypervisor/uuid)  ]]; then
+  if [[ "$RHEL" == "1" ]] && [[ $(grep -q "ec2" /sys/hypervisor/uuid) == 1 ]]; then
     sudo firewall-cmd --zone=public --add-service=http --add-service=https
     sudo firewall-cmd --zone=public --permanent --add-service=http --add-service=https
   fi

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -471,7 +471,7 @@ get_full_pkg_versions() {
 adjust_selinux_policies() {
   if getenforce | grep -q 'Enforcing'; then
     # SELINUX management tools, not available for some minimal installations
-    sudo yum install -y policycoreutils-python
+    sudo yum install -y policycoreutils-python-utils
 
     # Allow rabbitmq to use '25672' port, otherwise it will fail to start
     sudo semanage port --list | grep -q 25672 || sudo semanage port -a -t amqp_port_t -p tcp 25672

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -497,7 +497,8 @@ install_st2_dependencies() {
   # Install rabbit from packagecloud
   # Package are not in EPEL or CentOS repos -
   # recommended by rabbit: https://www.rabbitmq.com/install-rpm.html#package-cloud
-  # Leaving epel repo to switch out with rpm when released
+  # TODO: Migrate install back to EPEL rpm when available
+  # https://github.com/StackStorm/st2-packages/issues/632
   curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
 
@@ -664,7 +665,8 @@ EOT"
   sudo systemctl enable nginx
 
   # RHEL 8 runs firewalld so we need to open http/https
-  if [[ "$RHEL" == "1" ]]; then
+  # Don't run this on ec2
+  if [[ "$RHEL" == "1" ]] && [[ $(grep -q "ec2" /sys/hypervisor/uuid)  ]]; then
     sudo firewall-cmd --zone=public --add-service=http --add-service=https
     sudo firewall-cmd --zone=public --permanent --add-service=http --add-service=https
   fi

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -508,9 +508,9 @@ install_st2_dependencies() {
   fi
 
   # Install rabbit from packagecloud
-  # Package are not in EPEL or CentOS repos -
+  # Package are not in EPEL or CentOS repos - but this is required for erlang.
   # recommended by rabbit: https://www.rabbitmq.com/install-rpm.html#package-cloud
-  # TODO: Migrate install back to EPEL rpm when available
+  # TODO: Migrate rabbitmq packages to be sourced from EPEL rpm when available for EL8
   # https://github.com/StackStorm/st2-packages/issues/632
   curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -637,7 +637,8 @@ EOT"
 
   # EL8: Comment out server { block } in nginx.conf and clean up
   sudo cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak
-  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf.bak > /etc/nginx/nginx.conf
+  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf.bak > /tmp/nginx.conf
+  sudo mv /tmp/nginx.conf /etc/nginx/nginx.conf
   sudo sed -i -e 's/##/#/' /etc/nginx/nginx.conf
   sudo sed -i -e 's/#}/}/' /etc/nginx/nginx.conf
 

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -491,6 +491,11 @@ install_st2_dependencies() {
   if [[ -z "$is_epel_installed" ]]; then
     sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
   fi
+
+  # Install rabbit from packagecloud
+  curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
+  sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
+
   sudo yum -y install curl rabbitmq-server
 
   # Configure RabbitMQ to listen on localhost only
@@ -506,13 +511,13 @@ install_st2_dependencies() {
 install_mongodb() {
   # Add key and repo for the latest stable MongoDB (3.4)
   sudo rpm --import https://www.mongodb.org/static/pgp/server-3.4.asc
-  sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.4.repo
-[mongodb-org-3.4]
+  sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-4.repo
+[mongodb-org-4]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.4/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/8/mongodb-org/4.0/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
+gpgkey=https://www.mongodb.org/static/pgp/server-4.0.asc
 EOT"
 
   sudo yum -y install mongodb-org
@@ -651,7 +656,7 @@ install_st2web() {
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/nginx.repo
 [nginx]
 name=nginx repo
-baseurl=http://nginx.org/packages/rhel/7/x86_64/
+baseurl=http://nginx.org/packages/rhel/8/x86_64/
 gpgcheck=1
 enabled=1
 EOT"

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -720,7 +720,7 @@ STEP="Verify st2" && verify_st2
 
 STEP="Install st2web" && install_st2web
 STEP="Install st2chatops" && install_st2chatops
-# STEP="Configure st2chatops" && configure_st2chatops
+STEP="Configure st2chatops" && configure_st2chatops
 trap - EXIT
 
 ok_message

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -251,7 +251,6 @@ configure_st2_user () {
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
-  ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
     PEM="-m PEM"

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -724,8 +724,10 @@ trap 'fail' EXIT
 
 # check for RHEL 8
 ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
-if [[ "$ELMAJVER" == "8" ]] && [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
-    RHEL=1
+if [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
+  RHEL=1
+else
+  RHEL=0
 fi
 
 STEP='Parse arguments' && setup_args $@

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -252,7 +252,8 @@ configure_st2_user () {
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
-    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P ""
+    # EL8 added -m PEM to force RSA PEM format
+    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" -m PEM
   fi
 
   if ! sudo grep -s -q -f ${SYSTEM_HOME}/.ssh/stanley_rsa.pub ${SYSTEM_HOME}/.ssh/authorized_keys;

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -637,7 +637,7 @@ EOT"
 
   # EL8: Comment out server { block } in nginx.conf and clean up
   sudo cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak
-  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf.bak < /etc/nginx/nginx.conf
+  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf.bak > /etc/nginx/nginx.conf
   sudo sed -i -e 's/##/#/' /etc/nginx/nginx.conf
   sudo sed -i -e 's/#}/}/' /etc/nginx/nginx.conf
 

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -497,6 +497,11 @@ install_net_tools() {
 }
 
 install_st2_dependencies() {
+  # RabbitMQ on RHEL8 requires module(perl:5.26
+  if [[ "$RHEL" == "1" ]]; then
+    sudo yum -y module enable perl:5.26
+  fi
+
   is_epel_installed=$(rpm -qa | grep epel-release || true)
   if [[ -z "$is_epel_installed" ]]; then
     sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
@@ -523,11 +528,6 @@ install_st2_dependencies() {
 }
 
 install_mongodb() {
-
-#  # Need yum perl module enabled on RHEL 8
-#  if [[ "$RHEL" == "1" ]]; then
-#    sudo yum -y module enable perl:5.26
-#  fi
 
   # Add key and repo for the latest stable MongoDB (4.0)
   sudo rpm --import https://www.mongodb.org/static/pgp/server-4.0.asc

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -524,10 +524,10 @@ install_st2_dependencies() {
 
 install_mongodb() {
 
-  # Need yum perl module enabled on RHEL 8
-  if [[ "$RHEL" == "1" ]]; then
-    sudo yum -y module enable perl:5.26
-  fi
+#  # Need yum perl module enabled on RHEL 8
+#  if [[ "$RHEL" == "1" ]]; then
+#    sudo yum -y module enable perl:5.26
+#  fi
 
   # Add key and repo for the latest stable MongoDB (4.0)
   sudo rpm --import https://www.mongodb.org/static/pgp/server-4.0.asc

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -637,7 +637,8 @@ EOT"
 
   # EL8: Comment out server { block } in nginx.conf and clean up
   sudo cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak
-  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf
+  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf.bak < /etc/nginx/nginx
+  .conf
   sudo sed -i -e 's/##/#/' /etc/nginx/nginx.conf
   sudo sed -i -e 's/#}/}/' /etc/nginx/nginx.conf
 

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -22,7 +22,7 @@ ST2_PKG='st2'
 ST2WEB_PKG='st2web'
 ST2CHATOPS_PKG='st2chatops'
 
-check_for_rhel() {
+is_rhel() {
   if [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
     RHEL=1
   else
@@ -498,7 +498,7 @@ install_net_tools() {
 
 install_st2_dependencies() {
   # RabbitMQ on RHEL8 requires module(perl:5.26
-  if [[ "$RHEL" == "1" ]]; then
+  if is_rhel; then
     sudo yum -y module enable perl:5.26
   fi
 
@@ -674,7 +674,7 @@ EOT"
 
   # RHEL 8 runs firewalld so we need to open http/https
   # Don't run this on ec2
-  if [[ "$RHEL" == "1" ]] && [[ $(grep -q "ec2" /sys/hypervisor/uuid) == 1 ]]; then
+  if is_rhel && [[ $(grep -q "ec2" /sys/hypervisor/uuid) == 1 ]]; then
     sudo firewall-cmd --zone=public --add-service=http --add-service=https
     sudo firewall-cmd --zone=public --permanent --add-service=http --add-service=https
   fi
@@ -730,7 +730,6 @@ configure_st2chatops() {
 
 trap 'fail' EXIT
 
-STEP='Check for RHEL' && check_for_rhel
 STEP='Parse arguments' && setup_args $@
 STEP="Configure Proxy" && configure_proxy
 STEP='Install net-tools' && install_net_tools

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -637,8 +637,7 @@ EOT"
 
   # EL8: Comment out server { block } in nginx.conf and clean up
   sudo cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak
-  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf.bak < /etc/nginx/nginx
-  .conf
+  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf.bak < /etc/nginx/nginx.conf
   sudo sed -i -e 's/##/#/' /etc/nginx/nginx.conf
   sudo sed -i -e 's/#}/}/' /etc/nginx/nginx.conf
 

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -516,8 +516,8 @@ install_st2_dependencies() {
 }
 
 install_mongodb() {
-  # Add key and repo for the latest stable MongoDB (3.4)
-  sudo rpm --import https://www.mongodb.org/static/pgp/server-3.4.asc
+  # Add key and repo for the latest stable MongoDB (4.0)
+  sudo rpm --import https://www.mongodb.org/static/pgp/server-4.0.asc
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-4.repo
 [mongodb-org-4]
 name=MongoDB Repository

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -19,7 +19,6 @@ DEV_BUILD=''
 USERNAME=''
 PASSWORD=''
 ST2_PKG='st2'
-ST2MISTRAL_PKG='st2mistral'
 ST2WEB_PKG='st2web'
 ST2CHATOPS_PKG='st2chatops'
 
@@ -748,13 +747,10 @@ STEP="Configure st2 CLI config" && configure_st2_cli_config
 STEP="Generate symmetric crypto key for datastore" && generate_symmetric_crypto_key_for_datastore
 STEP="Verify st2" && verify_st2
 
-# Disable for EL8, mistral not supported
-# STEP="Install mistral dependencies" && install_st2mistral_dependencies
-# STEP="Install mistral" && install_st2mistral
 
 STEP="Install st2web" && install_st2web
 STEP="Install st2chatops" && install_st2chatops
-STEP="Configure st2chatops" && configure_st2chatops
+# STEP="Configure st2chatops" && configure_st2chatops
 trap - EXIT
 
 ok_message

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -254,7 +254,7 @@ configure_st2_user () {
   ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     if [[ "$ELMAJVER" == 8 ]]; then
-        # EL8: added -m PEM to force RSA PEM format
+        # EL8 added -m PEM to force RSA PEM format
         PEM="-m PEM"
     fi
     sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -497,6 +497,7 @@ install_st2_dependencies() {
   # Install rabbit from packagecloud
   # Package are not in EPEL or CentOS repos -
   # recommended by rabbit: https://www.rabbitmq.com/install-rpm.html#package-cloud
+  # Leaving epel repo to switch out with rpm when released
   curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
 

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -22,6 +22,14 @@ ST2_PKG='st2'
 ST2WEB_PKG='st2web'
 ST2CHATOPS_PKG='st2chatops'
 
+check_for_rhel() {
+  if [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
+    RHEL=1
+  else
+    RHEL=0
+  fi
+}
+
 setup_args() {
   for i in "$@"
     do
@@ -722,14 +730,7 @@ configure_st2chatops() {
 
 trap 'fail' EXIT
 
-# check for RHEL 8
-ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
-if [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
-  RHEL=1
-else
-  RHEL=0
-fi
-
+STEP='Check for RHEL' && check_for_rhel
 STEP='Parse arguments' && setup_args $@
 STEP="Configure Proxy" && configure_proxy
 STEP='Install net-tools' && install_net_tools

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -635,6 +635,13 @@ EOT"
   # Remove default site, if present
   sudo rm -f /etc/nginx/conf.d/default.conf
 
+  # EL8: Comment out server { block } in nginx.conf and clean up
+  sudo cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak
+  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf
+  sudo sed -i -e 's/##/#/' /etc/nginx/nginx.conf
+  sudo sed -i -e 's/#}/}/' /etc/nginx/nginx.conf
+
+
   # Copy and enable StackStorm's supplied config file
   sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/
 

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -112,7 +112,7 @@ setup_args() {
 adjust_selinux_policies() {
   if getenforce | grep -q 'Enforcing'; then
     # SELINUX management tools, not available for some minimal installations
-    sudo yum install -y policycoreutils-python
+    sudo yum install -y policycoreutils-python-utils
 
     # Allow rabbitmq to use '25672' port, otherwise it will fail to start
     sudo semanage port --list | grep -q 25672 || sudo semanage port -a -t amqp_port_t -p tcp 25672

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -304,7 +304,7 @@ EOT"
 
   # RHEL 8 runs firewalld so we need to open http/https
   # Don't run this on ec2
-  if [[ "$RHEL" == "1" ]] && [[ $(grep -q "ec2" /sys/hypervisor/uuid)  ]]; then
+  if [[ "$RHEL" == "1" ]] && [[ $(grep -q "ec2" /sys/hypervisor/uuid) == 1 ]]; then
     sudo firewall-cmd --zone=public --add-service=http --add-service=https
     sudo firewall-cmd --zone=public --permanent --add-service=http --add-service=https
   fi

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -151,8 +151,8 @@ install_st2_dependencies() {
 }
 
 install_mongodb() {
-  # Add key and repo for the latest stable MongoDB (3.4)
-  sudo rpm --import https://www.mongodb.org/static/pgp/server-3.4.asc
+  # Add key and repo for the latest stable MongoDB (4.0)
+  sudo rpm --import https://www.mongodb.org/static/pgp/server-4.0.asc
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-4.repo
 [mongodb-org-4]
 name=MongoDB Repository

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -135,6 +135,11 @@ install_net_tools() {
 }
 
 install_st2_dependencies() {
+  # RabbitMQ on RHEL8 requires module(perl:5.26
+  if [[ "$RHEL" == "1" ]]; then
+    sudo yum -y module enable perl:5.26
+  fi
+
   is_epel_installed=$(rpm -qa | grep epel-release || true)
   if [[ -z "$is_epel_installed" ]]; then
     sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
@@ -161,11 +166,6 @@ install_st2_dependencies() {
 }
 
 install_mongodb() {
-
-#  # Need yum perl module enabled on RHEL 8
-#  if [[ "$RHEL" == "1" ]]; then
-#    sudo yum -y module enable perl:5.26
-#  fi
 
   # Add key and repo for the latest stable MongoDB (4.0)
   sudo rpm --import https://www.mongodb.org/static/pgp/server-4.0.asc

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -135,6 +135,7 @@ install_st2_dependencies() {
   # Install rabbit from packagecloud
   # Package are not in EPEL or CentOS repos -
   # recommended by rabbit: https://www.rabbitmq.com/install-rpm.html#package-cloud
+  # Leaving epel repo to switch out with rpm when released
   curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
 

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -162,10 +162,10 @@ install_st2_dependencies() {
 
 install_mongodb() {
 
-  # Need yum perl module enabled on RHEL 8
-  if [[ "$RHEL" == "1" ]]; then
-    sudo yum -y module enable perl:5.26
-  fi
+#  # Need yum perl module enabled on RHEL 8
+#  if [[ "$RHEL" == "1" ]]; then
+#    sudo yum -y module enable perl:5.26
+#  fi
 
   # Add key and repo for the latest stable MongoDB (4.0)
   sudo rpm --import https://www.mongodb.org/static/pgp/server-4.0.asc

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -135,7 +135,8 @@ install_st2_dependencies() {
   # Install rabbit from packagecloud
   # Package are not in EPEL or CentOS repos -
   # recommended by rabbit: https://www.rabbitmq.com/install-rpm.html#package-cloud
-  # Leaving epel repo to switch out with rpm when released
+  # TODO: Migrate install back to EPEL rpm when available
+  # https://github.com/StackStorm/st2-packages/issues/632
   curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
 
@@ -302,7 +303,8 @@ EOT"
   sudo systemctl enable nginx
 
   # RHEL 8 runs firewalld so we need to open http/https
-  if [[ "$RHEL" == "1" ]]; then
+  # Don't run this on ec2
+  if [[ "$RHEL" == "1" ]] && [[ $(grep -q "ec2" /sys/hypervisor/uuid)  ]]; then
     sudo firewall-cmd --zone=public --add-service=http --add-service=https
     sudo firewall-cmd --zone=public --permanent --add-service=http --add-service=https
   fi

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -362,8 +362,10 @@ trap 'fail' EXIT
 
 # check for RHEL 8
 ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
-if [[ "$ELMAJVER" == "8" ]] && [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
-    RHEL=1
+if [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
+  RHEL=1
+else
+  RHEL=0
 fi
 
 STEP='Parse arguments' && setup_args $@

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -146,9 +146,9 @@ install_st2_dependencies() {
   fi
 
   # Install rabbit from packagecloud
-  # Package are not in EPEL or CentOS repos -
+  # Package are not in EPEL or CentOS repos - but this is required for erlang.
   # recommended by rabbit: https://www.rabbitmq.com/install-rpm.html#package-cloud
-  # TODO: Migrate install back to EPEL rpm when available
+  # TODO: Migrate rabbitmq packages to be sourced from EPEL rpm when available for EL8
   # https://github.com/StackStorm/st2-packages/issues/632
   curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -155,7 +155,7 @@ install_mongodb() {
 
   # Need yum perl module enabled on RHEL 8
   if [[ "$RHEL" == "1" ]]; then
-    yum module enable perl:5.26
+    sudo yum -y module enable perl:5.26
   fi
 
   # Add key and repo for the latest stable MongoDB (4.0)

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -14,7 +14,7 @@ ST2_PKG='st2'
 ST2WEB_PKG='st2web'
 ST2CHATOPS_PKG='st2chatops'
 
-check_for_rhel() {
+is_rhel() {
   if [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
     RHEL=1
   else
@@ -136,7 +136,7 @@ install_net_tools() {
 
 install_st2_dependencies() {
   # RabbitMQ on RHEL8 requires module(perl:5.26
-  if [[ "$RHEL" == "1" ]]; then
+  if is_rhel; then
     sudo yum -y module enable perl:5.26
   fi
 
@@ -312,7 +312,7 @@ EOT"
 
   # RHEL 8 runs firewalld so we need to open http/https
   # Don't run this on ec2
-  if [[ "$RHEL" == "1" ]] && [[ $(grep -q "ec2" /sys/hypervisor/uuid) == 1 ]]; then
+  if is_rhel && [[ $(grep -q "ec2" /sys/hypervisor/uuid) == 1 ]]; then
     sudo firewall-cmd --zone=public --add-service=http --add-service=https
     sudo firewall-cmd --zone=public --permanent --add-service=http --add-service=https
   fi
@@ -368,7 +368,6 @@ configure_st2chatops() {
 
 trap 'fail' EXIT
 
-STEP='Check for RHEL' && check_for_rhel
 STEP='Parse arguments' && setup_args $@
 STEP="Configure Proxy" && configure_proxy
 STEP='Install net-tools' && install_net_tools

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -72,14 +72,14 @@ setup_args() {
   echo "          Installing st2 $RELEASE $VERSION              "
   echo "########################################################"
 
-  if [ "$REPO_TYPE" == "staging" ]; then
+  if [[ "$REPO_TYPE" == "staging" ]]; then
     printf "\n\n"
     echo "################################################################"
     echo "### Installing from staging repos!!! USE AT YOUR OWN RISK!!! ###"
     echo "################################################################"
   fi
 
-  if [ "$DEV_BUILD" != '' ]; then
+  if [[ "$DEV_BUILD" != '' ]]; then
     printf "\n\n"
     echo "###############################################################################"
     echo "### Installing from dev build artifacts!!! REALLY, ANYTHING COULD HAPPEN!!! ###"
@@ -93,7 +93,7 @@ setup_args() {
     read -e -p "Admin username: " -i "st2admin" USERNAME
     read -e -s -p "Password: " PASSWORD
 
-    if [ "${PASSWORD}" = '' ]; then
+    if [[ "${PASSWORD}" = '' ]]; then
         echo "Password cannot be empty."
         exit 1
     fi
@@ -208,7 +208,7 @@ install_st2() {
   curl -s https://packagecloud.io/install/repositories/StackStorm/${REPO_PREFIX}${RELEASE}/script.rpm.sh | sudo bash
 
   # 'mistral' repo builds single 'st2mistral' package and so we have to install 'st2' from repo
-  if [ "$DEV_BUILD" = '' ] || [[ "$DEV_BUILD" =~ ^mistral/.* ]]; then
+  if [[ "$DEV_BUILD" = '' ]] || [[ "$DEV_BUILD" =~ ^mistral/.* ]]; then
     STEP="Get package versions" && get_full_pkg_versions && STEP="Install st2"
     sudo yum -y install ${ST2_PKG}
   else
@@ -275,12 +275,18 @@ EOT"
   sudo rm -f /etc/nginx/conf.d/default.conf
 
   # EL8: Comment out server { block } in nginx.conf and clean up
-  sudo cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak
-  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf.bak > /tmp/nginx.conf
-  sudo mv /tmp/nginx.conf /etc/nginx/nginx.conf
-  sudo sed -i -e 's/##/#/' /etc/nginx/nginx.conf
-  sudo sed -i -e 's/#}/}/' /etc/nginx/nginx.conf
+  # nginx 1.6 in EL8 ships with a server block enabled which needs to be disabled
 
+  # back up conf
+  sudo cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak
+  # comment out server block eg. server {...}
+  sudo awk '/^    server {/{f=1}f{$0 = "#" $0}{print}' /etc/nginx/nginx.conf.bak > /tmp/nginx.conf
+  # copy modified file over
+  sudo mv /tmp/nginx.conf /etc/nginx/nginx.conf
+  # remove double comments
+  sudo sed -i -e 's/##/#/' /etc/nginx/nginx.conf
+  # remove comment closing out server block
+  sudo sed -i -e 's/#}/}/' /etc/nginx/nginx.conf
 
   # Copy and enable StackStorm's supplied config file
   sudo cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -14,6 +14,14 @@ ST2_PKG='st2'
 ST2WEB_PKG='st2web'
 ST2CHATOPS_PKG='st2chatops'
 
+check_for_rhel() {
+  if [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
+    RHEL=1
+  else
+    RHEL=0
+  fi
+}
+
 setup_args() {
   for i in "$@"
     do
@@ -360,14 +368,7 @@ configure_st2chatops() {
 
 trap 'fail' EXIT
 
-# check for RHEL 8
-ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
-if [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
-  RHEL=1
-else
-  RHEL=0
-fi
-
+STEP='Check for RHEL' && check_for_rhel
 STEP='Parse arguments' && setup_args $@
 STEP="Configure Proxy" && configure_proxy
 STEP='Install net-tools' && install_net_tools

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -152,6 +152,12 @@ install_st2_dependencies() {
 }
 
 install_mongodb() {
+
+  # Need yum perl module enabled on RHEL 8
+  if [[ "$RHEL" == "1" ]]; then
+    yum module enable perl:5.26
+  fi
+
   # Add key and repo for the latest stable MongoDB (4.0)
   sudo rpm --import https://www.mongodb.org/static/pgp/server-4.0.asc
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-4.repo
@@ -294,6 +300,12 @@ EOT"
 
   sudo systemctl restart nginx
   sudo systemctl enable nginx
+
+  # RHEL 8 runs firewalld so we need to open http/https
+  if [[ "$RHEL" == "1" ]]; then
+    sudo firewall-cmd --zone=public --add-service=http --add-service=https
+    sudo firewall-cmd --zone=public --permanent --add-service=http --add-service=https
+  fi
 }
 
 install_st2chatops() {
@@ -345,6 +357,13 @@ configure_st2chatops() {
 }
 
 trap 'fail' EXIT
+
+# check for RHEL 8
+ELMAJVER=$(cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/')
+if [[ "$ELMAJVER" == "8" ]] && [[ $(cat /etc/os-release | grep 'ID="rhel"') ]]; then
+    RHEL=1
+fi
+
 STEP='Parse arguments' && setup_args $@
 STEP="Configure Proxy" && configure_proxy
 STEP='Install net-tools' && install_net_tools


### PR DESCRIPTION
### Done so far
- [x] Create EL8 Packages in `staging-unstable`
- [x] Prep Vagrantfile
- [x] Update st2bootstrap scripts (This PR)
- [x] Author (@punkrokk) testing
- [x] You test

### Updates for EL8:
- Currently need the rabbit packagecloud repo:
```
# Install rabbit from packagecloud
  curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
  sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
```
- selinux policy utils package name is different: `policycoreutils-python -> policycoreutils-python-utils`
- modify `[includes/common.sh](https://github.com/StackStorm/st2-packages/blob/f0e1e650d17ccee9c8e4ab05bfdbd1a664378089/scripts/st2bootstrap-el8.sh#L256-L260)` to force `PEM` key type. 
- MongoDB to 4.0 (Readme not updated yet)

See https://github.com/StackStorm/st2docs/pull/955 more differences from EL7 -> EL8.

### How I am testing

Here is a reasonably plain Vanilla `Vagrantfile` that I'm using. Main difference is 4 CPUs and 4GB of RAM and a Private Network static IP. YMMV. 
https://gist.github.com/punkrokk/36db930d50d0a272c93ae6049919bf5c

#### Vagrant setup
```
mkdir el8test && cd el8test
[copy above or your own Vagrantfile in this dir
vagrant up --provider virtualbox && vagrant ssh
```
In Vagrant box or your CentOS 8 VM: :
```
sudo yum -y install git
git clone https://github.com/StackStorm/st2-packages.git
cd st2-packages
git checkout el8-install-testing 
cd scripts
bash st2bootstrap-el8.sh  --unstable --staging  --user=st2admin --password=Ch@ngeMe
```

Please comment here if you:
- Succeed (Thumbs up this PR)
- Find a bug (Comment or request a change and explain why/what)