### PR TITLE
Add extra flag for Ubuntu 16.04 to install py3 PPA automatically

### DIFF
--- a/scripts/st2_bootstrap.sh
+++ b/scripts/st2_bootstrap.sh
@@ -13,6 +13,7 @@ ST2_PKG_VERSION=''
 DEV_BUILD=''
 USERNAME=''
 PASSWORD=''
+EXTRA_OPTS=''
 
 # Note: This variable needs to default to a branch of the latest stable release
 BRANCH='v3.3'
@@ -64,6 +65,12 @@ setup_args() {
           # changes which are in a branch)
           --force-branch=*)
           FORCE_BRANCH="${i#*=}"
+          shift
+          ;;
+          # Provide a flag to enable installing Python3 from 3rd party insecure PPA for Ubuntu Xenial
+          # TODO: Remove once Ubuntu Xenial is dropped
+          --u16-add-insecure-py3-ppa)
+          EXTRA_OPTS="--u16-add-insecure-py3-ppa"
           shift
           ;;
           *)
@@ -194,6 +201,6 @@ else
     echo "OS specific script cmd: bash ${BOOTSTRAP_FILE} ${VERSION} ${RELEASE} ${REPO_TYPE} ${DEV_BUILD} ${USERNAME} --password=****"
     TS=$(date +%Y%m%dT%H%M%S)
     sudo mkdir -p /var/log/st2
-    bash ${BOOTSTRAP_FILE} ${VERSION} ${RELEASE} ${REPO_TYPE} ${DEV_BUILD} ${USERNAME} ${PASSWORD} 2>&1 | adddate | sudo tee /var/log/st2/st2-install.${TS}.log
+    bash ${BOOTSTRAP_FILE} ${VERSION} ${RELEASE} ${REPO_TYPE} ${DEV_BUILD} ${USERNAME} ${PASSWORD} ${EXTRA_OPTS} 2>&1 | adddate | sudo tee /var/log/st2/st2-install.${TS}.log
     exit ${PIPESTATUS[0]}
 fi

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -139,7 +139,8 @@ setup_args() {
         echo ""
         echo "To bypass this check in future, you can provide the following flag: --u16-add-insecure-py3-ppa"
         echo ""
-        read -p "Press [y] to continue or [n] to cancel adding it: " choice
+        echo "Press [y] to continue or [n] to cancel adding it: "
+        read choice
       fi
       case "$choice" in
         y|Y )

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -20,6 +20,7 @@ ST2CHATOPS_PKG_VERSION=''
 DEV_BUILD=''
 USERNAME=''
 PASSWORD=''
+PY3_ADD_INSECURE_PPA=0
 SUBTYPE=`lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}'`
 
 if [[ "$SUBTYPE" != 'xenial' && "$SUBTYPE" != 'bionic' ]]; then
@@ -58,6 +59,12 @@ setup_args() {
           ;;
           --password=*)
           PASSWORD="${i#*=}"
+          shift
+          ;;
+          # Provide flag to enable installing Python3 from 3rd party insecure PPA for Ubuntu Xenial
+          # TODO: Remove once Ubuntu Xenial is dropped
+          --u16-add-insecure-py3-ppa)
+          PY3_ADD_INSECURE_PPA=1
           shift
           ;;
           *)
@@ -119,15 +126,23 @@ setup_args() {
     sudo apt-get update > /dev/null 2>/dev/null
     # check if python3.6 is available
     if (! apt-cache show python3.6 2> /dev/null | grep 'Package:' > /dev/null); then
-      echo ""
-      echo "WARNING!"
-      echo "The python3.6 package is a required dependency for the StackStorm st2 package but that is not installable from any of the default Ubuntu 16.04 repositories."
-      echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions."
-      echo ""
-      echo "Alternatively we'll try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
-      echo "By continuing you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04."
-      echo ""
-      read -p "Press [y] to continue or [n] to cancel adding it: " choice
+      if [[ "$PY3_ADD_INSECURE_PPA" = "1" ]]; then
+        choice=y
+      else
+        echo ""
+        echo "WARNING!"
+        echo "The python3.6 package is a required dependency for the StackStorm st2 package but that is not installable from any of the default Ubuntu 16.04 repositories."
+        echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions."
+        echo ""
+        echo "Alternatively we'll try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
+        echo "By continuing you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04."
+        echo ""
+        echo "To bypass this check in future, you can provide the following flag: --u16-add-insecure-py3-ppa"
+        echo ""
+        echo "Press [y] to continue or [n] to cancel adding it: "
+        # Fix to read user input in a subshell
+        read -p "" choice < /dev/tty
+      fi
       case "$choice" in
         y|Y )
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -20,7 +20,7 @@ ST2CHATOPS_PKG_VERSION=''
 DEV_BUILD=''
 USERNAME=''
 PASSWORD=''
-PY3_ADD_INSECURE_PPA=0
+U16_ADD_INSECURE_PY3_PPA=0
 SUBTYPE=`lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}'`
 
 if [[ "$SUBTYPE" != 'xenial' && "$SUBTYPE" != 'bionic' ]]; then
@@ -64,7 +64,7 @@ setup_args() {
           # Provide flag to enable installing Python3 from 3rd party insecure PPA for Ubuntu Xenial
           # TODO: Remove once Ubuntu Xenial is dropped
           --u16-add-insecure-py3-ppa)
-          PY3_ADD_INSECURE_PPA=1
+          U16_ADD_INSECURE_PY3_PPA=1
           shift
           ;;
           *)
@@ -126,7 +126,7 @@ setup_args() {
     sudo apt-get update > /dev/null 2>/dev/null
     # check if python3.6 is available
     if (! apt-cache show python3.6 2> /dev/null | grep 'Package:' > /dev/null); then
-      if [[ "$PY3_ADD_INSECURE_PPA" = "1" ]]; then
+      if [[ "$U16_ADD_INSECURE_PY3_PPA" = "1" ]]; then
         choice=y
       else
         echo ""

--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -139,9 +139,7 @@ setup_args() {
         echo ""
         echo "To bypass this check in future, you can provide the following flag: --u16-add-insecure-py3-ppa"
         echo ""
-        echo "Press [y] to continue or [n] to cancel adding it: "
-        # Fix to read user input in a subshell
-        read -p "" choice < /dev/tty
+        read -p "Press [y] to continue or [n] to cancel adding it: " choice
       fi
       case "$choice" in
         y|Y )

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -12,7 +12,7 @@ ST2CHATOPS_PKG_VERSION=''
 DEV_BUILD=''
 USERNAME=''
 PASSWORD=''
-PY3_ADD_INSECURE_PPA=0
+U16_ADD_INSECURE_PY3_PPA=0
 SUBTYPE=`lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}'`
 
 if [[ "$SUBTYPE" != 'xenial' && "$SUBTYPE" != 'bionic' ]]; then
@@ -56,7 +56,7 @@ setup_args() {
           # Provide flag to enable installing Python3 from 3rd party insecure PPA for Ubuntu Xenial
           # TODO: Remove once Ubuntu Xenial is dropped
           --u16-add-insecure-py3-ppa)
-          PY3_ADD_INSECURE_PPA=1
+          U16_ADD_INSECURE_PY3_PPA=1
           shift
           ;;
           *)
@@ -118,7 +118,7 @@ setup_args() {
     sudo apt-get update > /dev/null 2>/dev/null
     # check if python3.6 is available
     if (! apt-cache show python3.6 2> /dev/null | grep 'Package:' > /dev/null); then
-      if [[ "$PY3_ADD_INSECURE_PPA" = "1" ]]; then
+      if [[ "$U16_ADD_INSECURE_PY3_PPA" = "1" ]]; then
         choice=y
       else
         echo ""

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -131,7 +131,8 @@ setup_args() {
         echo ""
         echo "To bypass this check in future, you can provide the following flag: --u16-add-insecure-py3-ppa"
         echo ""
-        read -p "Press [y] to continue or [n] to cancel adding it: " choice
+        echo "Press [y] to continue or [n] to cancel adding it: "
+        read choice
       fi
       case "$choice" in
         y|Y )


### PR DESCRIPTION
As a follow-up to https://github.com/StackStorm/st2-packages/pull/681, this PR adds extra flag `--u16-add-insecure-py3-ppa` passed to installer to add 3rd party insecure PPA with python3 under Ubuntu Xenial.

This fixes more corner cases I just identified with different non-interactive modes, subshells, `curl|bash` piping and other tricky situations.