### PR TITLE
Ignore systemctl deamon-reload failure

### DIFF
--- a/packages/st2/debian/postinst
+++ b/packages/st2/debian/postinst
@@ -55,7 +55,7 @@ case "$1" in
       rm -f $ST2_UPGRADESTAMP
 
       # make sure that our socket generators run
-      systemctl daemon-reload
+      systemctl daemon-reload >/dev/null 2>&1 || true
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;

--- a/packages/st2/rpm/postinst_script.spec
+++ b/packages/st2/rpm/postinst_script.spec
@@ -1,4 +1,4 @@
 set -e
 
 # make sure that our socket generators run
-systemctl daemon-reload
+systemctl daemon-reload >/dev/null 2>&1 || true


### PR DESCRIPTION
A follow-up to https://github.com/StackStorm/st2-packages/pull/706#discussion_r730419882
Fixes docker build where systemd is not available during the st2 package installation resulting in a failure.

https://app.circleci.com/pipelines/github/StackStorm/st2-dockerfiles/756/workflows/5fcaa169-2baa-4521-911e-5bc7f42ee300/jobs/1279

```
Setting up st2 (3.6dev-47) ...
System has not been booted with systemd as init system (PID 1). Can't operate.
dpkg: error processing package st2 (--configure):
 installed st2 package post-installation script subprocess returned error exit status 1
```
