### PR TITLE
Following the guidelines in the file, refreshing this

### DIFF
--- a/packages/st2/dist_utils.py
+++ b/packages/st2/dist_utils.py
@@ -2,6 +2,7 @@
 # NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
 #       Instead copy from https://github.com/StackStorm/st2/blob/master/scripts/dist_utils.py
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +23,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -41,51 +40,16 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     text_type = str
 else:
-    text_type = unicode  # NOQA
+    text_type = unicode  # noqa  # pylint: disable=E0602
 
-GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    'check_pip_is_installed',
-    'check_pip_version',
-    'fetch_requirements',
-    'apply_vagrant_workaround',
-    'get_version_string',
-    'parse_version_string'
+    "fetch_requirements",
+    "apply_vagrant_workaround",
+    "get_version_string",
+    "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print('Failed to import pip: %s' % (text_type(e)))
-        print('')
-        print('Download pip:\n%s' % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version='6.0.0'):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print("Upgrade pip, your version '{0}' "
-              "is outdated. Minimum required version is '{1}':\n{2}".format(pip.__version__,
-                                                                            min_version,
-                                                                            GET_PIP))
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):
@@ -96,21 +60,23 @@ def fetch_requirements(requirements_file_path):
     reqs = []
 
     def _get_link(line):
-        vcs_prefixes = ['git+', 'svn+', 'hg+', 'bzr+']
+        vcs_prefixes = ["git+", "svn+", "hg+", "bzr+"]
 
         for vcs_prefix in vcs_prefixes:
-            if line.startswith(vcs_prefix) or line.startswith('-e %s' % (vcs_prefix)):
-                req_name = re.findall('.*#egg=(.+)([&|@]).*$', line)
+            if line.startswith(vcs_prefix) or line.startswith("-e %s" % (vcs_prefix)):
+                req_name = re.findall(".*#egg=(.+)([&|@]).*$", line)
 
                 if not req_name:
-                    req_name = re.findall('.*#egg=(.+?)$', line)
+                    req_name = re.findall(".*#egg=(.+?)$", line)
                 else:
                     req_name = req_name[0]
 
                 if not req_name:
-                    raise ValueError('Line "%s" is missing "#egg=<package name>"' % (line))
+                    raise ValueError(
+                        'Line "%s" is missing "#egg=<package name>"' % (line)
+                    )
 
-                link = line.replace('-e ', '').strip()
+                link = line.replace("-e ", "").strip()
                 return link, req_name[0]
             elif vcs_prefix in line and line.count("@") == 2:
                 # PEP 440 direct reference: <package name>@ <url>@version
@@ -121,11 +87,11 @@ def fetch_requirements(requirements_file_path):
 
         return None, None
 
-    with open(requirements_file_path, 'r') as fp:
+    with open(requirements_file_path, "r") as fp:
         for line in fp.readlines():
             line = line.strip()
 
-            if line.startswith('#') or not line:
+            if line.startswith("#") or not line:
                 continue
 
             link, req_name = _get_link(line=line)
@@ -134,9 +100,6 @@ def fetch_requirements(requirements_file_path):
                 links.append(link)
             else:
                 req_name = line
-
-                if ';' in req_name:
-                    req_name = req_name.split(';')[0].strip()
 
             reqs.append(req_name)
 
@@ -150,7 +113,7 @@ def apply_vagrant_workaround():
     Note: Without this workaround, setup.py sdist will fail when running inside a shared directory
     (nfs / virtualbox shared folders).
     """
-    if os.environ.get('USER', None) == 'vagrant':
+    if os.environ.get("USER", None) == "vagrant":
         del os.link
 
 
@@ -159,14 +122,13 @@ def get_version_string(init_file):
     Read __version__ string for an init file.
     """
 
-    with open(init_file, 'r') as fp:
+    with open(init_file, "r") as fp:
         content = fp.read()
-        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                                  content, re.M)
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", content, re.M)
         if version_match:
             return version_match.group(1)
 
-        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+        raise RuntimeError("Unable to find version string in %s." % (init_file))
 
 
 # alias for get_version_string


### PR DESCRIPTION
The dist_utils.py in this repo according to the comments should be a near copy of the one in the st2 repo. I've copied it over (removed some comments specific to the st2 version) so that it can also stop breaking on requirements.txt that use the `;` to separate python markers.

This should fix the circleci tests on https://github.com/StackStorm/st2/pull/6296 and future PRs once merged.

This is a bit of a catch22 situation.

This build pulls master of st2, which does not have my dist_utils fixes yet, so it fails. The st2 pulls the current master of this repo which doesn't have my changes yet and fails.

One of these probably has to be forced merged so the other tests with the changes?