### PR TITLE
CI: Update ruby 2.4 -> 2.6 ro fix PackageCloud deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
   deploy:
     docker:
       # The primary container is an instance of the first list image listed. Your build commands run in this container.
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.6
     working_directory: /tmp/deploy
     environment:
       - DISTROS: "bionic focal el7 el8"


### PR DESCRIPTION
Same as https://github.com/StackStorm/st2/pull/6045, update ruby for CircleCI to fix PackageCloud deploy step.
https://app.circleci.com/pipelines/github/StackStorm/st2-packages/373/workflows/b701963d-0a97-4973-a637-cb0d19c607be/jobs/4066