### PR TITLE
Installer script should fail if any of the "mongo shell" steps fail

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -472,6 +472,10 @@ install_mongodb() {
   sleep 5
 
   # Create admin user and user used by StackStorm (MongoDB needs to be running)
+  # NOTE: mongo shell will automatically exit when piping from stdin. There is
+  # no need to put quit(); at the end. This way last command exit code will be
+  # correctly preserved and install script will correctly fail and abort if this
+  # command fails.
   mongo <<EOF
 use admin;
 db.createUser({
@@ -481,7 +485,6 @@ db.createUser({
         { role: "userAdminAnyDatabase", db: "admin" }
     ]
 });
-quit();
 EOF
 
   mongo <<EOF
@@ -493,7 +496,6 @@ db.createUser({
         { role: "readWrite", db: "st2" }
     ]
 });
-quit();
 EOF
 
   # Require authentication to be able to acccess the database

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -164,6 +164,10 @@ install_mongodb() {
   sleep 5
 
   # Create admin user and user used by StackStorm (MongoDB needs to be running)
+  # NOTE: mongo shell will automatically exit when piping from stdin. There is
+  # no need to put quit(); at the end. This way last command exit code will be
+  # correctly preserved and install script will correctly fail and abort if this
+  # command fails.
   mongo <<EOF
 use admin;
 db.createUser({
@@ -173,7 +177,6 @@ db.createUser({
         { role: "userAdminAnyDatabase", db: "admin" }
     ]
 });
-quit();
 EOF
 
   mongo <<EOF
@@ -185,7 +188,6 @@ db.createUser({
         { role: "readWrite", db: "st2" }
     ]
 });
-quit();
 EOF
 
   # Require authentication to be able to acccess the database

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -540,6 +540,10 @@ EOT"
   sleep 5
 
   # Create admin user and user used by StackStorm (MongoDB needs to be running)
+  # NOTE: mongo shell will automatically exit when piping from stdin. There is
+  # no need to put quit(); at the end. This way last command exit code will be
+  # correctly preserved and install script will correctly fail and abort if this
+  # command fails.
   mongo <<EOF
 use admin;
 db.createUser({
@@ -549,7 +553,6 @@ db.createUser({
         { role: "userAdminAnyDatabase", db: "admin" }
     ]
 });
-quit();
 EOF
 
   mongo <<EOF
@@ -561,7 +564,6 @@ db.createUser({
         { role: "readWrite", db: "st2" }
     ]
 });
-quit();
 EOF
 
   # Require authentication to be able to acccess the database

--- a/scripts/st2bootstrap-el6.template.sh
+++ b/scripts/st2bootstrap-el6.template.sh
@@ -180,6 +180,10 @@ EOT"
   sleep 5
 
   # Create admin user and user used by StackStorm (MongoDB needs to be running)
+  # NOTE: mongo shell will automatically exit when piping from stdin. There is
+  # no need to put quit(); at the end. This way last command exit code will be
+  # correctly preserved and install script will correctly fail and abort if this
+  # command fails.
   mongo <<EOF
 use admin;
 db.createUser({
@@ -189,7 +193,6 @@ db.createUser({
         { role: "userAdminAnyDatabase", db: "admin" }
     ]
 });
-quit();
 EOF
 
   mongo <<EOF
@@ -201,7 +204,6 @@ db.createUser({
         { role: "readWrite", db: "st2" }
     ]
 });
-quit();
 EOF
 
   # Require authentication to be able to acccess the database

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -527,6 +527,10 @@ EOT"
   sleep 5
 
   # Create admin user and user used by StackStorm (MongoDB needs to be running)
+  # NOTE: mongo shell will automatically exit when piping from stdin. There is
+  # no need to put quit(); at the end. This way last command exit code will be
+  # correctly preserved and install script will correctly fail and abort if this
+  # command fails.
   mongo <<EOF
 use admin;
 db.createUser({
@@ -536,7 +540,6 @@ db.createUser({
         { role: "userAdminAnyDatabase", db: "admin" }
     ]
 });
-quit();
 EOF
 
   mongo <<EOF
@@ -548,7 +551,6 @@ db.createUser({
         { role: "readWrite", db: "st2" }
     ]
 });
-quit();
 EOF
 
   # Require authentication to be able to acccess the database

--- a/scripts/st2bootstrap-el7.template.sh
+++ b/scripts/st2bootstrap-el7.template.sh
@@ -167,6 +167,10 @@ EOT"
   sleep 5
 
   # Create admin user and user used by StackStorm (MongoDB needs to be running)
+  # NOTE: mongo shell will automatically exit when piping from stdin. There is
+  # no need to put quit(); at the end. This way last command exit code will be
+  # correctly preserved and install script will correctly fail and abort if this
+  # command fails.
   mongo <<EOF
 use admin;
 db.createUser({
@@ -176,7 +180,6 @@ db.createUser({
         { role: "userAdminAnyDatabase", db: "admin" }
     ]
 });
-quit();
 EOF
 
   mongo <<EOF
@@ -188,7 +191,6 @@ db.createUser({
         { role: "readWrite", db: "st2" }
     ]
 });
-quit();
 EOF
 
   # Require authentication to be able to acccess the database

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -527,6 +527,10 @@ EOT"
   sleep 5
 
   # Create admin user and user used by StackStorm (MongoDB needs to be running)
+  # NOTE: mongo shell will automatically exit when piping from stdin. There is
+  # no need to put quit(); at the end. This way last command exit code will be
+  # correctly preserved and install script will correctly fail and abort if this
+  # command fails.
   mongo <<EOF
 use admin;
 db.createUser({
@@ -536,7 +540,6 @@ db.createUser({
         { role: "userAdminAnyDatabase", db: "admin" }
     ]
 });
-quit();
 EOF
 
   mongo <<EOF
@@ -548,7 +551,6 @@ db.createUser({
         { role: "readWrite", db: "st2" }
     ]
 });
-quit();
 EOF
 
   # Require authentication to be able to acccess the database

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -167,6 +167,10 @@ EOT"
   sleep 5
 
   # Create admin user and user used by StackStorm (MongoDB needs to be running)
+  # NOTE: mongo shell will automatically exit when piping from stdin. There is
+  # no need to put quit(); at the end. This way last command exit code will be
+  # correctly preserved and install script will correctly fail and abort if this
+  # command fails.
   mongo <<EOF
 use admin;
 db.createUser({
@@ -176,7 +180,6 @@ db.createUser({
         { role: "userAdminAnyDatabase", db: "admin" }
     ]
 });
-quit();
 EOF
 
   mongo <<EOF
@@ -188,7 +191,6 @@ db.createUser({
         { role: "readWrite", db: "st2" }
     ]
 });
-quit();
 EOF
 
   # Require authentication to be able to acccess the database


### PR DESCRIPTION
Currently, installer script doesn't correctly fail if any of the mongo shell commands we run fails (e.g. admin user creation fails, user already exists, etc.).

This means at the end, user may end up with a broken / half configured installation.

---

This pull request fixes that by removing ``quit()`` function call.

When piping data to mongo shell, it will already exit with the correct status code, even if the ``quit()`` statement is not present.

For example:

```bash
vagrant@ubuntu-xenial:~$ bash 2.sh ; echo $?
MongoDB shell version v3.4.23
connecting to: mongodb://127.0.0.1:27017
MongoDB server version: 3.4.23
switched to db admin
2020-02-10T09:08:03.491+0000 E QUERY    [thread1] Error: couldn't add user: User "admin@admin" already exists :
_getErrorWithCode@src/mongo/shell/utils.js:25:13
DB.prototype.createUser@src/mongo/shell/db.js:1292:15
@(shell):1:1
0

vagrant@ubuntu-xenial:~$ cat 1.sh
mongo <<EOF
use admin;
db.createUser({
    user: "admin",
    pwd: "wwq",
    roles: [
        { role: "userAdminAnyDatabase", db: "admin" }
    ]
});
EOF
vagrant@ubuntu-xenial:~$ bash 1.sh ; echo $?
MongoDB shell version v3.4.23
connecting to: mongodb://127.0.0.1:27017
MongoDB server version: 3.4.23
switched to db admin
2020-02-10T09:09:29.551+0000 E QUERY    [thread1] Error: couldn't add user: User "admin@admin" already exists :
_getErrorWithCode@src/mongo/shell/utils.js:25:13
DB.prototype.createUser@src/mongo/shell/db.js:1292:15
@(shell):1:1
bye
1
```
 