### PR TITLE
check that deployment script can be written in PWD

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -182,6 +182,10 @@ if [ $? -ne 0 ]; then
     exit 2
 else
     echo "Downloading deployment script from: ${ST2BOOTSTRAP}..."
+    # Make sure we are in a writable directory
+    if [ ! -w $(pwd) ]; then
+        echo "$(pwd) not writable, please cd to a different directory and try again."
+    fi
     curl -sSL -k -o ${BOOTSTRAP_FILE} ${ST2BOOTSTRAP}
     chmod +x ${BOOTSTRAP_FILE}
 

--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -185,6 +185,7 @@ else
     # Make sure we are in a writable directory
     if [ ! -w $(pwd) ]; then
         echo "$(pwd) not writable, please cd to a different directory and try again."
+        exit 2
     fi
     curl -sSL -k -o ${BOOTSTRAP_FILE} ${ST2BOOTSTRAP}
     chmod +x ${BOOTSTRAP_FILE}


### PR DESCRIPTION
Adds logic that checks if we can write the deployment script to disk before downloading it and failing. 