### PR TITLE
Pin rabbitmq version

### DIFF
--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -22,6 +22,10 @@ ST2_PKG='st2'
 ST2WEB_PKG='st2web'
 ST2CHATOPS_PKG='st2chatops'
 
+# WORKAROUND - pin rabbitmq version for the moment due to 3.8.13 requiring
+# erlang version that is not in EPEL or CentOS repos
+RABBITMQ_VERSION=3.8.12
+
 is_rhel() {
   return $(cat /etc/os-release | grep 'ID="rhel"')
 }
@@ -509,8 +513,10 @@ install_st2_dependencies() {
   # https://github.com/StackStorm/st2-packages/issues/632
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
-
-  sudo yum -y install curl rabbitmq-server
+  
+  # WORKAROUND - pin rabbitmq version for the moment due to 3.8.13 requiring
+  # erlang version that is not in EPEL or CentOS repos
+  sudo yum -y install curl rabbitmq-server-${RABBITMQ_VERSION}
 
   # Configure RabbitMQ to listen on localhost only
   sudo sh -c 'echo "RABBITMQ_NODE_IP_ADDRESS=127.0.0.1" >> /etc/rabbitmq/rabbitmq-env.conf'

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -14,6 +14,10 @@ ST2_PKG='st2'
 ST2WEB_PKG='st2web'
 ST2CHATOPS_PKG='st2chatops'
 
+# WORKAROUND - pin rabbitmq version for the moment due to 3.8.13 requiring
+# erlang version that is not in EPEL or CentOS repos
+RABBITMQ_VERSION=3.8.12
+
 is_rhel() {
   return $(cat /etc/os-release | grep 'ID="rhel"')
 }
@@ -148,8 +152,10 @@ install_st2_dependencies() {
   # https://github.com/StackStorm/st2-packages/issues/632
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
-
-  sudo yum -y install curl rabbitmq-server
+  
+  # WORKAROUND - pin rabbitmq version for the moment due to 3.8.13 requiring
+  # erlang version that is not in EPEL or CentOS repos
+  sudo yum -y install curl rabbitmq-server-${RABBITMQ_VERSION}
 
   # Configure RabbitMQ to listen on localhost only
   sudo sh -c 'echo "RABBITMQ_NODE_IP_ADDRESS=127.0.0.1" >> /etc/rabbitmq/rabbitmq-env.conf'


### PR DESCRIPTION
Rabbitmq-server 3.8.13 and above requires erlang 22.3 or higher, which is not available in the EL8 or EPEL yum repos.

Pin rabbitmq on EL8 to 3.8.13 temporarily.

Next release resolve repositories so that do not need to pin rabbitmq-server verseion.

