### PR TITLE
Switch to MongoDB 4.4 fo U18

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -492,12 +492,8 @@ EOF
 }
 
 install_mongodb() {
-  # Add key and repo for the latest stable MongoDB 4.0
-  if [[ "$SUBTYPE" = 'focal' ]]; then
-    MONGO_VERSION="4.4"
-  else
-    MONGO_VERSION="4.0"
-  fi
+  # Add key and repo for the MongoDB 4.4 (Ubuntu Focal, Bionic)
+  MONGO_VERSION="4.4"
 
   wget -qO - https://www.mongodb.org/static/pgp/server-${MONGO_VERSION}.asc | sudo apt-key add -
   echo "deb http://repo.mongodb.org/apt/ubuntu ${SUBTYPE}/mongodb-org/${MONGO_VERSION} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-${MONGO_VERSION}.list

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -178,12 +178,8 @@ EOF
 }
 
 install_mongodb() {
-  # Add key and repo for the latest stable MongoDB 4.0
-  if [[ "$SUBTYPE" = 'focal' ]]; then
-    MONGO_VERSION="4.4"
-  else
-    MONGO_VERSION="4.0"
-  fi
+  # Add key and repo for the MongoDB 4.4 (Ubuntu Focal, Bionic)
+  MONGO_VERSION="4.4"
 
   wget -qO - https://www.mongodb.org/static/pgp/server-${MONGO_VERSION}.asc | sudo apt-key add -
   echo "deb http://repo.mongodb.org/apt/ubuntu ${SUBTYPE}/mongodb-org/${MONGO_VERSION} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-${MONGO_VERSION}.list


### PR DESCRIPTION
MongoDB 4.0 key was expired which fails on U18 installation.

However MongoDB 4.4 is available for U18. Use that to fix e2e tests.

This is the last effort to make U18 working for releasing a st2 `v3.8.1` patch. We should [drop U18 support](https://github.com/StackStorm/st2-packages/issues/731) in st2 `v3.9.0`.
