### PR TITLE
Add strip to .so libraries

### DIFF
--- a/packages/st2/rpm/st2.spec
+++ b/packages/st2/rpm/st2.spec
@@ -50,7 +50,7 @@ Conflicts: st2common
 # We build cryptography for EL8, and this can contain buildroot path in the
 # built .so files. We use strip on these libraries so that there are no
 # references to the buildroot in the st2 rpm
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} == 8
   %cleanup_so_abspath
 %endif
   %cleanup_python_abspath

--- a/packages/st2/rpm/st2.spec
+++ b/packages/st2/rpm/st2.spec
@@ -47,7 +47,12 @@ Conflicts: st2common
   %service_install st2scheduler
   make post_install DESTDIR=%{buildroot}
 
+# We build cryptography for EL8, and this can contain buildroot path in the
+# built .so files. We use strip on these libraries so that there are no
+# references to the buildroot in the st2 rpm
+%if 0%{?rhel} >= 8
   %cleanup_so_abspath
+%endif
   %cleanup_python_abspath
 
 %prep

--- a/packages/st2/rpm/st2.spec
+++ b/packages/st2/rpm/st2.spec
@@ -47,6 +47,7 @@ Conflicts: st2common
   %service_install st2scheduler
   make post_install DESTDIR=%{buildroot}
 
+  %cleanup_so_abspath
   %cleanup_python_abspath
 
 %prep

--- a/rpmspec/helpers.spec
+++ b/rpmspec/helpers.spec
@@ -40,6 +40,11 @@
       xargs -I{} -n1 sed -i 's@%{buildroot}@@' {} \
 %{nil}
 
+#Cleanup .so files that may contain buildroot
+%define cleanup_so_abspath \
+   find %{venv_dir}/lib -type f -name "*.so" | xargs -r strip \
+%{nil}
+
 # Define use_systemd to know if we on a systemd system
 #
 %if 0%{?_unitdir:1}
@@ -56,6 +61,7 @@
   %define st2pkg_version %(python -c "from %{package} import __version__; print(__version__),")
 %endif  # if rhel8
 %endif  # st2 package version parsing
+
 
 # Redefine and to drop python brp bytecompile
 #

--- a/rpmspec/helpers.spec
+++ b/rpmspec/helpers.spec
@@ -40,9 +40,10 @@
       xargs -I{} -n1 sed -i 's@%{buildroot}@@' {} \
 %{nil}
 
-#Cleanup .so files that may contain buildroot
+#Cleanup .so files that contain buildroot
 %define cleanup_so_abspath \
-   find %{venv_dir}/lib -type f -name "*.so" | xargs -r strip \
+   for f in `find %{venv_dir}/lib -type f -name "*.so" | \
+      xargs grep -l %{buildroot} `; do strip $f; done \
 %{nil}
 
 # Define use_systemd to know if we on a systemd system


### PR DESCRIPTION
For some reason based on https://app.circleci.com/pipelines/github/StackStorm/st2/374/workflows/6bb47baf-c2a5-4b11-be22-5f86e318d9f9/jobs/11646 a few  `.so` files for  `EL8` rpm packages started to contain `BUILDROOT` in them which resulted in failed builds:

```
[package: st2]      + xargs '-I{}' -n1 sed -i s@/tmp/st2/st2/build/BUILDROOT/st2-3.3dev-51.x86_64@@ '{}'
[package: st2]      + find /tmp/st2/st2/build/BUILDROOT/st2-3.3dev-51.x86_64 -name RECORD -o -name '*.egg-link' -o -name '*.pth'
[package: st2]      + /usr/lib/rpm/check-buildroot
[package: st2]      Binary file /tmp/st2/st2/build/BUILDROOT/st2-3.3dev-51.x86_64/opt/**********/st2/lib/python3.6/site-packages/cryptography/hazmat/bindings/_padding.abi3.so matches
[package: st2]      Binary file /tmp/st2/st2/build/BUILDROOT/st2-3.3dev-51.x86_64/opt/**********/st2/lib/python3.6/site-packages/cryptography/hazmat/bindings/_constant_time.abi3.so matches
[package: st2]      Binary file /tmp/st2/st2/build/BUILDROOT/st2-3.3dev-51.x86_64/opt/**********/st2/lib/python3.6/site-packages/cryptography/hazmat/bindings/_openssl.abi3.so matches
[package: st2]      Found '/tmp/st2/st2/build/BUILDROOT/st2-3.3dev-51.x86_64' in installed files; aborting
[package: st2]      error: Bad exit status from /var/tmp/rpm-tmp.OtVxc8 (%install)
```


Call strip for any `.so` libraries, as per logic used in https://github.com/kevinconway/rpmvenv/issues/48 or https://stackoverflow.com/questions/52766091/removing-paths-from-so-files-so-that-rpm-check-buildroot-succeeds. 