### PR TITLE
Add commands to update cert on ubuntu

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -637,6 +637,10 @@ EOT"
 }
 
 install_st2chatops() {
+  # Update certificates
+  sudo apt-get update
+  sudo apt-get install -y ca-certificates
+
   # Add NodeJS 10 repo
   curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -323,6 +323,10 @@ EOT"
 }
 
 install_st2chatops() {
+  # Update certificates
+  sudo apt-get update
+  sudo apt-get install -y ca-certificates
+
   # Add NodeJS 10 repo
   curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 


### PR DESCRIPTION
E2E tests are failing to setup the nodejs repository due to outdated certificates.
Include update of ca-certificates to get updated certs.