### PR TITLE
Reorder in Makefile and restrict setuptools

### DIFF
--- a/packages/st2/Makefile
+++ b/packages/st2/Makefile
@@ -7,13 +7,17 @@ ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1
 	#DEB_EPOCH := $(shell echo $(ST2PKG_VERSION) | grep -q dev || echo '1')
 	DEB_DISTRO := $(shell lsb_release -cs)
+else ifneq (,$(wildcard /etc/rocky-release))
+	EL_DISTRO:=rocky
+	EL_VERSION := $(shell cat /etc/rocky-release | grep -oP '(?<= )[0-9]+(?=\.)')
+	REDHAT := 1
 else ifneq (,$(wildcard /etc/centos-release))
 	EL_DISTRO:=centos
 	EL_VERSION := $(shell cat /etc/centos-release | grep -oP '(?<= )[0-9]+(?=\.)')
 	REDHAT := 1
 else ifneq (,$(wildcard /etc/redhat-release))
 	EL_DISTRO:=redhat
-	EL_VERSION := $(shell cat /etc/centos-release | grep -oP '(?<= )[0-9]+(?=\.)')
+	EL_VERSION := $(shell cat /etc/redhat-release | grep -oP '(?<= )[0-9]+(?=\.)')
 	REDHAT := 1
 else
 	REDHAT := 1

--- a/packages/st2/component.makefile
+++ b/packages/st2/component.makefile
@@ -88,8 +88,7 @@ bdist_wheel: .stamp-bdist_wheel
 	cat requirements.txt
 # We need to install these python packages to handle rpmbuild 4.14 in EL8
 ifeq ($(EL_VERSION),8)
-        # Setuptools 60.x requires > python 3.6
-	$(PIP_BINARY) install wheel 'setuptools<60' virtualenv
+	$(PIP_BINARY) install wheel setuptools virtualenv
 	$(PIP_BINARY) install cryptography
 endif
 	$(PYTHON_BINARY) setup.py bdist_wheel -d $(WHEELDIR) || \

--- a/packages/st2/component.makefile
+++ b/packages/st2/component.makefile
@@ -6,13 +6,13 @@ ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1
 	DEB_DISTRO := $(shell lsb_release -cs)
 	DESTDIR ?= $(CURDIR)/debian/$(ST2_COMPONENT)
-else ifneq (,$(wildcard /etc/centos-release))
-	EL_DISTRO := centos
-	EL_VERSION := $(shell cat /etc/centos-release | grep -oP '(?<= )[0-9]+(?=\.)')
-	REDHAT := 1
 else ifneq (,$(wildcard /etc/rocky-release))
 	EL_DISTRO := rocky
 	EL_VERSION := $(shell cat /etc/rocky-release | grep -oP '(?<= )[0-9]+(?=\.)')
+	REDHAT := 1
+else ifneq (,$(wildcard /etc/centos-release))
+	EL_DISTRO := centos
+	EL_VERSION := $(shell cat /etc/centos-release | grep -oP '(?<= )[0-9]+(?=\.)')
 	REDHAT := 1
 else ifneq (,$(wildcard /etc/redhat-release))
 	EL_DISTRO := redhat
@@ -88,7 +88,8 @@ bdist_wheel: .stamp-bdist_wheel
 	cat requirements.txt
 # We need to install these python packages to handle rpmbuild 4.14 in EL8
 ifeq ($(EL_VERSION),8)
-	$(PIP_BINARY) install wheel setuptools virtualenv
+        # Setuptools 60.x requires > python 3.6
+	$(PIP_BINARY) install wheel 'setuptools<60' virtualenv
 	$(PIP_BINARY) install cryptography
 endif
 	$(PYTHON_BINARY) setup.py bdist_wheel -d $(WHEELDIR) || \


### PR DESCRIPTION
Need to check rocky-release before centos-release as on Rocky systems, rocky-release is link to centos-release.
Also restrict setuptools when it gets installed on EL8 Makefile to < 60 as will fail until we upgrade python to 3.8.