### PR TITLE
CircleCI build enhancements and fixes

### DIFF
--- a/.circle/buildenv_st2.sh
+++ b/.circle/buildenv_st2.sh
@@ -57,7 +57,3 @@ ST2_CIRCLE_URL=${CIRCLE_BUILD_URL}
 
 write_env ST2_GITURL ST2_GITREV ST2PKG_VERSION ST2PKG_RELEASE DISTRO TESTING ST2_CIRCLE_URL
 cat ~/.buildenv
-
-# Workaround for cache key since we can't reference arbitrary environment variables for cache keys
-echo "${DISTRO}" > /tmp/distro-version
-echo "${ST2PKG_VERSION}" > /tmp/st2-version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,7 @@ jobs:
       - setup_remote_docker:
           reusable: true    # default - false
           exclusive: true   # default - true
-          # Temporary workaround for Circle CI issue
-          # https://discuss.circleci.com/t/setup-remote-docker-connection-failures/26434
-          version: 18.05.0-ce
+          version: 19.03.14
       - run:
           name: Ensure installation scripts are synced with their templates
           command: make .generated-files-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,7 @@ jobs:
       - restore_cache:
           name: Restore Wheelhouse Cache
           keys:
-            - wheelhouse-v3-{{ .Branch }}-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
-            - wheelhouse-v3-{{ .Branch }}-
+            - wheelhouse-v4-{{ .Branch }}-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
       - run:
           name: Build the ${DISTRO} Packages
           command: |
@@ -116,7 +115,7 @@ jobs:
             # du -hs ~/st2-packages/wheelhouse/
       - save_cache:
           name: Store Wheelhouse Cache
-          key: wheelhouse-v3-{{ .Branch }}-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
+          key: wheelhouse-v4-{{ .Branch }}-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
           paths:
             - ~/st2-packages/wheelhouse/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,9 @@ jobs:
       - run:
           name: Build the ${DISTRO} Packages
           command: |
+            # Create necessary directories
+            mkdir -p ~/st2-packages/build/${DISTRO}/log/
+            
             # Run the build
             .circle/docker-compose2.sh build ${DISTRO}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,56 +68,14 @@ jobs:
       - run:
           name: Pull dependent Docker Images
           command: .circle/docker-compose2.sh pull ${DISTRO} || .circle/docker-compose2.sh pull ${DISTRO}
-      - restore_cache:
-          name: Restore Wheelhouse Cache
-          keys:
-            - wheelhouse-v4-{{ .Branch }}-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
       - run:
           name: Build the ${DISTRO} Packages
           command: |
-            # Create necessary directories
-            # TODO: Per distro directory?
-            mkdir -p ~/st2-packages/build/${DISTRO}/log/
-            mkdir -p ~/st2-packages/wheelhouse/
-
-            # List volume content to see if there is any cached dasta
-            # Uncomment if you are troubleshooting wheelhouse caching issues
-            # echo "local wheelhouse cache directory content"
-            # echo ""
-            # ls -la ~/st2-packages/wheelhouse/
-            # du -hs ~/st2-packages/wheelhouse/
-            # echo ""
-
-            # Copy over cached wheelhouse packages (if any exist)
-            docker cp ~/st2-packages/wheelhouse/. st2-packages-vol:/tmp/wheelhouse
-
-            # List volume content to see if there is any cached data
-            # echo "docker volume wheelhouse cache directory content"
-            # echo ""
-            # docker run --rm -i -v=st2-packages-vol:/tmp/wheelhouse busybox find /tmp/wheelhouse
-            # echo ""
-
             # Run the build
             .circle/docker-compose2.sh build ${DISTRO}
 
             # Once build container finishes we can copy packages directly from it
-
-            # Copy built packages
             docker cp st2-packages-vol:/root/build/. ~/st2-packages/build/${DISTRO}
-
-            # Copy all the files from /tmp/wheelhouse so we can cache it and substantially speed
-            # up subsequent builds
-            docker cp st2-packages-vol:/tmp/wheelhouse/. ~/st2-packages/wheelhouse/
-
-            # echo "wheelhouse cache directory content"
-            # Uncomment if you are troubleshooting wheelhouse caching issues
-            # ls -la ~/st2-packages/wheelhouse/
-            # du -hs ~/st2-packages/wheelhouse/
-      - save_cache:
-          name: Store Wheelhouse Cache
-          key: wheelhouse-v4-{{ .Branch }}-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
-          paths:
-            - ~/st2-packages/wheelhouse/
       - run:
           name: Test the Packages
           command: .circle/docker-compose2.sh test ${DISTRO}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             docker cp ~/st2-packages st2-packages-vol:/root
       - run:
           name: Pull dependent Docker Images
-          command: .circle/docker-compose2.sh pull ${DISTRO}
+          command: .circle/docker-compose2.sh pull ${DISTRO} || .circle/docker-compose2.sh pull ${DISTRO}
       - restore_cache:
           name: Restore Wheelhouse Cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,8 @@ jobs:
       - restore_cache:
           name: Restore Wheelhouse Cache
           keys:
-            - wheelhouse-v2-{{ .Branch }}-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
-            - wheelhouse-v2-{{ .Branch }}-
+            - wheelhouse-v3-{{ .Branch }}-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
+            - wheelhouse-v3-{{ .Branch }}-
       - run:
           name: Build the ${DISTRO} Packages
           command: |
@@ -116,7 +116,7 @@ jobs:
             # du -hs ~/st2-packages/wheelhouse/
       - save_cache:
           name: Store Wheelhouse Cache
-          key: wheelhouse-v2-{{ .Branch }}-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
+          key: wheelhouse-v3-{{ .Branch }}-{{ checksum "/tmp/distro-version" }}-{{ checksum "/tmp/st2-version" }}
           paths:
             - ~/st2-packages/wheelhouse/
       - run:


### PR DESCRIPTION
CircleCI is showing some instability and different results in the packaging builds recently.
Experiment with the CircleCI environment.

* Update the outdated Docker environment
* Retry docker-pull on failure (helps with noisy build failures unable to download docker images)
* Invalidate the wheelhouse cache, where old cache might bring issues with the el8->rocky switch
* Fix corner case when the same wheelhouse cache/key could be used by all the distros as a fallback