### PR TITLE
Fix scripted EL6 stable installation

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -152,7 +152,7 @@ if [[ -n "$RHTEST" ]]; then
   echo "*** Detected Distro is ${RHTEST} ***"
   RHMAJVER=`cat /etc/redhat-release | sed 's/[^0-9.]*\([0-9.]\).*/\1/'`
   echo "*** Detected distro version ${RHMAJVER} ***"
-  if [[ "$RHMAJVER" != '7' && "$RHMAJVER" != '8' ]]; then
+  if [[ "$RHMAJVER" != '6' && "$RHMAJVER" != '7' && "$RHMAJVER" != '8' ]]; then
     echo "Unsupported distro version $RHMAJVER! Aborting!"
     exit 2
   fi


### PR DESCRIPTION
Fix regression introduced in https://github.com/StackStorm/st2-packages/pull/654 based on my review in that PR.

We're about to remove EL6 support.
While we can rely on a stable `v3.2` branch and individual OS scripts depending on expected st2 version to install
https://github.com/StackStorm/st2-packages/blob/01b90f67068f850365f31d44f5a7d214bd5fd08d/scripts/st2_bootstrap.sh#L17-L18
we don't follow versioning for the entry `st2_bootstrap.sh` script.
