### PR TITLE
EL7 to use python3

### DIFF
--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -27,6 +27,10 @@ else ifeq ($(EL_VERSION),8)
 	PYTHON_BINARY := /usr/bin/python3
 	PIP_BINARY := /usr/local/bin/pip3
 	PYTHON_ALT_BINARY := python3
+else ifeq ($(EL_VERSION),7)
+	PYTHON_BINARY := /usr/bin/python3
+	PIP_BINARY := /usr/local/bin/pip3
+	PYTHON_ALT_BINARY := python3
 else
 	PYTHON_BINARY := python
 	PIP_BINARY := pip

--- a/packages/st2/component.makefile
+++ b/packages/st2/component.makefile
@@ -25,6 +25,9 @@ ifeq ($(DEB_DISTRO),bionic)
 else ifeq ($(EL_VERSION),8)
 	PYTHON_BINARY := /usr/bin/python3
 	PIP_BINARY := /usr/local/bin/pip3
+else ifeq ($(EL_VERSION),7)
+	PYTHON_BINARY := /usr/bin/python3
+	PIP_BINARY := /usr/local/bin/pip3
 else
 	PYTHON_BINARY := python
 	PIP_BINARY := pip

--- a/packages/st2/rpm/st2.spec
+++ b/packages/st2/rpm/st2.spec
@@ -10,14 +10,11 @@
 Epoch: %{epoch}
 %endif
 
-%if 0%{?rhel} == 7
-Requires: python-devel, openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash, setup
-%endif
-
 %if 0%{?rhel} >= 8
 %global _build_id_links none
-Requires: python3-devel openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash, setup
 %endif
+
+Requires: python3-devel, openssl-devel, libffi-devel, git, pam, openssh-server, openssh-clients, bash, setup
 
 # EL8 requires a few python packages available within 'BUILDROOT' when outside venv
 # These are in the el8 packagingbuild dockerfile

--- a/rpmspec/helpers.spec
+++ b/rpmspec/helpers.spec
@@ -56,11 +56,7 @@
 #   if package name starts with st2 then it's st2 component.
 #
 %if %(PKG=%{package}; [ "${PKG##st2}" != "$PKG" ] && echo 1 || echo 0 ) == 1
-%if 0%{?rhel} >= 8
-  %define st2pkg_version %(python3 -c "from %{package} import __version__; print(__version__),")
-%else
-  %define st2pkg_version %(python -c "from %{package} import __version__; print(__version__),")
-%endif  # if rhel8
+%define st2pkg_version %(python3 -c "from %{package} import __version__; print(__version__),")
 %endif  # st2 package version parsing
 
 

--- a/rpmspec/package_venv.spec
+++ b/rpmspec/package_venv.spec
@@ -7,19 +7,16 @@
 %define venv_dir %{buildroot}/%{venv_install_dir}
 %define venv_bin %{venv_dir}/bin
 
-%if 0%{?rhel} == 8
 %define venv_python %{venv_bin}/python3
-%define pin_pip %{venv_python} %{venv_bin}/pip install pip==19.1.1
-%define install_crypto %{venv_python} %{venv_bin}/pip install cryptography==2.8 --no-binary cryptography
+%define pin_pip %{venv_python} %{venv_bin}/pip3 install pip==19.1.1
 %define install_venvctrl python3 -m pip install venvctrl
+%if 0%{?rhel} == 8
+%define install_crypto %{venv_python} %{venv_bin}/pip install cryptography==2.8 --no-binary cryptography
 %else
-%define venv_python %{venv_bin}/python
-%define pin_pip %{nil}
 %define install_crypto %{nil}
-%define install_venvctrl %{nil}
 %endif
 
-%define venv_pip %{venv_python} %{venv_bin}/pip install --find-links=%{wheel_dir} --no-index
+%define venv_pip %{venv_python} %{venv_bin}/pip3 install --find-links=%{wheel_dir} --no-index
 
 # Change the virtualenv path to the target installation directory.
 #   - Install dependencies
@@ -27,7 +24,7 @@
 
 # EL8 requires crypto built locally and venvctrl available outside of venv
 %define pip_install_venv \
-    virtualenv --no-download %{venv_dir} \
+    virtualenv-3 -p python3 --no-download %{venv_dir} \
     %{pin_pip} \
     %{install_crypto} \
     %{venv_pip} -r requirements.txt \


### PR DESCRIPTION
Update the EL7 packages so that they use python3 not python2.

Part of StackStorm/discussions#54