### PR TITLE
Fixing RHEL 6 and 7 not having repoquery -y

### DIFF
--- a/scripts/includes/rhel.sh
+++ b/scripts/includes/rhel.sh
@@ -26,7 +26,7 @@ get_full_pkg_versions() {
 
     local ST2MISTRAL_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     # RHEL 8 and newer does not install Mistral
-    if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
+    if [[ -z "$ST2MISTRAL_VER" && "$RHMAJVER" -lt "8" ]]; then
       echo "Could not find requested version of st2mistral!!!"
       sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral
       exit 3

--- a/scripts/includes/rhel.sh
+++ b/scripts/includes/rhel.sh
@@ -9,35 +9,42 @@ install_yum_utils() {
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
-    local ST2_VER=$(repoquery -y --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
+    local REPOQUERY_FLAGS="--nvr --show-duplicates"
+    if [ "$RHMAJVER" -ge "8" ]; then
+      # RHEL 8 and newer, you need "-y" flag to avoid being prompted to confirm "yes"
+      local REPOQUERY_FLAGS="-y ${REPOQUERY_FLAGS}"
+    fi
+
+    local ST2_VER=$(repoquery ${REPOQUERY_FLAGS} st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery -y --nvr --show-duplicates st2
+      sudo repoquery ${REPOQUERY_FLAGS} st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-    local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2MISTRAL_VER" && "$RHMAJVER" != '8' ]; then
+    local ST2MISTRAL_VER=$(repoquery ${REPOQUERY_FLAGS} st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    # RHEL 8 and newer does not install Mistral
+    if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery -y --nvr --show-duplicates st2mistral
+      sudo repoquery ${REPOQUERY_FLAGS} st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery -y --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery ${REPOQUERY_FLAGS} st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery -y --nvr --show-duplicates st2web
+      sudo repoquery ${REPOQUERY_FLAGS} st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery -y --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery ${REPOQUERY_FLAGS} st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery -y --nvr --show-duplicates st2chatops
+      sudo repoquery ${REPOQUERY_FLAGS} st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/includes/rhel.sh
+++ b/scripts/includes/rhel.sh
@@ -10,41 +10,41 @@ get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
     local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-    local REPOQUERY_FLAGS="--nvr --show-duplicates"
+    local YES_FLAG=""
     if [ "$RHMAJVER" -ge "8" ]; then
       # RHEL 8 and newer, you need "-y" flag to avoid being prompted to confirm "yes"
-      local REPOQUERY_FLAGS="-y ${REPOQUERY_FLAGS}"
+      local YES_FLAG="-y"
     fi
 
-    local ST2_VER=$(repoquery ${REPOQUERY_FLAGS} st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery ${REPOQUERY_FLAGS} st2
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local ST2MISTRAL_VER=$(repoquery ${REPOQUERY_FLAGS} st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2MISTRAL_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     # RHEL 8 and newer does not install Mistral
     if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery ${REPOQUERY_FLAGS} st2mistral
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery ${REPOQUERY_FLAGS} st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery ${REPOQUERY_FLAGS} st2web
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery ${REPOQUERY_FLAGS} st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery ${REPOQUERY_FLAGS} st2chatops
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -428,35 +428,42 @@ install_yum_utils() {
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
-    local ST2_VER=$(repoquery -y --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
+    local REPOQUERY_FLAGS="--nvr --show-duplicates"
+    if [ "$RHMAJVER" -ge "8" ]; then
+      # RHEL 8 and newer, you need "-y" flag to avoid being prompted to confirm "yes"
+      local REPOQUERY_FLAGS="-y ${REPOQUERY_FLAGS}"
+    fi
+
+    local ST2_VER=$(repoquery ${REPOQUERY_FLAGS} st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery -y --nvr --show-duplicates st2
+      sudo repoquery ${REPOQUERY_FLAGS} st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-    local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2MISTRAL_VER" && "$RHMAJVER" != '8' ]; then
+    local ST2MISTRAL_VER=$(repoquery ${REPOQUERY_FLAGS} st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    # RHEL 8 and newer does not install Mistral
+    if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery -y --nvr --show-duplicates st2mistral
+      sudo repoquery ${REPOQUERY_FLAGS} st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery -y --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery ${REPOQUERY_FLAGS} st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery -y --nvr --show-duplicates st2web
+      sudo repoquery ${REPOQUERY_FLAGS} st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery -y --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery ${REPOQUERY_FLAGS} st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery -y --nvr --show-duplicates st2chatops
+      sudo repoquery ${REPOQUERY_FLAGS} st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -429,41 +429,41 @@ get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
     local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-    local REPOQUERY_FLAGS="--nvr --show-duplicates"
+    local YES_FLAG=""
     if [ "$RHMAJVER" -ge "8" ]; then
       # RHEL 8 and newer, you need "-y" flag to avoid being prompted to confirm "yes"
-      local REPOQUERY_FLAGS="-y ${REPOQUERY_FLAGS}"
+      local YES_FLAG="-y"
     fi
 
-    local ST2_VER=$(repoquery ${REPOQUERY_FLAGS} st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery ${REPOQUERY_FLAGS} st2
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local ST2MISTRAL_VER=$(repoquery ${REPOQUERY_FLAGS} st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2MISTRAL_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     # RHEL 8 and newer does not install Mistral
     if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery ${REPOQUERY_FLAGS} st2mistral
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery ${REPOQUERY_FLAGS} st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery ${REPOQUERY_FLAGS} st2web
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery ${REPOQUERY_FLAGS} st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery ${REPOQUERY_FLAGS} st2chatops
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/st2bootstrap-el6.sh
+++ b/scripts/st2bootstrap-el6.sh
@@ -445,7 +445,7 @@ get_full_pkg_versions() {
 
     local ST2MISTRAL_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     # RHEL 8 and newer does not install Mistral
-    if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
+    if [[ -z "$ST2MISTRAL_VER" && "$RHMAJVER" -lt "8" ]]; then
       echo "Could not find requested version of st2mistral!!!"
       sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral
       exit 3

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -428,35 +428,42 @@ install_yum_utils() {
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
-    local ST2_VER=$(repoquery -y --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
+    local REPOQUERY_FLAGS="--nvr --show-duplicates"
+    if [ "$RHMAJVER" -ge "8" ]; then
+      # RHEL 8 and newer, you need "-y" flag to avoid being prompted to confirm "yes"
+      local REPOQUERY_FLAGS="-y ${REPOQUERY_FLAGS}"
+    fi
+
+    local ST2_VER=$(repoquery ${REPOQUERY_FLAGS} st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery -y --nvr --show-duplicates st2
+      sudo repoquery ${REPOQUERY_FLAGS} st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-    local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2MISTRAL_VER" && "$RHMAJVER" != '8' ]; then
+    local ST2MISTRAL_VER=$(repoquery ${REPOQUERY_FLAGS} st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    # RHEL 8 and newer does not install Mistral
+    if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery -y --nvr --show-duplicates st2mistral
+      sudo repoquery ${REPOQUERY_FLAGS} st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery -y --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery ${REPOQUERY_FLAGS} st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery -y --nvr --show-duplicates st2web
+      sudo repoquery ${REPOQUERY_FLAGS} st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery -y --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery ${REPOQUERY_FLAGS} st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery -y --nvr --show-duplicates st2chatops
+      sudo repoquery ${REPOQUERY_FLAGS} st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -429,41 +429,41 @@ get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
     local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-    local REPOQUERY_FLAGS="--nvr --show-duplicates"
+    local YES_FLAG=""
     if [ "$RHMAJVER" -ge "8" ]; then
       # RHEL 8 and newer, you need "-y" flag to avoid being prompted to confirm "yes"
-      local REPOQUERY_FLAGS="-y ${REPOQUERY_FLAGS}"
+      local YES_FLAG="-y"
     fi
 
-    local ST2_VER=$(repoquery ${REPOQUERY_FLAGS} st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery ${REPOQUERY_FLAGS} st2
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local ST2MISTRAL_VER=$(repoquery ${REPOQUERY_FLAGS} st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2MISTRAL_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     # RHEL 8 and newer does not install Mistral
     if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery ${REPOQUERY_FLAGS} st2mistral
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery ${REPOQUERY_FLAGS} st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery ${REPOQUERY_FLAGS} st2web
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery ${REPOQUERY_FLAGS} st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery ${REPOQUERY_FLAGS} st2chatops
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -445,7 +445,7 @@ get_full_pkg_versions() {
 
     local ST2MISTRAL_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     # RHEL 8 and newer does not install Mistral
-    if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
+    if [[ -z "$ST2MISTRAL_VER" && "$RHMAJVER" -lt "8" ]]; then
       echo "Could not find requested version of st2mistral!!!"
       sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral
       exit 3

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -448,7 +448,7 @@ get_full_pkg_versions() {
 
     local ST2MISTRAL_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     # RHEL 8 and newer does not install Mistral
-    if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
+    if [[ -z "$ST2MISTRAL_VER" && "$RHMAJVER" -lt "8" ]]; then
       echo "Could not find requested version of st2mistral!!!"
       sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral
       exit 3

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -432,41 +432,41 @@ get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
     local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-    local REPOQUERY_FLAGS="--nvr --show-duplicates"
+    local YES_FLAG=""
     if [ "$RHMAJVER" -ge "8" ]; then
       # RHEL 8 and newer, you need "-y" flag to avoid being prompted to confirm "yes"
-      local REPOQUERY_FLAGS="-y ${REPOQUERY_FLAGS}"
+      local YES_FLAG="-y"
     fi
 
-    local ST2_VER=$(repoquery ${REPOQUERY_FLAGS} st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery ${REPOQUERY_FLAGS} st2
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local ST2MISTRAL_VER=$(repoquery ${REPOQUERY_FLAGS} st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2MISTRAL_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
     # RHEL 8 and newer does not install Mistral
     if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery ${REPOQUERY_FLAGS} st2mistral
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery ${REPOQUERY_FLAGS} st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery ${REPOQUERY_FLAGS} st2web
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery ${REPOQUERY_FLAGS} st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery ${YES_FLAG} --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery ${REPOQUERY_FLAGS} st2chatops
+      sudo repoquery ${YES_FLAG} --nvr --show-duplicates st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -431,35 +431,42 @@ install_yum_utils() {
 get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
-    local ST2_VER=$(repoquery -y --nvr --show-duplicates st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
+    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
+    local REPOQUERY_FLAGS="--nvr --show-duplicates"
+    if [ "$RHMAJVER" -ge "8" ]; then
+      # RHEL 8 and newer, you need "-y" flag to avoid being prompted to confirm "yes"
+      local REPOQUERY_FLAGS="-y ${REPOQUERY_FLAGS}"
+    fi
+
+    local ST2_VER=$(repoquery ${REPOQUERY_FLAGS} st2 | grep -F st2-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2_VER" ]; then
       echo "Could not find requested version of st2!!!"
-      sudo repoquery -y --nvr --show-duplicates st2
+      sudo repoquery ${REPOQUERY_FLAGS} st2
       exit 3
     fi
     ST2_PKG=${ST2_VER}
 
-    local RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
-    local ST2MISTRAL_VER=$(repoquery -y --nvr --show-duplicates st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2MISTRAL_VER" && "$RHMAJVER" != '8' ]; then
+    local ST2MISTRAL_VER=$(repoquery ${REPOQUERY_FLAGS} st2mistral | grep -F st2mistral-${VERSION} | sort --version-sort | tail -n 1)
+    # RHEL 8 and newer does not install Mistral
+    if [ -z "$ST2MISTRAL_VER" -a "$RHMAJVER" -lt "8" ]; then
       echo "Could not find requested version of st2mistral!!!"
-      sudo repoquery -y --nvr --show-duplicates st2mistral
+      sudo repoquery ${REPOQUERY_FLAGS} st2mistral
       exit 3
     fi
     ST2MISTRAL_PKG=${ST2MISTRAL_VER}
 
-    local ST2WEB_VER=$(repoquery -y --nvr --show-duplicates st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2WEB_VER=$(repoquery ${REPOQUERY_FLAGS} st2web | grep -F st2web-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2WEB_VER" ]; then
       echo "Could not find requested version of st2web."
-      sudo repoquery -y --nvr --show-duplicates st2web
+      sudo repoquery ${REPOQUERY_FLAGS} st2web
       exit 3
     fi
     ST2WEB_PKG=${ST2WEB_VER}
 
-    local ST2CHATOPS_VER=$(repoquery -y --nvr --show-duplicates st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
+    local ST2CHATOPS_VER=$(repoquery ${REPOQUERY_FLAGS} st2chatops | grep -F st2chatops-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$ST2CHATOPS_VER" ]; then
       echo "Could not find requested version of st2chatops."
-      sudo repoquery -y --nvr --show-duplicates st2chatops
+      sudo repoquery ${REPOQUERY_FLAGS} st2chatops
       exit 3
     fi
     ST2CHATOPS_PKG=${ST2CHATOPS_VER}


### PR DESCRIPTION
Closes #641 

Moves the `RHMAJVER` test to the top of the function.

Based on the `RHMAJVER` it adds in the `-y` flag for `repoquery`

Also fixed a bug in the Mistral test where we were using `&&` inside of single brackets instead of `-a` for logical AND.

**Testing steps - CentOS 7**
(assumes fresh CentOS 7 VM)
```bash
$ sudo yum -y install wget
$ wget https://raw.githubusercontent.com/nmaludy/st2-packages/bugfix/rhel-6-7-repoquery/scripts/st2bootstrap-el7.sh
$ chmod a+x ./st2bootstrap-el7.sh
$ sudo bash st2bootstrap-el7.sh --version=3.1dev --unstable   --user=st2admin --password=Ch@ngeMe
```

**Testing steps - CentOS 8**
(assumes fresh CentOS 8 VM)
```bash
$ sudo yum -y install wget
$ wget https://raw.githubusercontent.com/nmaludy/st2-packages/bugfix/rhel-6-7-repoquery/scripts/st2bootstrap-el8.sh
$ chmod a+x ./st2bootstrap-el8.sh
$ sudo bash st2bootstrap-el8.sh --version=3.2dev --unstable   --user=st2admin --password=Ch@ngeMe
```