### PR TITLE
Don't ask the user to continue with the deadsnakes repo and just mention the cmd line flag

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -126,32 +126,23 @@ setup_args() {
     sudo apt-get update > /dev/null 2>/dev/null
     # check if python3.6 is available
     if (! apt-cache show python3.6 2> /dev/null | grep 'Package:' > /dev/null); then
-      if [[ "$U16_ADD_INSECURE_PY3_PPA" = "1" ]]; then
-        choice=y
-      else
+      if [[ "$U16_ADD_INSECURE_PY3_PPA" = "0" ]]; then
         echo ""
         echo "WARNING!"
         echo "The python3.6 package is a required dependency for the StackStorm st2 package but that is not installable from any of the default Ubuntu 16.04 repositories."
         echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions."
         echo ""
         echo "Alternatively we'll try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
-        echo "By continuing you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04."
         echo ""
-        echo "To bypass this check in future, you can provide the following flag: --u16-add-insecure-py3-ppa"
+        echo "You can provide the following flag os use python3.6 from the 'deadsnakes'repository: --u16-add-insecure-py3-ppa"
         echo ""
-        echo "Press [y] to continue or [n] to cancel adding it: "
-        read choice
+        echo "By using the flag you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04."
+        echo ""
+        exit 1
+      else:
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
+        echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-xenial.list
       fi
-      case "$choice" in
-        y|Y )
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
-          echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-xenial.list
-          ;;
-        * )
-          echo "python3.6 PPA installation aborted"
-          exit 1
-          ;;
-      esac
     fi
   fi
 }

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -118,32 +118,23 @@ setup_args() {
     sudo apt-get update > /dev/null 2>/dev/null
     # check if python3.6 is available
     if (! apt-cache show python3.6 2> /dev/null | grep 'Package:' > /dev/null); then
-      if [[ "$U16_ADD_INSECURE_PY3_PPA" = "1" ]]; then
-        choice=y
-      else
+      if [[ "$U16_ADD_INSECURE_PY3_PPA" = "0" ]]; then
         echo ""
         echo "WARNING!"
         echo "The python3.6 package is a required dependency for the StackStorm st2 package but that is not installable from any of the default Ubuntu 16.04 repositories."
         echo "We recommend switching to Ubuntu 18.04 LTS (Bionic) as a base OS. Support for Ubuntu 16.04 will be removed with future StackStorm versions."
         echo ""
         echo "Alternatively we'll try to add python3.6 from the 3rd party 'deadsnakes' repository: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa."
-        echo "By continuing you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04."
         echo ""
-        echo "To bypass this check in future, you can provide the following flag: --u16-add-insecure-py3-ppa"
+        echo "You can provide the following flag os use python3.6 from the 'deadsnakes'repository: --u16-add-insecure-py3-ppa"
         echo ""
-        echo "Press [y] to continue or [n] to cancel adding it: "
-        read choice
+        echo "By using the flag you are aware of the support and security risks associated with using unofficial 3rd party PPA repository, and you understand that StackStorm does NOT provide ANY support for python3.6 packages on Ubuntu 16.04."
+        echo ""
+        exit 1
+      else:
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
+        echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-xenial.list
       fi
-      case "$choice" in
-        y|Y )
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
-          echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-xenial.list
-          ;;
-        * )
-          echo "python3.6 PPA installation aborted"
-          exit 1
-          ;;
-      esac
     fi
   fi
 }


### PR DESCRIPTION
This PR removes the ability to confirm or deny the installation of python3.6 from the deadsnake repositories on Ubuntu 16.04. Instead it just mentions the corresponding command line flag.

To me, this pragmatic approach to address https://github.com/StackStorm/st2-packages/issues/688 is fine since users who want to use python3.6 from the unsupported repositories should really know what they do and can just run the script(s) again with the --u16-add-insecure-py3-ppa flag or add the necessary flag to their automation. 

!close https://github.com/StackStorm/st2-packages/issues/688