### PR TITLE
Change to use latest erlang

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -469,14 +469,6 @@ EOF
   # Update package indices
   sudo apt-get update -y
 
-  # Set preferences to use 1:24.* for erlang 
-  sudo tee /etc/apt/preferences.d/erlang <<EOF
-# prefer packages erlang less than 25 repository
-Package: erlang-*
-Pin: version 1:24.*
-Pin-Priority: 800
-EOF
-
   # Install Erlang packages
   sudo apt-get install -y erlang-base \
                         erlang-asn1 erlang-crypto erlang-eldap erlang-ftp erlang-inets \

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -155,14 +155,6 @@ EOF
   # Update package indices
   sudo apt-get update -y
 
-  # Set preferences to use 1:24.* for erlang 
-  sudo tee /etc/apt/preferences.d/erlang <<EOF
-# prefer packages erlang less than 25 repository
-Package: erlang-*
-Pin: version 1:24.*
-Pin-Priority: 800
-EOF
-
   # Install Erlang packages
   sudo apt-get install -y erlang-base \
                         erlang-asn1 erlang-crypto erlang-eldap erlang-ftp erlang-inets \

--- a/scripts/st2bootstrap-el8.sh
+++ b/scripts/st2bootstrap-el8.sh
@@ -512,9 +512,8 @@ install_st2_dependencies() {
 install_rabbitmq() {
   # Install erlang from rabbitmq/erlang as need newer version
   # than available in epel.
-  # Use Erlang 24 has Erlang 25 has only preview support with RabbitMQ 3.10
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
-  sudo yum -y install erlang-24*
+  sudo yum -y install erlang
   # Install rabbit from packagecloud
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'

--- a/scripts/st2bootstrap-el8.template.sh
+++ b/scripts/st2bootstrap-el8.template.sh
@@ -148,9 +148,8 @@ install_st2_dependencies() {
 install_rabbitmq() {
   # Install erlang from rabbitmq/erlang as need newer version
   # than available in epel.
-  # Use Erlang 24 has Erlang 25 has only preview support with RabbitMQ 3.10
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
-  sudo yum -y install erlang-24*
+  sudo yum -y install erlang
   # Install rabbit from packagecloud
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'


### PR DESCRIPTION
Update 3.7 install scripts to use latest erlang.

Re-application of PRs https://github.com/StackStorm/st2-packages/pull/725 and https://github.com/StackStorm/st2-packages/pull/724 with a slight tidy up on the el8 change.