### PR TITLE
[WIP] Speed up builds by caching /tmp/wheelhouse directory

### DIFF
--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -56,5 +56,8 @@ re="\\b$DISTRO\\b"
 ST2_CIRCLE_URL=${CIRCLE_BUILD_URL}
 
 write_env ST2_GITURL ST2_GITREV ST2PKG_VERSION ST2PKG_RELEASE DISTRO TESTING ST2_CIRCLE_URL
-
 cat ~/.buildenv
+
+# Workaround for cache key since we can't reference arbitrary environment variables for cache keys
+echo "${DISTRO}" > /tmp/distro-version
+echo "${ST2PKG_VERSION}" > /tmp/st2-version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           exclusive: true   # default - true
           # Temporary workaround for Circle CI issue
           # https://discuss.circleci.com/t/setup-remote-docker-connection-failures/26434
-          version: 18.05.0-ce 
+          version: 18.05.0-ce
       - run:
           name: Ensure installation scripts are synced with their templates
           command: make .generated-files-check
@@ -70,21 +70,54 @@ jobs:
       - run:
           name: Pull dependent Docker Images
           command: .circle/docker-compose2.sh pull ${DISTRO}
+      - restore_cache:
+          name: Restore Wheelhouse Cache
+          keys:
+            - wheelhouse-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
+            - wheelhouse-
       - run:
           name: Build the ${DISTRO} Packages
           command: |
-            .circle/docker-compose2.sh build ${DISTRO}
-            # Once build container finishes we can copy packages directly from it
+            # Create necessary directories
             mkdir -p ~/st2-packages/build/${DISTRO}/log/
+            mkdir -p ~/st2-packages/wheelhouse/
+
+            # List volume content to see if there is any cached dasta
+            echo "local wheelhouse cache directory content"
+            echo ""
+            ls -la ~/st2-packages/wheelhouse/
+            du -hs ~/st2-packages/wheelhouse/
+            echo ""
+
+            # Copy over cached wheelhouse packages (if any exist)
+            docker cp ~/st2-packages/wheelhouse/. st2-packages-vol:/tmp/wheelhouse
+
+            # List volume content to see if there is any cached data
+            echo "docker volume wheelhouse cache directory content"
+            echo ""
+            docker run --rm -i -v=st2-packages-vol:/tmp/wheelhouse busybox find /tmp/wheelhouse
+            echo ""
+
+            # Run the build
+            .circle/docker-compose2.sh build ${DISTRO}
+
+            # Once build container finishes we can copy packages directly from it
+
+            # Copy built packages
             docker cp st2-packages-vol:/root/build/. ~/st2-packages/build/${DISTRO}
-#      # TODO: It works! (~0.5-1min speed-up) Enable CircleCI2.0 cache for pip and wheelhouse later
-#      - run:
-#          name: Build the ${DISTRO} Packages 2nd time (compare with pip/wheelhouse cached)
-#          command: |
-#            .circle/docker-compose2.sh build ${DISTRO}
-#            # Once build container finishes we can copy packages directly from it
-#            docker cp st2-packages-vol:/root/build /tmp/st2-packages
-#          working_directory: ~/st2-packages
+
+            # Copy all the files from /tmp/wheelhouse so we can cache it and substantially speed
+            # up subsequent builds
+            docker cp st2-packages-vol:/tmp/wheelhouse/. ~/st2-packages/wheelhouse/
+
+            echo "wheelhouse cache directory content"
+            ls -la ~/st2-packages/wheelhouse/
+            du -hs ~/st2-packages/wheelhouse/
+      - save_cache:
+          name: Store Wheelhouse Cache
+          key: wheelhouse-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
+          paths:
+            - ~/st2-packages/wheelhouse/
       - run:
           name: Test the Packages
           command: .circle/docker-compose2.sh test ${DISTRO}


### PR DESCRIPTION
This pull request is an attempt to speed up builds by caching ``/tmp/wheelhouse`` directory.

This way we can avoid re-building wheels for all the dependencies for each run which is quite slow.