### PR TITLE
Use erlang < 25 on EL8

### DIFF
--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -511,9 +511,10 @@ install_st2_dependencies() {
 
 install_rabbitmq() {
   # Install erlang from rabbitmq/erlang as need newer version
-  # than available in epel
+  # than available in epel.
+  # Use Erlang 24 has Erlang 25 has only preview support with RabbitMQ 3.10
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
-  sudo yum -y install erlang
+  sudo yum -y install erlang-24*
   # Install rabbit from packagecloud
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -147,9 +147,10 @@ install_st2_dependencies() {
 
 install_rabbitmq() {
   # Install erlang from rabbitmq/erlang as need newer version
-  # than available in epel
+  # than available in epel.
+  # Use Erlang 24 has Erlang 25 has only preview support with RabbitMQ 3.10
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
-  sudo yum -y install erlang
+  sudo yum -y install erlang-24*
   # Install rabbit from packagecloud
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'


### PR DESCRIPTION
Update Bash installer for 3.7 to use erlang24*

RabbitMQ have released a newer version 3.10.2 which now manages to start with erlang 25. But they still report on https://www.rabbitmq.com/which-erlang.html that the erlang 25 support is preview. 
Therefore probably safer to stick with using 24*