### PR TITLE
-v doesn't allow you to set version

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -28,7 +28,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -32,7 +32,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -24,7 +24,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;

--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -26,7 +26,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;

--- a/scripts/st2bootstrap-el7.template.sh
+++ b/scripts/st2bootstrap-el7.template.sh
@@ -18,7 +18,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -30,7 +30,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -22,7 +22,7 @@ setup_args() {
   for i in "$@"
     do
       case $i in
-          -v|--version=*)
+          -v=*|--version=*)
           VERSION="${i#*=}"
           shift
           ;;


### PR DESCRIPTION
The install.sh supports -v and --version to set the version.

Using --version=3.2.0 then it allows you to configure the specify the version to install.

However if you use -v=3.2.0 or -v3.2.0 then it ignores the version specified and uses the default value set to BRANCH. If you use "-v 3.2.0" then it complains that the version -v is not valid.

I believe that you should have been able to use -v=3.2.0 or --version=3.2.0 - and have amended the setup_args so that it will extract the version number out on -v same as --version.


NB. This appears to be legacy behaviour, so should not be a blocker for 3.3 release.