### PR TITLE
Ubuntu Xenial Warning: Block python3.6 PPA installation waiting on user's agreement

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -121,11 +121,11 @@ setup_args() {
     if (! apt-cache show python3.6 2> /dev/null | grep 'Package:' > /dev/null); then
       echo ""
       echo "WARNING!"
-      echo "python3.6 package is required as a dependency for StackStorm and none of your software repositories provide it."
-      echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS."
+      echo "The python3.6 package is a required dependency for the StackStorm st2 package but that is not installable from any of the default Ubuntu 16.04 repositories."
+      echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions."
       echo ""
-      echo "Alternatively we'll try to add 3rd party python3.6 APT repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
-      echo "By continuing you're aware of security risk associated with using unofficial 3rd party PPA repository."
+      echo "Alternatively we'll try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
+      echo "By continuing you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04."
       echo ""
       read -p "Press [y] to continue or [n] to cancel adding it: " choice
       case "$choice" in

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -112,6 +112,34 @@ setup_args() {
         exit 1
     fi
   fi
+
+  # Python 3.6 package is not available in Ubuntu Xenial
+  # Installer can add it via 3rd party PPA based on user agreement
+  if [[ "$SUBTYPE" = 'xenial' ]]; then
+    sudo apt-get update > /dev/null 2>/dev/null
+    # check if python3.6 is available
+    if (! apt-cache show python3.6 2> /dev/null | grep 'Package:' > /dev/null); then
+      echo ""
+      echo "WARNING!"
+      echo "python3.6 package is required as a dependency for StackStorm and none of your software repositories provide it."
+      echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS."
+      echo ""
+      echo "Alternatively we'll try to add 3rd party python3.6 APT repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
+      echo "By continue you're aware of security risk associated with using unofficial 3rd party PPA repository."
+      echo ""
+      read -p "Press [y] to continue or [n] to cancel adding it: " choice
+      case "$choice" in
+        y|Y )
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
+          echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-xenial.list
+          ;;
+        * )
+          echo "python3.6 PPA installation aborted"
+          exit 1
+          ;;
+      esac
+    fi
+  fi
 }
 
 

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -125,7 +125,7 @@ setup_args() {
       echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS."
       echo ""
       echo "Alternatively we'll try to add 3rd party python3.6 APT repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
-      echo "By continue you're aware of security risk associated with using unofficial 3rd party PPA repository."
+      echo "By continuing you're aware of security risk associated with using unofficial 3rd party PPA repository."
       echo ""
       read -p "Press [y] to continue or [n] to cancel adding it: " choice
       case "$choice" in

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -113,11 +113,11 @@ setup_args() {
     if (! apt-cache show python3.6 2> /dev/null | grep 'Package:' > /dev/null); then
       echo ""
       echo "WARNING!"
-      echo "python3.6 package is required as a dependency for StackStorm and none of your software repositories provide it."
-      echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS."
+      echo "The python3.6 package is a required dependency for the StackStorm st2 package but that is not installable from any of the default Ubuntu 16.04 repositories."
+      echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions."
       echo ""
-      echo "Alternatively we'll try to add 3rd party python3.6 APT repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
-      echo "By continuing you're aware of security risk associated with using unofficial 3rd party PPA repository."
+      echo "Alternatively we'll try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
+      echo "By continuing you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04."
       echo ""
       read -p "Press [y] to continue or [n] to cancel adding it: " choice
       case "$choice" in

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -117,7 +117,7 @@ setup_args() {
       echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS."
       echo ""
       echo "Alternatively we'll try to add 3rd party python3.6 APT repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
-      echo "By continue you're aware of security risk associated with using unofficial 3rd party PPA repository."
+      echo "By continuing you're aware of security risk associated with using unofficial 3rd party PPA repository."
       echo ""
       read -p "Press [y] to continue or [n] to cancel adding it: " choice
       case "$choice" in

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -104,6 +104,34 @@ setup_args() {
         exit 1
     fi
   fi
+
+  # Python 3.6 package is not available in Ubuntu Xenial
+  # Installer can add it via 3rd party PPA based on user agreement
+  if [[ "$SUBTYPE" = 'xenial' ]]; then
+    sudo apt-get update > /dev/null 2>/dev/null
+    # check if python3.6 is available
+    if (! apt-cache show python3.6 2> /dev/null | grep 'Package:' > /dev/null); then
+      echo ""
+      echo "WARNING!"
+      echo "python3.6 package is required as a dependency for StackStorm and none of your software repositories provide it."
+      echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS."
+      echo ""
+      echo "Alternatively we'll try to add 3rd party python3.6 APT repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
+      echo "By continue you're aware of security risk associated with using unofficial 3rd party PPA repository."
+      echo ""
+      read -p "Press [y] to continue or [n] to cancel adding it: " choice
+      case "$choice" in
+        y|Y )
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
+          echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-xenial.list
+          ;;
+        * )
+          echo "python3.6 PPA installation aborted"
+          exit 1
+          ;;
+      esac
+    fi
+  fi
 }
 
 


### PR DESCRIPTION
Per previous discussion in https://github.com/StackStorm/st2-packages/pull/679, adding an option to install 3rd party PPA based on user's input.

On Ubuntu Xenial the installer would stop, show insecure warning and wait for user's input to continue:


>WARNING!
>python3.6 package is required as a dependency for StackStorm and none of your software repositories provide it.
>We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS.
>
>Alternatively we'll try to add 3rd party python3.6 APT repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa.
>By continue you're aware of security risk associated with using unofficial 3rd party PPA repository.

