### PR TITLE
Install net-tools automatically on deb-distributions

### DIFF
--- a/scripts/st2bootstrap-deb.sh
+++ b/scripts/st2bootstrap-deb.sh
@@ -430,6 +430,10 @@ fail() {
 }
 
 
+install_net_tools() {
+  # Install netstat
+  sudo apt install -y net-tools
+}
 
 install_st2_dependencies() {
   # Silence debconf prompt, raised during some dep installations. This will be passed to sudo via 'env_keep'.
@@ -718,6 +722,7 @@ configure_st2chatops() {
 
 trap 'fail' EXIT
 STEP="Setup args" && setup_args $@
+STEP="Install net-tools" && install_net_tools
 STEP="Check TCP ports and MongoDB storage requirements" && check_st2_host_dependencies
 STEP="Generate random password" && generate_random_passwords
 STEP="Configure Proxy" && configure_proxy

--- a/scripts/st2bootstrap-deb.template.sh
+++ b/scripts/st2bootstrap-deb.template.sh
@@ -116,6 +116,10 @@ setup_args() {
 
 # include:includes/common.sh
 
+install_net_tools() {
+  # Install netstat
+  sudo apt install -y net-tools
+}
 
 install_st2_dependencies() {
   # Silence debconf prompt, raised during some dep installations. This will be passed to sudo via 'env_keep'.
@@ -404,6 +408,7 @@ configure_st2chatops() {
 
 trap 'fail' EXIT
 STEP="Setup args" && setup_args $@
+STEP="Install net-tools" && install_net_tools
 STEP="Check TCP ports and MongoDB storage requirements" && check_st2_host_dependencies
 STEP="Generate random password" && generate_random_passwords
 STEP="Configure Proxy" && configure_proxy


### PR DESCRIPTION
We already install net-tools on CentOS and Rocky Linux. Now, we also do it for installations using the deb-installer.  The package manager will detect on it's own if it's actually needed to install or update the net-tools or if the latest version is already installed and it does not have to do anything else.

This also addresses an error when running the installer without having netstat available on Ubuntu 20.04 for example: 
```
20231212T161937+0000 ################################################################
20231212T161937+0000 ### Installing from staging repos!!! USE AT YOUR OWN RISK!!! ###
20231212T161937+0000 ################################################################
20231212T161937+0000 sudo: netstat: command not found
20231212T161937+0000 sudo: netstat: command not found
20231212T161937+0000 sudo: netstat: command not found
20231212T161937+0000 sudo: netstat: command not found
20231212T161937+0000 sudo: netstat: command not found
20231212T161937+0000 sudo: netstat: command not found
20231212T161937+0000 sudo: netstat: command not found
20231212T161937+0000 sudo: netstat: command not found
20231212T161937+0000 sudo: netstat: command not found
20231212T161937+0000 sudo: netstat: command not found
20231212T161937+0000 Hit:1 http://mirrors.digitalocean.com/ubuntu focal InRelease
20231212T161937+0000 Hit:2 http://mirrors.digitalocean.com/ubuntu focal-updates InRelease
``` 

