### PR TITLE
Skip st2mistral check for el8 installer

### DIFF
--- a/scripts/includes/rhel.sh
+++ b/scripts/includes/rhel.sh
@@ -17,8 +17,9 @@ get_full_pkg_versions() {
     fi
     ST2_PKG=${ST2_VER}
 
+    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
     local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2MISTRAL_VER" ]; then
+    if [ -z "$ST2MISTRAL_VER" && "$RHMAJVER" != '8' ]; then
       echo "Could not find requested version of st2mistral!!!"
       sudo repoquery -y --nvr --show-duplicates st2mistral
       exit 3

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -436,8 +436,9 @@ get_full_pkg_versions() {
     fi
     ST2_PKG=${ST2_VER}
 
+    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
     local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2MISTRAL_VER" ]; then
+    if [ -z "$ST2MISTRAL_VER" && "$RHMAJVER" != '8' ]; then
       echo "Could not find requested version of st2mistral!!!"
       sudo repoquery -y --nvr --show-duplicates st2mistral
       exit 3

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -436,8 +436,9 @@ get_full_pkg_versions() {
     fi
     ST2_PKG=${ST2_VER}
 
+    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
     local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2MISTRAL_VER" ]; then
+    if [ -z "$ST2MISTRAL_VER" && "$RHMAJVER" != '8' ]; then
       echo "Could not find requested version of st2mistral!!!"
       sudo repoquery -y --nvr --show-duplicates st2mistral
       exit 3

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -439,8 +439,9 @@ get_full_pkg_versions() {
     fi
     ST2_PKG=${ST2_VER}
 
+    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
     local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2MISTRAL_VER" ]; then
+    if [ -z "$ST2MISTRAL_VER" && "$RHMAJVER" != '8' ]; then
       echo "Could not find requested version of st2mistral!!!"
       sudo repoquery -y --nvr --show-duplicates st2mistral
       exit 3


### PR DESCRIPTION
The package st2mistral is not supported on el8 because st2 runs on python3 and the StackStorm fork is not tested on python3. The RHEL installer script is modified to ignore the st2mistral warning for RHEL8.