### PR TITLE
Use erlang < 25 on EL8

### DIFF
--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -512,7 +512,7 @@ install_st2_dependencies() {
 install_rabbitmq() {
   # Install erlang from rabbitmq/erlang as need newer version
   # than available in epel.
-  # Use Erlang 24 has Erlang 25 has only preview support with RabbitMQ 3.10
+  # Use Erlang 24 as RabbitMQ 3.10 only has preview support for Erlang 25.
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
   sudo yum -y install erlang-24*
   # Install rabbit from packagecloud

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -511,9 +511,10 @@ install_st2_dependencies() {
 
 install_rabbitmq() {
   # Install erlang from rabbitmq/erlang as need newer version
-  # than available in epel
+  # than available in epel.
+  # Use Erlang 24 has Erlang 25 has only preview support with RabbitMQ 3.10
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
-  sudo yum -y install erlang
+  sudo yum -y install erlang-24*
   # Install rabbit from packagecloud
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -148,7 +148,7 @@ install_st2_dependencies() {
 install_rabbitmq() {
   # Install erlang from rabbitmq/erlang as need newer version
   # than available in epel.
-  # Use Erlang 24 has Erlang 25 has only preview support with RabbitMQ 3.10
+  # Use Erlang 24 as RabbitMQ 3.10 only has preview support for Erlang 25.
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
   sudo yum -y install erlang-24*
   # Install rabbit from packagecloud

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -147,9 +147,10 @@ install_st2_dependencies() {
 
 install_rabbitmq() {
   # Install erlang from rabbitmq/erlang as need newer version
-  # than available in epel
+  # than available in epel.
+  # Use Erlang 24 has Erlang 25 has only preview support with RabbitMQ 3.10
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
-  sudo yum -y install erlang
+  sudo yum -y install erlang-24*
   # Install rabbit from packagecloud
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'


### PR DESCRIPTION
Modify El8 to use Erlang 25 to avoid issues with RabbitMQ 3.10 which only has preview support for erlang 25.

Partially resolves: https://github.com/StackStorm/st2/issues/5651