### PR TITLE
[WIP] Fix ST2 install scripts for rabbitMQ problems

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -469,8 +469,6 @@ EOF
   # Update package indices
   sudo apt-get update -y
 
-EOF
-
   # Install Erlang packages
   sudo apt-get install -y erlang-base \
                         erlang-asn1 erlang-crypto erlang-eldap erlang-ftp erlang-inets \

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -155,8 +155,6 @@ EOF
   # Update package indices
   sudo apt-get update -y
 
-EOF
-
   # Install Erlang packages
   sudo apt-get install -y erlang-base \
                         erlang-asn1 erlang-crypto erlang-eldap erlang-ftp erlang-inets \

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -513,7 +513,7 @@ install_rabbitmq() {
   # Install erlang from rabbitmq/erlang as need newer version
   # than available in epel.
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
-  sudo yum -y install erlang*
+  sudo yum -y install erlang-25*
   # Install rabbit from packagecloud
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -149,7 +149,7 @@ install_rabbitmq() {
   # Install erlang from rabbitmq/erlang as need newer version
   # than available in epel.
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
-  sudo yum -y install erlang*
+  sudo yum -y install erlang-25*
   # Install rabbit from packagecloud
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'


### PR DESCRIPTION
Left trailing EOF in changes for debian installs, on previous attempt to fix erlang issues for debian builds.

On El8 need to explictly mention erlang-25* so that it doesn't try and use erlang-22 libraries from epel release.