### PR TITLE
fix RHMAJVER on direct run

### DIFF
--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -135,24 +135,15 @@ configure_st2_user () {
 
   SYSTEM_HOME=$(echo ~stanley)
 
-  sudo mkdir -p ${SYSTEM_HOME}/.ssh
-  if [[ -f 'etc/redhat-release' ]]; then
-    RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-  else
-    RHMAJVER=''
-  fi
+
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '7' ]]; then
-      PEM="-m PEM"
-    elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
-      # PEM flag not present in ssh-keygen version in EL6
-      PEM=""
-    fi
-    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
+    # Hotfix for EL6 which doesn't have '-m' param for ssh-keygen
+    # TODO: Revert once EL6 is deprecated, may need testing
+    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" -m PEM || sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P ""
   fi
 
   if ! sudo grep -s -q -f ${SYSTEM_HOME}/.ssh/stanley_rsa.pub ${SYSTEM_HOME}/.ssh/authorized_keys;

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -146,7 +146,7 @@ configure_st2_user () {
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '8' ]]; then
+    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '7' ]]; then
       PEM="-m PEM"
     elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
       # PEM flag not present in ssh-keygen version in EL6

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -136,15 +136,19 @@ configure_st2_user () {
   SYSTEM_HOME=$(echo ~stanley)
 
   sudo mkdir -p ${SYSTEM_HOME}/.ssh
-
+  if [[ -f 'etc/redhat-release' ]]; then
+    RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
+  else
+    RHMAJVER=''
+  fi
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" != '6' ]]; then
+    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '8' ]]; then
       PEM="-m PEM"
-    else
+    elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
       # PEM flag not present in ssh-keygen version in EL6
       PEM=""
     fi

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -253,24 +253,15 @@ configure_st2_user () {
 
   SYSTEM_HOME=$(echo ~stanley)
 
-  sudo mkdir -p ${SYSTEM_HOME}/.ssh
-  if [[ -f 'etc/redhat-release' ]]; then
-    RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-  else
-    RHMAJVER=''
-  fi
+
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '7' ]]; then
-      PEM="-m PEM"
-    elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
-      # PEM flag not present in ssh-keygen version in EL6
-      PEM=""
-    fi
-    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
+    # Hotfix for EL6 which doesn't have '-m' param for ssh-keygen
+    # TODO: Revert once EL6 is deprecated, may need testing
+    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" -m PEM || sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P ""
   fi
 
   if ! sudo grep -s -q -f ${SYSTEM_HOME}/.ssh/stanley_rsa.pub ${SYSTEM_HOME}/.ssh/authorized_keys;

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -116,7 +116,6 @@ setup_args() {
 }
 
 
-#!/usr/bin/env bash
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
@@ -265,9 +264,9 @@ configure_st2_user () {
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '8' ]]; then
+    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '7' ]]; then
       PEM="-m PEM"
-    elif [[ "$RHMAJVER" = '6' ]]; then
+    elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
       # PEM flag not present in ssh-keygen version in EL6
       PEM=""
     fi

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -116,6 +116,7 @@ setup_args() {
 }
 
 
+#!/usr/bin/env bash
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
@@ -254,15 +255,19 @@ configure_st2_user () {
   SYSTEM_HOME=$(echo ~stanley)
 
   sudo mkdir -p ${SYSTEM_HOME}/.ssh
-
+  if [[ -f 'etc/redhat-release' ]]; then
+    RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
+  else
+    RHMAJVER=''
+  fi
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" != '6' ]]; then
+    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '8' ]]; then
       PEM="-m PEM"
-    else
+    elif [[ "$RHMAJVER" = '6' ]]; then
       # PEM flag not present in ssh-keygen version in EL6
       PEM=""
     fi

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -110,6 +110,7 @@ setup_args() {
 }
 
 
+#!/usr/bin/env bash
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
@@ -248,15 +249,19 @@ configure_st2_user () {
   SYSTEM_HOME=$(echo ~stanley)
 
   sudo mkdir -p ${SYSTEM_HOME}/.ssh
-
+  if [[ -f 'etc/redhat-release' ]]; then
+    RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
+  else
+    RHMAJVER=''
+  fi
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" != '6' ]]; then
+    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '8' ]]; then
       PEM="-m PEM"
-    else
+    elif [[ "$RHMAJVER" = '6' ]]; then
       # PEM flag not present in ssh-keygen version in EL6
       PEM=""
     fi

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -110,7 +110,6 @@ setup_args() {
 }
 
 
-#!/usr/bin/env bash
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
@@ -259,9 +258,9 @@ configure_st2_user () {
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '8' ]]; then
+    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '7' ]]; then
       PEM="-m PEM"
-    elif [[ "$RHMAJVER" = '6' ]]; then
+    elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
       # PEM flag not present in ssh-keygen version in EL6
       PEM=""
     fi

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -247,24 +247,15 @@ configure_st2_user () {
 
   SYSTEM_HOME=$(echo ~stanley)
 
-  sudo mkdir -p ${SYSTEM_HOME}/.ssh
-  if [[ -f 'etc/redhat-release' ]]; then
-    RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-  else
-    RHMAJVER=''
-  fi
+
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '7' ]]; then
-      PEM="-m PEM"
-    elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
-      # PEM flag not present in ssh-keygen version in EL6
-      PEM=""
-    fi
-    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
+    # Hotfix for EL6 which doesn't have '-m' param for ssh-keygen
+    # TODO: Revert once EL6 is deprecated, may need testing
+    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" -m PEM || sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P ""
   fi
 
   if ! sudo grep -s -q -f ${SYSTEM_HOME}/.ssh/stanley_rsa.pub ${SYSTEM_HOME}/.ssh/authorized_keys;

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -110,6 +110,7 @@ setup_args() {
 }
 
 
+#!/usr/bin/env bash
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
@@ -248,15 +249,19 @@ configure_st2_user () {
   SYSTEM_HOME=$(echo ~stanley)
 
   sudo mkdir -p ${SYSTEM_HOME}/.ssh
-
+  if [[ -f 'etc/redhat-release' ]]; then
+    RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
+  else
+    RHMAJVER=''
+  fi
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" != '6' ]]; then
+    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '8' ]]; then
       PEM="-m PEM"
-    else
+    elif [[ "$RHMAJVER" = '6' ]]; then
       # PEM flag not present in ssh-keygen version in EL6
       PEM=""
     fi

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -110,7 +110,6 @@ setup_args() {
 }
 
 
-#!/usr/bin/env bash
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
@@ -259,9 +258,9 @@ configure_st2_user () {
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '8' ]]; then
+    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '7' ]]; then
       PEM="-m PEM"
-    elif [[ "$RHMAJVER" = '6' ]]; then
+    elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
       # PEM flag not present in ssh-keygen version in EL6
       PEM=""
     fi

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -247,24 +247,15 @@ configure_st2_user () {
 
   SYSTEM_HOME=$(echo ~stanley)
 
-  sudo mkdir -p ${SYSTEM_HOME}/.ssh
-  if [[ -f 'etc/redhat-release' ]]; then
-    RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-  else
-    RHMAJVER=''
-  fi
+
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '7' ]]; then
-      PEM="-m PEM"
-    elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
-      # PEM flag not present in ssh-keygen version in EL6
-      PEM=""
-    fi
-    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
+    # Hotfix for EL6 which doesn't have '-m' param for ssh-keygen
+    # TODO: Revert once EL6 is deprecated, may need testing
+    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" -m PEM || sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P ""
   fi
 
   if ! sudo grep -s -q -f ${SYSTEM_HOME}/.ssh/stanley_rsa.pub ${SYSTEM_HOME}/.ssh/authorized_keys;

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -113,7 +113,6 @@ setup_args() {
 }
 
 
-#!/usr/bin/env bash
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
@@ -262,9 +261,9 @@ configure_st2_user () {
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '8' ]]; then
+    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '7' ]]; then
       PEM="-m PEM"
-    elif [[ "$RHMAJVER" = '6' ]]; then
+    elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
       # PEM flag not present in ssh-keygen version in EL6
       PEM=""
     fi

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -250,24 +250,15 @@ configure_st2_user () {
 
   SYSTEM_HOME=$(echo ~stanley)
 
-  sudo mkdir -p ${SYSTEM_HOME}/.ssh
-  if [[ -f 'etc/redhat-release' ]]; then
-    RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-  else
-    RHMAJVER=''
-  fi
+
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '7' ]]; then
-      PEM="-m PEM"
-    elif [[ "$RHMAJVER" = '6' ]] || [[ -z "$RHMAJVER" ]]; then
-      # PEM flag not present in ssh-keygen version in EL6
-      PEM=""
-    fi
-    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" ${PEM}
+    # Hotfix for EL6 which doesn't have '-m' param for ssh-keygen
+    # TODO: Revert once EL6 is deprecated, may need testing
+    sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P "" -m PEM || sudo ssh-keygen -f ${SYSTEM_HOME}/.ssh/stanley_rsa -P ""
   fi
 
   if ! sudo grep -s -q -f ${SYSTEM_HOME}/.ssh/stanley_rsa.pub ${SYSTEM_HOME}/.ssh/authorized_keys;

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -113,6 +113,7 @@ setup_args() {
 }
 
 
+#!/usr/bin/env bash
 function configure_proxy() {
   # Allow bypassing 'proxy' env vars via sudo
   local sudoers_proxy='Defaults env_keep += "http_proxy https_proxy no_proxy proxy_ca_bundle_path DEBIAN_FRONTEND"'
@@ -251,15 +252,19 @@ configure_st2_user () {
   SYSTEM_HOME=$(echo ~stanley)
 
   sudo mkdir -p ${SYSTEM_HOME}/.ssh
-
+  if [[ -f 'etc/redhat-release' ]]; then
+    RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
+  else
+    RHMAJVER=''
+  fi
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
   # to be generated again.
   if ! sudo test -s ${SYSTEM_HOME}/.ssh/stanley_rsa; then
     # added PEM to enforce PEM ssh key type in EL8 to maintain consistency
-    if [[ "$RHMAJVER" != '6' ]]; then
+    if [[ "$RHMAJVER" = '8' ]] || [[ "$RHMAJVER" = '8' ]]; then
       PEM="-m PEM"
-    else
+    elif [[ "$RHMAJVER" = '6' ]]; then
       # PEM flag not present in ssh-keygen version in EL6
       PEM=""
     fi


### PR DESCRIPTION
* implents an or `||` to try and use ssh-keygen with and without the -P PEM option to accomodate EL6 vs EL7-8, and U16-20.