### PR TITLE
HACK: Add python-virtualenv apt package dependency

### DIFF
--- a/packages/st2/debian/control
+++ b/packages/st2/debian/control
@@ -15,7 +15,7 @@ Vcs-Browser: https://github.com/stackstorm/st2
 Package: st2
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.16), ${pre:Depends}, ${misc:Pre-Depends}, adduser
-Depends: ${shlibs:Depends}, ${misc:Depends}, sudo, adduser, ${Depends}, libssl-dev, libffi-dev, git, libpam0g, openssh-server, openssh-client, bash, netbase
+Depends: ${shlibs:Depends}, ${misc:Depends}, sudo, adduser, ${Depends}, libssl-dev, libffi-dev, git, libpam0g, openssh-server, openssh-client, bash, netbase, python-virtualenv
 Conflicts: st2common
 Description: StackStorm Event-driven automation
  Package is full standalone st2 installation including


### PR DESCRIPTION
This PR is a nasty hack to get the packaging tests to pass - adding python-virtualenv as a dependency to ensure that the virtualenv binary is available to StackStorm when it goes to create a virtualenv when it's installing a non-system pack.

This is a nasty, nasty hack, because the version of virtualenv that it installs is 15.0.1 on Ubuntu Xenial and 15.1.0 [look closely at those version strings, they are different], but only 15.1.0 officially supports Python 3.6 virtualenvs. While this "works" and passes tests, there is no guarantee that it will work in production for ST2 v3.4 on Ubuntu Xenial, so I opened this in a separate PR so we can decide if we are okay with merging this hack.

The proper fix is to refactor StackStorm to use Python 3's built-in `venv` module to create pack virtualenvs. Once that is done, then the python-virtualenv package dependency should be removed. I have not investigated this yet, but we may need to install the python3-venv package to ensure that StackStorm has the `venv` module available. I'm not sure that that module is available on PyPI/installable via pip. More investigation is needed.