### PR TITLE
bump pip to match st2 makefile

### DIFF
--- a/packages/st2/debian/rules
+++ b/packages/st2/debian/rules
@@ -11,7 +11,7 @@ PATH = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 WHEELDIR ?= /tmp/wheelhouse
 DH_VIRTUALENV_INSTALL_ROOT := /opt/stackstorm
 export DH_VIRTUALENV_INSTALL_ROOT
-PIP_VERSION = 20.3.3
+PIP_VERSION = 25.0.1
 
 IS_SYSTEMD = $(shell command -v dh_systemd_enable > /dev/null 2>&1 && echo true)
 DEB_DISTRO := $(shell lsb_release -cs)


### PR DESCRIPTION
bump pip to match st2 make file and fix projects that only have a pyproject.toml

Requires StackStorm/st2packaging-dockerfiles#124