### PR TITLE
Add -y option to yum list http-parser command

### DIFF
--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -692,7 +692,7 @@ EOT"
 
 install_st2chatops() {
   # Temporary hack until proper upstream fix https://bugs.centos.org/view.php?id=13669
-  if ! yum list http-parser 1>/dev/null 2>&1; then
+  if ! yum -y list http-parser 1>/dev/null 2>&1; then
     sudo yum install -y http://repo.okay.com.mx/centos/8/x86_64/release//http-parser-2.8.0-2.el8.x86_64.rpm
   fi
 

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -318,7 +318,7 @@ EOT"
 
 install_st2chatops() {
   # Temporary hack until proper upstream fix https://bugs.centos.org/view.php?id=13669
-  if ! yum list http-parser 1>/dev/null 2>&1; then
+  if ! yum -y list http-parser 1>/dev/null 2>&1; then
     sudo yum install -y http://repo.okay.com.mx/centos/8/x86_64/release//http-parser-2.8.0-2.el8.x86_64.rpm
   fi
 


### PR DESCRIPTION
Add the -y option to the yum list http-parser command during st2chatops install to prevent install script from hanging while waiting for user to answer prompt.