### PR TITLE
Various fixes to the el8 installer script

### DIFF
--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -136,7 +136,8 @@ configure_st2_user () {
   SYSTEM_HOME=$(echo ~stanley)
 
   if [ ! -d "${SYSTEM_HOME}/.ssh" ]; then
-  	sudo mkdir ${SYSTEM_HOME}/.ssh
+    sudo mkdir ${SYSTEM_HOME}/.ssh
+    sudo chmod 700 ${SYSTEM_HOME}/.ssh
   fi
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.

--- a/scripts/includes/common.sh
+++ b/scripts/includes/common.sh
@@ -135,6 +135,9 @@ configure_st2_user () {
 
   SYSTEM_HOME=$(echo ~stanley)
 
+  if [ ! -d "${SYSTEM_HOME}/.ssh" ]; then
+  	sudo mkdir ${SYSTEM_HOME}/.ssh
+  fi
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need

--- a/scripts/includes/rhel.sh
+++ b/scripts/includes/rhel.sh
@@ -9,34 +9,34 @@ install_yum_utils() {
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
-    local ST2_VER=$(repoquery --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2_VER=$(repoquery -y --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery --nvr --show-duplicates st2
+      sudo repoquery -y --nvr --show-duplicates st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local ST2MISTRAL_VER=$(repoquery --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2MISTRAL_VER" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery --nvr --show-duplicates st2mistral
+      sudo repoquery -y --nvr --show-duplicates st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery -y --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery --nvr --show-duplicates st2web
+      sudo repoquery -y --nvr --show-duplicates st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery -y --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery --nvr --show-duplicates st2chatops
+      sudo repoquery -y --nvr --show-duplicates st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -253,6 +253,9 @@ configure_st2_user () {
 
   SYSTEM_HOME=$(echo ~stanley)
 
+  if [ ! -d "${SYSTEM_HOME}/.ssh" ]; then
+  	sudo mkdir ${SYSTEM_HOME}/.ssh
+  fi
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -254,7 +254,8 @@ configure_st2_user () {
   SYSTEM_HOME=$(echo ~stanley)
 
   if [ ! -d "${SYSTEM_HOME}/.ssh" ]; then
-  	sudo mkdir ${SYSTEM_HOME}/.ssh
+    sudo mkdir ${SYSTEM_HOME}/.ssh
+    sudo chmod 700 ${SYSTEM_HOME}/.ssh
   fi
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -247,6 +247,9 @@ configure_st2_user () {
 
   SYSTEM_HOME=$(echo ~stanley)
 
+  if [ ! -d "${SYSTEM_HOME}/.ssh" ]; then
+  	sudo mkdir ${SYSTEM_HOME}/.ssh
+  fi
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
@@ -424,34 +427,34 @@ install_yum_utils() {
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
-    local ST2_VER=$(repoquery --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2_VER=$(repoquery -y --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery --nvr --show-duplicates st2
+      sudo repoquery -y --nvr --show-duplicates st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local ST2MISTRAL_VER=$(repoquery --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2MISTRAL_VER" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery --nvr --show-duplicates st2mistral
+      sudo repoquery -y --nvr --show-duplicates st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery -y --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery --nvr --show-duplicates st2web
+      sudo repoquery -y --nvr --show-duplicates st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery -y --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery --nvr --show-duplicates st2chatops
+      sudo repoquery -y --nvr --show-duplicates st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -248,7 +248,8 @@ configure_st2_user () {
   SYSTEM_HOME=$(echo ~stanley)
 
   if [ ! -d "${SYSTEM_HOME}/.ssh" ]; then
-  	sudo mkdir ${SYSTEM_HOME}/.ssh
+    sudo mkdir ${SYSTEM_HOME}/.ssh
+    sudo chmod 700 ${SYSTEM_HOME}/.ssh
   fi
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -247,6 +247,9 @@ configure_st2_user () {
 
   SYSTEM_HOME=$(echo ~stanley)
 
+  if [ ! -d "${SYSTEM_HOME}/.ssh" ]; then
+  	sudo mkdir ${SYSTEM_HOME}/.ssh
+  fi
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
@@ -424,34 +427,34 @@ install_yum_utils() {
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
-    local ST2_VER=$(repoquery --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2_VER=$(repoquery -y --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery --nvr --show-duplicates st2
+      sudo repoquery -y --nvr --show-duplicates st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local ST2MISTRAL_VER=$(repoquery --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2MISTRAL_VER" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery --nvr --show-duplicates st2mistral
+      sudo repoquery -y --nvr --show-duplicates st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery -y --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery --nvr --show-duplicates st2web
+      sudo repoquery -y --nvr --show-duplicates st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery -y --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery --nvr --show-duplicates st2chatops
+      sudo repoquery -y --nvr --show-duplicates st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -248,7 +248,8 @@ configure_st2_user () {
   SYSTEM_HOME=$(echo ~stanley)
 
   if [ ! -d "${SYSTEM_HOME}/.ssh" ]; then
-  	sudo mkdir ${SYSTEM_HOME}/.ssh
+    sudo mkdir ${SYSTEM_HOME}/.ssh
+    sudo chmod 700 ${SYSTEM_HOME}/.ssh
   fi
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -250,6 +250,9 @@ configure_st2_user () {
 
   SYSTEM_HOME=$(echo ~stanley)
 
+  if [ ! -d "${SYSTEM_HOME}/.ssh" ]; then
+  	sudo mkdir ${SYSTEM_HOME}/.ssh
+  fi
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.
   # NOTE: If the file already exists and is non-empty, then assume the key does not need
@@ -427,34 +430,34 @@ install_yum_utils() {
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
-    local ST2_VER=$(repoquery --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2_VER=$(repoquery -y --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery --nvr --show-duplicates st2
+      sudo repoquery -y --nvr --show-duplicates st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local ST2MISTRAL_VER=$(repoquery --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2MISTRAL_VER" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery --nvr --show-duplicates st2mistral
+      sudo repoquery -y --nvr --show-duplicates st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery -y --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery --nvr --show-duplicates st2web
+      sudo repoquery -y --nvr --show-duplicates st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery -y --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery --nvr --show-duplicates st2chatops
+      sudo repoquery -y --nvr --show-duplicates st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -251,7 +251,8 @@ configure_st2_user () {
   SYSTEM_HOME=$(echo ~stanley)
 
   if [ ! -d "${SYSTEM_HOME}/.ssh" ]; then
-  	sudo mkdir ${SYSTEM_HOME}/.ssh
+    sudo mkdir ${SYSTEM_HOME}/.ssh
+    sudo chmod 700 ${SYSTEM_HOME}/.ssh
   fi
 
   # Generate ssh keys on StackStorm box and copy over public key into remote box.


### PR DESCRIPTION
Add -y to flag to the repoquery commands so that it doesn't prompt for y/ok during the install. Currently, it prompts for y/ok silently and the installer script will hang awhile and then fail. Create the .ssh directory for the stanley user if it does not exists.