### PR TITLE
Add Redis for the Focal build

### DIFF
--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -40,6 +40,7 @@ focal:
     - focaltest
     - rabbitmq
     - mongodb
+    - redis
 
 el8:
   image: quay.io/stackstorm/packagingrunner

--- a/docker-compose.circle2.yml
+++ b/docker-compose.circle2.yml
@@ -43,6 +43,7 @@ focal:
     - focaltest
     - rabbitmq
     - mongodb
+    - redis
 
 el8:
   image: quay.io/stackstorm/packagingrunner

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ focal:
     - focaltest
     - rabbitmq
     - mongodb
+    - redis
 
 el8:
   image: quay.io/stackstorm/packagingrunner


### PR DESCRIPTION
One oversight from the https://github.com/StackStorm/st2-packages/pull/700 is that before merging I forgot to sync up with the latest master which included `Redis` changes #698.

This PR should fix the master build here
https://app.circleci.com/pipelines/github/StackStorm/st2-packages/241/workflows/6ec15014-f2f7-4215-8bf2-ed0a10c062f2/jobs/3846
