### PR TITLE
Switch to v3.3 for the default stable installer scripts

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -15,7 +15,7 @@ USERNAME=''
 PASSWORD=''
 
 # Note: This variable needs to default to a branch of the latest stable release
-BRANCH='v3.2'
+BRANCH='v3.3'
 FORCE_BRANCH=""
 
 adddate() {


### PR DESCRIPTION
As v3.3 release is technically out, this PR reverts StackStorm/st2-packages#666 and sets default stable installer branch to `v3.3`.
For example, during the Vagrant/Packer build pipeline older version is installed while 3.3 should be deployed (https://github.com/StackStorm/packer-st2/pull/49).

Now it's time to revert the #666