### PR TITLE
Unpin rabbitmq and use minimal erlang

### DIFF
--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -22,10 +22,6 @@ ST2_PKG='st2'
 ST2WEB_PKG='st2web'
 ST2CHATOPS_PKG='st2chatops'
 
-# WORKAROUND - pin rabbitmq version for the moment due to 3.8.13 requiring
-# erlang version that is not in EPEL or CentOS repos
-RABBITMQ_VERSION=3.8.12
-
 is_rhel() {
   return $(cat /etc/os-release | grep 'ID="rhel"')
 }
@@ -514,6 +510,10 @@ install_st2_dependencies() {
 
 install_rabbitmq() {
   # Install rabbit from packagecloud
+  # WORKAROUND - install erlang from rabbitmq/erlang as need newer version
+  # than available in epel
+  curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
+  sudo yum -y install erlang
   # Package are not in EPEL or CentOS repos - but this is required for erlang.
   # recommended by rabbit: https://www.rabbitmq.com/install-rpm.html#package-cloud
   # TODO: Migrate rabbitmq packages to be sourced from EPEL rpm when available for EL8
@@ -521,9 +521,7 @@ install_rabbitmq() {
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
   
-  # WORKAROUND - pin rabbitmq version for the moment due to 3.8.13 requiring
-  # erlang version that is not in EPEL or CentOS repos
-  sudo yum -y install curl rabbitmq-server-${RABBITMQ_VERSION}
+  sudo yum -y install curl rabbitmq-server
 
   # Configure RabbitMQ to listen on localhost only
   sudo sh -c 'echo "RABBITMQ_NODE_IP_ADDRESS=127.0.0.1" >> /etc/rabbitmq/rabbitmq-env.conf'

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -14,10 +14,6 @@ ST2_PKG='st2'
 ST2WEB_PKG='st2web'
 ST2CHATOPS_PKG='st2chatops'
 
-# WORKAROUND - pin rabbitmq version for the moment due to 3.8.13 requiring
-# erlang version that is not in EPEL or CentOS repos
-RABBITMQ_VERSION=3.8.12
-
 is_rhel() {
   return $(cat /etc/os-release | grep 'ID="rhel"')
 }
@@ -151,6 +147,10 @@ install_st2_dependencies() {
 
 install_rabbitmq() {
   # Install rabbit from packagecloud
+  # WORKAROUND - install erlang from rabbitmq/erlang as need newer version
+  # than available in epel
+  curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
+  sudo yum -y install erlang
   # Package are not in EPEL or CentOS repos - but this is required for erlang.
   # recommended by rabbit: https://www.rabbitmq.com/install-rpm.html#package-cloud
   # TODO: Migrate rabbitmq packages to be sourced from EPEL rpm when available for EL8
@@ -158,9 +158,7 @@ install_rabbitmq() {
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
   
-  # WORKAROUND - pin rabbitmq version for the moment due to 3.8.13 requiring
-  # erlang version that is not in EPEL or CentOS repos
-  sudo yum -y install curl rabbitmq-server-${RABBITMQ_VERSION}
+  sudo yum -y install curl rabbitmq-server
 
   # Configure RabbitMQ to listen on localhost only
   sudo sh -c 'echo "RABBITMQ_NODE_IP_ADDRESS=127.0.0.1" >> /etc/rabbitmq/rabbitmq-env.conf'


### PR DESCRIPTION
Stop pinning version of rabbitmq on EL8.

Install latest from packagecloud, and therefore as that requires newer version of erlang, install the minimal erland provided by rabbitmq - as per instructions at https://github.com/rabbitmq/erlang-rpm

Resolves #694 