### PR TITLE
Install pip 20.0.2 in rpm package venv

### DIFF
--- a/rpmspec/package_venv.spec
+++ b/rpmspec/package_venv.spec
@@ -8,7 +8,7 @@
 %define venv_bin %{venv_dir}/bin
 
 %define venv_python %{venv_bin}/python3
-%define pin_pip %{venv_python} %{venv_bin}/pip3 install pip==19.1.1
+%define pin_pip %{venv_python} %{venv_bin}/pip3 install pip==20.0.2
 %define install_venvctrl python3 -m pip install venvctrl
 %if 0%{?rhel} == 8
 %define install_crypto %{venv_python} %{venv_bin}/pip install cryptography==2.8 --no-binary cryptography


### PR DESCRIPTION
This pull request updates rpmspec for package venv so we use the same pip version as we use elsewhere and in deb packages.

NOTE: I'm trying to get build with orjson to work but it's a pita since it looks like we are using python2.7 to build dh virtualenv so it will need more work :/