### PR TITLE
Relax ini parsing to allow duplicate entries.

### DIFF
--- a/packages/st2/debian/st2api-generator
+++ b/packages/st2/debian/st2api-generator
@@ -30,7 +30,7 @@ LOG.debug(
     f"Systemd directories: Early='{EARLY_DIR}' Normal='{NORMAL_DIR}' Late='{LATE_DIR}'"
 )
 
-config = configparser.ConfigParser()
+config = configparser.ConfigParser(strict=False)
 config.read(ST2CFG)
 
 section = ST2SVC[3:]

--- a/packages/st2/debian/st2auth-generator
+++ b/packages/st2/debian/st2auth-generator
@@ -30,7 +30,7 @@ LOG.debug(
     f"Systemd directories: Early='{EARLY_DIR}' Normal='{NORMAL_DIR}' Late='{LATE_DIR}'"
 )
 
-config = configparser.ConfigParser()
+config = configparser.ConfigParser(strict=False)
 config.read(ST2CFG)
 
 section = ST2SVC[3:]

--- a/packages/st2/debian/st2stream-generator
+++ b/packages/st2/debian/st2stream-generator
@@ -30,7 +30,7 @@ LOG.debug(
     f"Systemd directories: Early='{EARLY_DIR}' Normal='{NORMAL_DIR}' Late='{LATE_DIR}'"
 )
 
-config = configparser.ConfigParser()
+config = configparser.ConfigParser(strict=False)
 config.read(ST2CFG)
 
 section = ST2SVC[3:]


### PR DESCRIPTION
Following failures in the end to end testing due to duplicate entries in the section, the config parser has been relaxed to allow duplicate entries.  The current default behaviour for duplicate keys is order of parsing so the last key read will be the value used.