### PR TITLE
No-longer need to exclude mistral runner, as it is removed from st2

### DIFF
--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -33,10 +33,7 @@ else
 	PYTHON_ALT_BINARY := python
 endif
 
-# Don't include Mistral runner
-# TODO: Go back to all runners when mistral removed from st2
-#	RUNNERS := $(shell ls ../contrib/runners)
-	RUNNERS := $(shell ls -I mistral* ../contrib/runners)
+	RUNNERS := $(shell ls ../contrib/runners)
 
 # Moved from top of file to handle when only py2 or py3 available
 ST2PKG_VERSION ?= $(shell $(PYTHON_BINARY) -c "from $(ST2_COMPONENT) import __version__; print(__version__),")
@@ -114,10 +111,7 @@ populate_version: .stamp-populate_version
 	touch $@
 
 requirements:
-# Don't include Mistral runner for now
-# TODO: Use all runners when mistral removed from st2 core
-#	$(PYTHON_BINARY) ../scripts/fixate-requirements.py -s ../st2*/in-requirements.txt ../contrib/runners/*/in-requirements.txt -f ../fixed-requirements.txt
-	$(PYTHON_BINARY) ../scripts/fixate-requirements.py --skip=stackstorm-runner-mistral-v2,python-mistralclient -s ../st2*/in-requirements.txt ../contrib/runners/*/in-requirements.txt -f ../fixed-requirements.txt
+	$(PYTHON_BINARY) ../scripts/fixate-requirements.py -s ../st2*/in-requirements.txt ../contrib/runners/*/in-requirements.txt -f ../fixed-requirements.txt
 	cat requirements.txt
 
 changelog: populate_version


### PR DESCRIPTION
Tidy-up Makefile now that mistral runner is removed from st2 code base.