### PR TITLE
Remove st2debug component

### DIFF
--- a/packages/st2/debian/st2.links
+++ b/packages/st2/debian/st2.links
@@ -5,10 +5,8 @@ opt/stackstorm/st2/bin/st2-rule-tester usr/bin/st2-rule-tester
 opt/stackstorm/st2/bin/st2-run-pack-tests usr/bin/st2-run-pack-tests
 opt/stackstorm/st2/bin/st2-register-content usr/bin/st2-register-content
 opt/stackstorm/st2/bin/st2-bootstrap-rmq usr/bin/st2-bootstrap-rmq
-opt/stackstorm/st2/bin/st2-submit-debug-info usr/bin/st2-submit-debug-info
 opt/stackstorm/st2/bin/st2-generate-symmetric-crypto-key usr/bin/st2-generate-symmetric-crypto-key
 opt/stackstorm/st2/bin/st2-self-check usr/bin/st2-self-check
 opt/stackstorm/st2/bin/st2-track-result usr/bin/st2-track-result
 opt/stackstorm/st2/bin/st2-validate-pack-config usr/bin/st2-validate-pack-config
-opt/stackstorm/st2/bin/st2-check-license usr/bin/st2-check-license
 opt/stackstorm/st2/bin/st2ctl usr/bin/st2ctl

--- a/packages/st2/in-requirements.txt
+++ b/packages/st2/in-requirements.txt
@@ -5,7 +5,6 @@ st2stream
 st2auth
 st2reactor
 st2exporter
-st2debug
 st2tests
 git+https://github.com/StackStorm/st2-auth-backend-pam.git@master#egg=st2-auth-backend-pam
 stackstorm-runner-action-chain

--- a/rake/build/environment.rb
+++ b/rake/build/environment.rb
@@ -10,7 +10,6 @@ ST2_COMPONENTS = %w(
   st2api st2stream st2actions st2common
   st2auth st2client st2exporter
   st2reactor
-  st2debug
   st2tests)
 
 # Default list of packages to build

--- a/rake/spec/spec_helper.rb
+++ b/rake/spec/spec_helper.rb
@@ -50,8 +50,7 @@ class ST2Spec
     package_has_binaries: {
       st2: %w(st2 st2ctl st2-bootstrap-rmq st2-register-content st2-rule-tester st2-run-pack-tests
               st2-trigger-refire st2 st2-self-check st2-track-result
-              st2-validate-pack-config st2-check-license
-              st2-generate-symmetric-crypto-key st2-submit-debug-info),
+              st2-validate-pack-config st2-generate-symmetric-crypto-key),
     },
 
     package_has_directories: {


### PR DESCRIPTION
Companion to https://github.com/StackStorm/st2/pull/5103. 
The only item in st2debug component is the submit-debug-info component, so when this is removed the st2debug component also is removed. So remove it from the packages.