### PR TITLE
Fix EL7 build for Orquesta v1.6.0 update with 'python_version' markers

### DIFF
--- a/rpmspec/package_venv.spec
+++ b/rpmspec/package_venv.spec
@@ -17,7 +17,7 @@
 
 %define venv_python %{venv_bin}/%{python_binname}
 # https://github.com/StackStorm/st2/wiki/Where-all-to-update-pip-and-or-virtualenv
-%define pin_pip %{venv_python} %{venv_bin}/%{pip_binname} install pip==21.3.1
+%define pin_pip %{venv_python} %{venv_bin}/%{pip_binname} install pip==20.3.3
 %define install_venvctrl %{python_binname} -m pip install venvctrl
 %if 0%{?rhel} == 8
 %define install_crypto %{venv_python} %{venv_bin}/pip3.8 install cryptography==2.8

--- a/rpmspec/package_venv.spec
+++ b/rpmspec/package_venv.spec
@@ -37,7 +37,7 @@
     %{pin_pip} \
     %{install_crypto} \
     %{venv_pip} --use-deprecated=legacy-resolver -r requirements.txt \
-    %{venv_pip} . \
+    %{venv_pip} --use-deprecated=legacy-resolver . \
     %{install_venvctrl} \
     venvctrl-relocate --source=%{venv_dir} --destination=/%{venv_install_dir} \
 %{nil}

--- a/rpmspec/package_venv.spec
+++ b/rpmspec/package_venv.spec
@@ -17,7 +17,7 @@
 
 %define venv_python %{venv_bin}/%{python_binname}
 # https://github.com/StackStorm/st2/wiki/Where-all-to-update-pip-and-or-virtualenv
-%define pin_pip %{venv_python} %{venv_bin}/%{pip_binname} install pip==20.3.3
+%define pin_pip %{venv_python} %{venv_bin}/%{pip_binname} install pip==22.1.2
 %define install_venvctrl %{python_binname} -m pip install venvctrl
 %if 0%{?rhel} == 8
 %define install_crypto %{venv_python} %{venv_bin}/pip3.8 install cryptography==2.8

--- a/rpmspec/package_venv.spec
+++ b/rpmspec/package_venv.spec
@@ -17,7 +17,7 @@
 
 %define venv_python %{venv_bin}/%{python_binname}
 # https://github.com/StackStorm/st2/wiki/Where-all-to-update-pip-and-or-virtualenv
-%define pin_pip %{venv_python} %{venv_bin}/%{pip_binname} install pip==22.1.2
+%define pin_pip %{venv_python} %{venv_bin}/%{pip_binname} install pip==21.3.1
 %define install_venvctrl %{python_binname} -m pip install venvctrl
 %if 0%{?rhel} == 8
 %define install_crypto %{venv_python} %{venv_bin}/pip3.8 install cryptography==2.8


### PR DESCRIPTION
pip resolver failed processing the dependencies when using the `python_version` dependent environment markers in orquesta requirements.txt https://github.com/StackStorm/orquesta/pull/255.

Build failure: https://app.circleci.com/pipelines/github/StackStorm/st2/4158/workflows/11838dac-5adc-4554-9a87-f7bf506bedb6/jobs/15940?invite=true#step-109-978547_123

Relying on `--use-deprecated=legacy-resolver` masks the problem and makes the build succeed.

See https://github.com/StackStorm/st2/pull/6050 for more context.