### PR TITLE
st2-apply-rbac-defintions binary needs to be shipped with the st2 deb…

### DIFF
--- a/packages/st2/debian/st2.links
+++ b/packages/st2/debian/st2.links
@@ -4,6 +4,7 @@ opt/stackstorm/st2/bin/st2-trigger-refire usr/bin/st2-trigger-refire
 opt/stackstorm/st2/bin/st2-rule-tester usr/bin/st2-rule-tester
 opt/stackstorm/st2/bin/st2-run-pack-tests usr/bin/st2-run-pack-tests
 opt/stackstorm/st2/bin/st2-register-content usr/bin/st2-register-content
+opt/stackstorm/st2/bin/st2-apply-rbac-definitions usr/bin/st2-apply-rbac-definitions
 opt/stackstorm/st2/bin/st2-bootstrap-rmq usr/bin/st2-bootstrap-rmq
 opt/stackstorm/st2/bin/st2-submit-debug-info usr/bin/st2-submit-debug-info
 opt/stackstorm/st2/bin/st2-generate-symmetric-crypto-key usr/bin/st2-generate-symmetric-crypto-key
@@ -12,3 +13,6 @@ opt/stackstorm/st2/bin/st2-track-result usr/bin/st2-track-result
 opt/stackstorm/st2/bin/st2-validate-pack-config usr/bin/st2-validate-pack-config
 opt/stackstorm/st2/bin/st2-check-license usr/bin/st2-check-license
 opt/stackstorm/st2/bin/st2ctl usr/bin/st2ctl
+
+
+

--- a/packages/st2/debian/st2.links
+++ b/packages/st2/debian/st2.links
@@ -13,6 +13,3 @@ opt/stackstorm/st2/bin/st2-track-result usr/bin/st2-track-result
 opt/stackstorm/st2/bin/st2-validate-pack-config usr/bin/st2-validate-pack-config
 opt/stackstorm/st2/bin/st2-check-license usr/bin/st2-check-license
 opt/stackstorm/st2/bin/st2ctl usr/bin/st2ctl
-
-
-

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -48,7 +48,7 @@ class ST2Spec
     },
 
     package_has_binaries: {
-      st2: %w(st2 st2ctl st2-bootstrap-rmq st2-register-content st2-rule-tester st2-run-pack-tests
+      st2: %w(st2 st2ctl st2-apply-rbac-definitions st2-bootstrap-rmq st2-register-content st2-rule-tester st2-run-pack-tests
               st2-trigger-refire st2 st2-self-check st2-track-result
               st2-validate-pack-config st2-check-license
               st2-generate-symmetric-crypto-key st2-submit-debug-info),


### PR DESCRIPTION
…/rpm package for rbac integration

Part of the https://github.com/StackStorm/st2/pull/5086