### PR TITLE
Allow PEP 440 direct references in requirements (dist_utils.py)

### DIFF
--- a/packages/st2/dist_utils.py
+++ b/packages/st2/dist_utils.py
@@ -112,6 +112,12 @@ def fetch_requirements(requirements_file_path):
 
                 link = line.replace('-e ', '').strip()
                 return link, req_name[0]
+            elif vcs_prefix in line and line.count("@") == 2:
+                # PEP 440 direct reference: <package name>@ <url>@version
+                req_name, link = line.split("@", 1)
+                req_name = req_name.strip()
+                link = f"{link.strip()}#egg={req_name}"
+                return link, req_name
 
         return None, None
 

--- a/packages/st2/in-requirements.txt
+++ b/packages/st2/in-requirements.txt
@@ -6,7 +6,7 @@ st2auth
 st2reactor
 st2exporter
 st2tests
-git+https://github.com/StackStorm/st2-auth-backend-pam.git@master#egg=st2-auth-backend-pam
+st2-auth-backend-pam@ git+https://github.com/StackStorm/st2-auth-backend-pam.git@master
 stackstorm-runner-action-chain
 stackstorm-runner-announcement
 stackstorm-runner-http

--- a/packages/st2/in-requirements.txt
+++ b/packages/st2/in-requirements.txt
@@ -6,7 +6,7 @@ st2auth
 st2reactor
 st2exporter
 st2tests
-st2-auth-backend-pam@ git+https://github.com/StackStorm/st2-auth-backend-pam.git@master
+git+https://github.com/StackStorm/st2-auth-backend-pam.git@master#egg=st2-auth-backend-pam
 stackstorm-runner-action-chain
 stackstorm-runner-announcement
 stackstorm-runner-http


### PR DESCRIPTION
This adds support for PEP 440 requirements instead of using the pip-specific VCS format.
see: https://peps.python.org/pep-0440/\#direct-references

This facilitates using newer tooling that does not support using the legacy pip VCS format.

Here is a VCS style requirement:
https://github.com/StackStorm/st2-packages/blob/6f64885cae4b89fbec21c7782b500312e6214fb8/packages/st2/in-requirements.txt#L9

Here is a PEP 440 requirement:
https://github.com/StackStorm/st2-packages/blob/8e0e574a9feb3eadf86d35a844709d16b564e190/packages/st2/in-requirements.txt#L9

This PR is based on StackStorm/st2#5673 and must be merged before StackStorm/st2#5673 CI can pass. This can safely be merged before StackStorm/st2#5673 is ready w/ approvals, however, as it adds support for PEP 440 without removing support for the old pip VCS requirements. In other words, we don't need to synchronize merging both PRs at the same time.

NB: I'm not changing `packages/st2/in-requirements.txt` in this PR because fixate-requirements does not handle that yet. We'll adjust fixate-requirements later if needed.