### PR TITLE
[BUGFIX] Use pip==20.0.2 to match core st2 pin

### DIFF
--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -22,7 +22,7 @@ endif
 
 ifeq ($(DEB_DISTRO),bionic)
 	PYTHON_BINARY := /usr/bin/python3
-	PIP_BINARY := pip
+	PIP_BINARY := /usr/local/bin/pip3.6
 else ifeq ($(DEB_DISTRO),xenial)
 	PYTHON_BINARY := /usr/bin/python3.6
 	PIP_BINARY := /usr/local/bin/pip3.6

--- a/packages/st2/component.makefile
+++ b/packages/st2/component.makefile
@@ -21,7 +21,7 @@ endif
 
 ifeq ($(DEB_DISTRO),bionic)
 	PYTHON_BINARY := /usr/bin/python3
-	PIP_BINARY := /usr/bin/pip3
+	PIP_BINARY := /usr/local/bin/pip3.6
 else ifeq ($(DEB_DISTRO),xenial)
 	PYTHON_BINARY := /usr/bin/python3.6
 	PIP_BINARY := /usr/local/bin/pip3.6
@@ -54,6 +54,7 @@ info:
 	@echo "PIP_BINARY=$(PIP_BINARY)"
 	@echo "EL_VERSION=$(EL_VERSION)"
 	@echo "EL_DISTRO=$(EL_DISTRO)"
+	$(PIP_BINARY) --version
 
 .PHONY: populate_version requirements wheelhouse bdist_wheel
 all: info populate_version requirements bdist_wheel

--- a/packages/st2/debian/rules
+++ b/packages/st2/debian/rules
@@ -27,7 +27,7 @@ endif
 %:
 # Use Python 3 binary on Ubuntu Bionic
 ifeq ($(DEB_DISTRO),bionic)
-	dh $@ --with python-virtualenv --python /usr/bin/python3
+	dh $@ --with python-virtualenv --python /usr/bin/python3.6
 else ifeq ($(DEB_DISTRO),xenial)
 	dh $@ --with python-virtualenv --python /usr/bin/python3.6
 endif

--- a/packages/st2/debian/rules
+++ b/packages/st2/debian/rules
@@ -67,7 +67,10 @@ override_dh_virtualenv:
 	#
 	# NB! Use '--no-download' arg for 'virtualenv' is required,
 	# otherwise it downloads latest PIP version instead of bundled/pinned one.
+	# --force-pip-version is needed to ensure correct pip version is installed
+	# inside dh virtualenv
 	dh_virtualenv --extra-virtualenv-arg='--no-download' \
+								--force-pip-version='20.0.2' \
 								--extra-pip-arg '--find-links=$(WHEELDIR)' \
 								--extra-pip-arg '--no-index' --no-test
 

--- a/rake/build/package_st2.rake
+++ b/rake/build/package_st2.rake
@@ -9,6 +9,7 @@ namespace :package do
         with opts.env do
           opts.components.each do |component|
             within ::File.join(opts.gitdir, component) do
+              make :info, label: "make info"
               make :bdist_wheel, label: "bdist: #{component}"
             end
           end

--- a/rpmspec/package_venv.spec
+++ b/rpmspec/package_venv.spec
@@ -8,7 +8,8 @@
 %define venv_bin %{venv_dir}/bin
 
 %define venv_python %{venv_bin}/python3
-%define pin_pip %{venv_python} %{venv_bin}/pip3 install pip==19.1.1
+# https://github.com/StackStorm/st2/wiki/Where-all-to-update-pip-and-or-virtualenv
+%define pin_pip %{venv_python} %{venv_bin}/pip3 install pip==20.0.2
 %define install_venvctrl python3 -m pip install venvctrl
 %if 0%{?rhel} == 8
 %define install_crypto %{venv_python} %{venv_bin}/pip install cryptography==2.8 --no-binary cryptography


### PR DESCRIPTION
We have been running tests with pip==20.0.2 in v3.3.0 and v3.2.0. But we have still been installing pip 19 in production.

That is very likely to cause installation errors for packs in production that would not exist during testing (eg if a pack's dep uses a pip feature that is not available in pip 19, which is becoming more common).

See these commits in StackStorm/st2:
- a6c4b89373e01f1c38396ce65d9dda3e3be0e842
- c9f6638c491383e7587ab44f76673c81805aaa13
- e1804fb666cd9d41a77a1e776fe6bb0a1e1b949b
- 40827e7fdb04588bfc12ce4da7c7a9bc7e9c4ae3

We have not been testing with anything newer than pip 20.0.2, however, so upgrading to a newer version is dangerous. Since we've already been testing with 20.0.2, we should start with making pip consistent across all of our infrastructure and then we can worry about upgrading.

Here is a list of places that need to be updated when we do upgrade pip:
https://github.com/StackStorm/st2/wiki/Where-all-to-update-pip-and-or-virtualenv
