### PR TITLE
Install python3 selinux library in preparation for Python 3 move on EL7

### DIFF
--- a/scripts/st2bootstrap-el7.sh
+++ b/scripts/st2bootstrap-el7.sh
@@ -473,6 +473,7 @@ adjust_selinux_policies() {
   if getenforce | grep -q 'Enforcing'; then
     # SELINUX management tools, not available for some minimal installations
     sudo yum install -y policycoreutils-python
+    sudo yum install -y libselinux-python3
 
     # Allow rabbitmq to use '25672' port, otherwise it will fail to start
     sudo semanage port --list | grep -q 25672 || sudo semanage port -a -t amqp_port_t -p tcp 25672

--- a/scripts/st2bootstrap-el7.template.sh
+++ b/scripts/st2bootstrap-el7.template.sh
@@ -112,6 +112,7 @@ adjust_selinux_policies() {
   if getenforce | grep -q 'Enforcing'; then
     # SELINUX management tools, not available for some minimal installations
     sudo yum install -y policycoreutils-python
+    sudo yum install -y libselinux-python3
 
     # Allow rabbitmq to use '25672' port, otherwise it will fail to start
     sudo semanage port --list | grep -q 25672 || sudo semanage port -a -t amqp_port_t -p tcp 25672


### PR DESCRIPTION
Install python3 SELinux library on EL7.

Part of https://github.com/StackStorm/discussions/issues/54
